### PR TITLE
Improvements to cod4, csgo, tf2, minecraft & quake3 commands

### DIFF
--- a/modules/game_stats/callOfDuty4.js
+++ b/modules/game_stats/callOfDuty4.js
@@ -44,19 +44,19 @@ exports.exec = (Bastion, message, args) => {
       gametype = 'Team Deathmatch';
     }
     else if (data.raw.g_gametype === 'dm') {
-      gametype = 'Free for All';
+      gametype = 'FFA';
     }
     else if (data.raw.g_gametype === 'sd') {
-      gametype = 'Search and Destroy';
+      gametype = 'S&D';
     }
     else if (data.raw.g_gametype === 'dom') {
-      gametype = 'Domination';
+      gametype = 'DOM';
     }
     else if (data.raw.g_gametype === 'koth') {
-      gametype = 'Headquarters';
+      gametype = 'HQ';
     }
     else if (data.raw.g_gametype === 'sab') {
-      gametype = 'Sabotage';
+      gametype = 'SAB';
     }
     else {
       gametype = data.raw.g_gametype;
@@ -64,49 +64,65 @@ exports.exec = (Bastion, message, args) => {
 
     let stats = [
       {
-        name: 'Server IP',
-        value: `[${host}:${port}](cod4://${host}:${port})`,
-        inline: true
-      },
-      {
-        name: 'Private',
-        value: data.password,
+        name: 'Address',
+        value: '`' + host + ':' + port + '`',
         inline: true
       },
       {
         name: 'Players',
-        value: `${data.players.length}/${data.maxplayers}`,
+        value: '`' + data.players.length + '/' + data.maxplayers + '`',
         inline: true
       },
       {
-        name: 'Map/Gametype',
-        value: `${data.map.replace('mp_', '').split('_').map(e => e.charAt(0).toUpperCase() + e.slice(1))} - ${gametype}`
+        name: 'Map',
+        value: '`' + data.map.replace('mp_', '').split('_').map(e => e.charAt(0).toUpperCase() + e.slice(1)) + ' - ' + gametype + '`',
+        inline: true
       }
     ];
 
     if (data.players.length > 0) {
       let players = [];
       let scores = [];
+      let pings = [];
       for (let i = 0; i < data.players.length; i++) {
-        players.push(data.players[i].name);
+        players.push(data.players[i].name.substring(0, 12));
       }
       for (let i = 0; i < data.players.length; i++) {
         scores.push(data.players[i].frags);
       }
+      for (let i = 0; i < data.players.length; i++) {
+        pings.push(data.players[i].ping);
+      }
       stats.push(
         {
-          name: 'Player',
-          value: players.join('\n'),
+          name: 'Player Name',
+          value: '```http\n' + players.join('\n') + '```',
           inline: true
         },
         {
           name: 'Score',
-          value: scores.join('\n'),
+          value: '```http\n' + scores.join('\n') + '```',
+          inline: true
+        },
+        {
+          name: 'Ping',
+          value: '```http\n' + pings.join('\n') + '```',
           inline: true
         }
       );
     }
 
+    let lock = data.password;
+    let lock_icon = '';
+    if (lock == true) {
+      lock = 'Password required to join server | ';
+      lock_icon = 'https://resources.bastionbot.org/images/lock.png';
+    } 
+    else {
+       lock = '';
+       lock_icon = '';
+    }
+    
     message.channel.send({
       embed: {
         color: Bastion.colors.BLUE,
@@ -114,7 +130,8 @@ exports.exec = (Bastion, message, args) => {
         description: '[Call of Duty 4®: Modern Warfare®](https://store.steampowered.com/app/7940)',
         fields: stats,
         footer: {
-          text: `Server Uptime: ${data.raw.uptime}`
+          text: lock + `Server Uptime: ${data.raw.uptime}`,
+          icon_url: lock_icon
         }
       }
     }).catch(e => {

--- a/modules/game_stats/callOfDuty4.js
+++ b/modules/game_stats/callOfDuty4.js
@@ -65,17 +65,17 @@ exports.exec = (Bastion, message, args) => {
     let stats = [
       {
         name: 'Address',
-        value: '`' + host + ':' + port + '`',
+        value: `\\`${host}:${port}\\``,
         inline: true
       },
       {
         name: 'Players',
-        value: '`' + data.players.length + '/' + data.maxplayers + '`',
+        value: `\\`${data.players.length}/${data.maxplayers}\\``,
         inline: true
       },
       {
         name: 'Map',
-        value: '`' + data.map.replace('mp_', '').split('_').map(e => e.charAt(0).toUpperCase() + e.slice(1)) + ' - ' + gametype + '`',
+        value: `\\`${data.map.replace('mp_', '').split('_').map(e => e.charAt(0).toUpperCase() + e.slice(1))} - ${gametype}\\``,
         inline: true
       }
     ];
@@ -96,17 +96,17 @@ exports.exec = (Bastion, message, args) => {
       stats.push(
         {
           name: 'Player Name',
-          value: '```http\n' + players.join('\n') + '```',
+          value: `\\`\\`\\`http\n${players.join('\n')}\\`\\`\\``,
           inline: true
         },
         {
           name: 'Score',
-          value: '```http\n' + scores.join('\n') + '```',
+          value: `\\`\\`\\`http\n${scores.join('\n')}\\`\\`\\``,
           inline: true
         },
         {
           name: 'Ping',
-          value: '```http\n' + pings.join('\n') + '```',
+          value: `\\`\\`\\`http\n${pings.join('\n')}\\`\\`\\``,
           inline: true
         }
       );
@@ -114,15 +114,15 @@ exports.exec = (Bastion, message, args) => {
 
     let lock = data.password;
     let lock_icon = '';
-    if (lock == true) {
+    if (lock === true) {
       lock = 'Password required to join server | ';
       lock_icon = 'https://resources.bastionbot.org/images/lock.png';
     } 
     else {
-       lock = '';
-       lock_icon = '';
+      lock = '';
+      lock_icon = '';
     }
-    
+
     message.channel.send({
       embed: {
         color: Bastion.colors.BLUE,
@@ -130,7 +130,7 @@ exports.exec = (Bastion, message, args) => {
         description: '[Call of Duty 4®: Modern Warfare®](https://store.steampowered.com/app/7940)',
         fields: stats,
         footer: {
-          text: lock + `Server Uptime: ${data.raw.uptime}`,
+          text: `${lock} Server Uptime: ${data.raw.uptime}`,
           icon_url: lock_icon
         }
       }

--- a/modules/game_stats/counterStrikeGlobalOffensive.js
+++ b/modules/game_stats/counterStrikeGlobalOffensive.js
@@ -41,55 +41,84 @@ exports.exec = (Bastion, message, args) => {
   }).then(data => {
     let stats = [
       {
-        name: 'Server IP',
-        value: `[${host}:${port}](steam://connect/${host}:${port})`,
-        inline: true
-      },
-      {
-        name: 'Private',
-        value: data.password,
+        name: 'Address',
+        value: '`' + host + ':' + port + '`',
         inline: true
       },
       {
         name: 'Players',
-        value: `${data.players.length}/${data.maxplayers}`,
+        value: '`' + data.players.length + '/' + data.maxplayers + '`',
         inline: true
       },
       {
         name: 'Map',
-        value: data.map
+        value: '`' + data.map + '`',
+        inline: true
       }
     ];
 
     if (data.players.length > 0) {
       let players = [];
       let scores = [];
+      let times = [];
       for (let i = 0; i < data.players.length; i++) {
-        players.push(data.players[i].name);
+        players.push(data.players[i].name.substring(0, 12));
       }
       for (let i = 0; i < data.players.length; i++) {
         scores.push(data.players[i].score);
       }
+      for (let i = 0; i < data.players.length; i++) {
+        times.push(new Date(data.players[i].time * 1000).toISOString().substr(11, 8));
+      }
       stats.push(
         {
-          name: 'Player',
-          value: players.join('\n'),
+          name: 'Player Name',
+          value: '```http\n' + players.join('\n') + '\n```',
           inline: true
         },
         {
           name: 'Score',
-          value: scores.join('\n'),
+          value: '```http\n' + scores.join('\n') + '\n```',
+          inline: true
+        },
+        {
+          name: 'Time',
+          value: '```http\n' + times.join('\n') + '\n```',
           inline: true
         }
+        
       );
     }
-
+    
+    stats.push(
+      {
+        name: 'Join Server',
+        value: 'steam://connect/' + host + ':' + port,
+        inline: false
+      }  
+    );
+    
+    let lock = data.password;
+    let lock_icon = '';
+    if (lock == true) {
+      lock = 'Password required to join server';
+      lock_icon = 'https://resources.bastionbot.org/images/lock.png';
+    } 
+    else {
+       lock = '';
+       lock_icon = '';
+    }
+    
     message.channel.send({
       embed: {
         color: Bastion.colors.BLUE,
         title: data.name,
-        description: '[Counter-Strike: Global Offensive](https://store.steampowered.com/app/730/)',
-        fields: stats
+        description: '[' + data.raw.game + '](https://store.steampowered.com/app/' + data.raw.gameid + '/)',
+        fields: stats,
+        footer: {
+          text: lock,
+          icon_url: lock_icon
+        }
       }
     }).catch(e => {
       Bastion.log.error(e);

--- a/modules/game_stats/counterStrikeGlobalOffensive.js
+++ b/modules/game_stats/counterStrikeGlobalOffensive.js
@@ -4,137 +4,130 @@
  * @license MIT
  */
 
-const CSGO = require('gamedig');
+const source = require('gamedig');
 
-exports.exec = (Bastion, message, args) => {
-  if (args.length < 1 || !/^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(:0*(?:6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9]))?$/.test(args = args[0])) {
-    /**
-     * The command was ran with invalid parameters.
-     * @fires commandUsage
-     */
-    return Bastion.emit('commandUsage', message, this.help);
-  }
+exports.exec = async (Bastion, message, args) => {
+  try {
+    if (!/^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(:0*(?:6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9]))?$/.test(args.address)) {
+      /**
+      * The command was ran with invalid parameters.
+      * @fires commandUsage
+      */
+      return Bastion.emit('commandUsage', message, this.help);
+    }
 
-  args = args.split(':');
-  let host = args[0];
+    args.address = args.address.split(':');
+    let host = args.address[0];
 
-  if (host === '127.0.0.1') {
-    return message.channel.send({
-      embed: {
-        description: 'There is no place like `127.0.0.1`'
-      }
+    if (host === '127.0.0.1') {
+      return message.channel.send({
+        embed: {
+          description: 'There is no place like `127.0.0.1`'
+        }
+      });
+    }
+
+    let port;
+    if (args.address[1]) {
+      port = parseInt(args.address[1]);
+    }
+    else {
+      port = 27015;
+    }
+
+    let data = await source.query({
+      type: 'csgo',
+      host: host,
+      port: port
     });
-  }
 
-  let port;
-  if (args[1]) {
-    port = parseInt(args[1]);
-  }
-  else {
-    port = 27015;
-  }
-
-  CSGO.query({
-    type: 'csgo',
-    host: host,
-    port: port
-  }).then(data => {
     let stats = [
       {
-        name: 'Address',
-        value: '`' + host + ':' + port + '`',
+        name: 'Server IP',
+        value: `\`${host}:${port}\``,
         inline: true
       },
       {
         name: 'Players',
-        value: '`' + data.players.length + '/' + data.maxplayers + '`',
+        value: `${data.players.length}/${data.maxplayers}`,
         inline: true
       },
       {
         name: 'Map',
-        value: '`' + data.map + '`',
-        inline: true
+        value: data.map
       }
     ];
 
     if (data.players.length > 0) {
       let players = [];
       let scores = [];
-      let times = [];
+      let playtimes = [];
       for (let i = 0; i < data.players.length; i++) {
-        players.push(data.players[i].name.substring(0, 12));
+        players.push(data.players[i].name);
       }
       for (let i = 0; i < data.players.length; i++) {
         scores.push(data.players[i].score);
       }
       for (let i = 0; i < data.players.length; i++) {
-        times.push(new Date(data.players[i].time * 1000).toISOString().substr(11, 8));
+        playtimes.push(`${parseInt(data.players[i].time)}s`);
       }
       stats.push(
         {
-          name: 'Player Name',
-          value: '```http\n' + players.join('\n') + '\n```',
+          name: 'Player',
+          value: `\`\`\`http\n${players.join('\n')}\`\`\``,
           inline: true
         },
         {
           name: 'Score',
-          value: '```http\n' + scores.join('\n') + '\n```',
+          value: `\`\`\`http\n${scores.join('\n')}\`\`\``,
           inline: true
         },
         {
-          name: 'Time',
-          value: '```http\n' + times.join('\n') + '\n```',
+          name: 'Playtime',
+          value: `\`\`\`http\n${playtimes.join('\n')}\`\`\``,
           inline: true
+        },
+        {
+          name: 'Join',
+          value: `<steam://connect/${host}:${port}>`
         }
-        
       );
     }
-    
-    stats.push(
-      {
-        name: 'Join Server',
-        value: 'steam://connect/' + host + ':' + port,
-        inline: false
-      }  
-    );
-    
-    let lock = data.password;
-    let lock_icon = '';
-    if (lock == true) {
-      lock = 'Password required to join server';
-      lock_icon = 'https://resources.bastionbot.org/images/lock.png';
-    } 
-    else {
-       lock = '';
-       lock_icon = '';
+
+    let footer;
+    if (data.password) {
+      footer = {
+        text: 'Private Server',
+        icon_url: 'https://resources.bastionbot.org/images/lock.png'
+      };
     }
-    
+
     message.channel.send({
       embed: {
         color: Bastion.colors.BLUE,
         title: data.name,
-        description: '[' + data.raw.game + '](https://store.steampowered.com/app/' + data.raw.gameid + '/)',
+        description: '[Counter-Strike: Global Offensive](https://store.steampowered.com/app/730/)',
         fields: stats,
-        footer: {
-          text: lock,
-          icon_url: lock_icon
-        }
+        footer: footer
       }
     }).catch(e => {
       Bastion.log.error(e);
     });
-  }).catch(() => {
-    /**
-     * Error condition is encountered.
-     * @fires error
-     */
-    return Bastion.emit('error', Bastion.strings.error(message.guild.language, 'connection'), Bastion.strings.error(message.guild.language, 'invalidIPPort', true), message.channel);
-  });
+  }
+  catch (e) {
+    if (e.toString() === 'UDP Watchdog Timeout') {
+      return Bastion.emit('error', Bastion.strings.error(message.guild.language, 'connection'), Bastion.strings.error(message.guild.language, 'invalidIPPort', true), message.channel);
+    }
+    Bastion.log.error(e);
+  }
 };
 
 exports.config = {
   aliases: [ 'csgo' ],
-  enabled: true
+  enabled: true,
+  argsDefinitions: [
+    { name: 'address', type: String, defaultOption: true }
+  ]
 };
 
 exports.help = {
@@ -142,6 +135,6 @@ exports.help = {
   botPermission: '',
   userTextPermission: '',
   userVoicePermission: '',
-  usage: 'counterStrikeGlobalOffensive <CSGO_SERVER_IP>[:PORT]',
-  example: [ 'counterStrikeGlobalOffensive 139.59.31.128', 'counterStrikeGlobalOffensive 139.59.31.128:27016' ]
+  usage: 'counterStrikeGlobalOffensive <CSGO_SERVER_IP:PORT>',
+  example: [ 'counterStrikeGlobalOffensive 139.59.31.128:27015' ]
 };

--- a/modules/game_stats/minecraft.js
+++ b/modules/game_stats/minecraft.js
@@ -4,51 +4,56 @@
  * @license MIT
  */
 
-const MINECRAFT = require('gamedig');
+const source = require('gamedig');
 
-exports.exec = (Bastion, message, args) => {
-  if (args.length < 1 || !/^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(:0*(?:6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9]))?$/.test(args = args[0])) {
-    /**
-     * The command was ran with invalid parameters.
-     * @fires commandUsage
-     */
-    return Bastion.emit('commandUsage', message, this.help);
-  }
-
-  args = args.split(':');
-  let host = args[0];
-
-  if (host === '127.0.0.1') {
-    return message.channel.send({
-      embed: {
-        description: 'There is no place like `127.0.0.1`'
-      }
-    });
-  }
-
-  let port;
-  if (args[1]) {
-    port = parseInt(args[1]);
-  }
-  else {
-    port = 25565;
-  }
-
-  MINECRAFT.query({
-    type: 'minecraft',
-    host: host,
-    port: port
-  }).then(data => {
-    let lock = data.password;
-    let lock_icon = '';
-    if (lock == true) {
-      lock = 'Password required to join server | ';
-      lock_icon = 'https://resources.bastionbot.org/images/lock.png';
-    } 
-    else {
-       lock = '';
-       lock_icon = '';
+exports.exec = async (Bastion, message, args) => {
+  try {
+    if (!/^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(:0*(?:6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9]))?$/.test(args.address)) {
+      /**
+       * The command was ran with invalid parameters.
+       * @fires commandUsage
+       */
+      return Bastion.emit('commandUsage', message, this.help);
     }
+
+    args.address = args.address.split(':');
+    let host = args.address[0];
+
+    if (host === '127.0.0.1') {
+      return message.channel.send({
+        embed: {
+          description: 'There is no place like `127.0.0.1`'
+        }
+      });
+    }
+
+    let port;
+    if (args.address[1]) {
+      port = parseInt(args.address[1]);
+    }
+    else {
+      port = 25565;
+    }
+
+    let data = await source.query({
+      type: 'minecraft',
+      host: host,
+      port: port
+    });
+
+    let footer;
+    if (data.password) {
+      footer = {
+        text: `Private Server • Version: ${data.raw.version}`,
+        icon_url: 'https://resources.bastionbot.org/images/lock.png'
+      };
+    }
+    else {
+      footer = {
+        text: `Version: ${data.raw.version}`
+      };
+    }
+
     message.channel.send({
       embed: {
         color: Bastion.colors.BLUE,
@@ -56,46 +61,46 @@ exports.exec = (Bastion, message, args) => {
         description: '[Minecraft](https://minecraft.net/)',
         fields: [
           {
-            name: 'Address',
-            value: '`' + host + ':' + port + '`',
+            name: 'Server',
+            value: `\`${host}:${port}\``,
             inline: true
           },
           {
             name: 'Players',
-            value: '`' + data.players.length + '/' + data.maxplayers + '`',
+            value: `${data.players.length}/${data.maxplayers}`,
             inline: true
           },
           {
             name: 'Map',
-            value: '`' + data.raw.map + '`',
+            value: data.raw.map,
             inline: true
           },
           {
-            name: 'Mode',
-            value: '`' + data.raw.gametype + '`',
+            name: 'Gametype',
+            value: data.raw.gametype,
             inline: true
           }
         ],
-        footer: {
-          text: lock + `Version: ${data.raw.version}`,
-          icon_url: lock_icon,
-        }
+        footer: footer
       }
     }).catch(e => {
       Bastion.log.error(e);
     });
-  }).catch(() => {
-    /**
-     * Error condition is encountered.
-     * @fires error
-     */
-    return Bastion.emit('error', Bastion.strings.error(message.guild.language, 'connection'), Bastion.strings.error(message.guild.language, 'invalidIPPort', true), message.channel);
-  });
+  }
+  catch (e) {
+    if (e.toString() === 'UDP Watchdog Timeout') {
+      return Bastion.emit('error', Bastion.strings.error(message.guild.language, 'connection'), Bastion.strings.error(message.guild.language, 'invalidIPPort', true), message.channel);
+    }
+    Bastion.log.error(e);
+  }
 };
 
 exports.config = {
   aliases: [ 'mc' ],
-  enabled: true
+  enabled: true,
+  argsDefinitions: [
+    { name: 'address', type: String, defaultOption: true }
+  ]
 };
 
 exports.help = {
@@ -103,6 +108,6 @@ exports.help = {
   botPermission: '',
   userTextPermission: '',
   userVoicePermission: '',
-  usage: 'minecraft <MC_SERVER_IP>[:PORT]',
-  example: [ 'minecraft 139.59.31.129', 'minecraft 139.59.31.129:25565' ]
+  usage: 'minecraft <MC_SERVER_IP:PORT>',
+  example: [ 'minecraft 139.59.31.129:25565' ]
 };

--- a/modules/game_stats/minecraft.js
+++ b/modules/game_stats/minecraft.js
@@ -39,6 +39,16 @@ exports.exec = (Bastion, message, args) => {
     host: host,
     port: port
   }).then(data => {
+    let lock = data.password;
+    let lock_icon = '';
+    if (lock == true) {
+      lock = 'Password required to join server | ';
+      lock_icon = 'https://resources.bastionbot.org/images/lock.png';
+    } 
+    else {
+       lock = '';
+       lock_icon = '';
+    }
     message.channel.send({
       embed: {
         color: Bastion.colors.BLUE,
@@ -46,33 +56,29 @@ exports.exec = (Bastion, message, args) => {
         description: '[Minecraft](https://minecraft.net/)',
         fields: [
           {
-            name: 'Server IP',
-            value: `${host}:${port}`,
-            inline: true
-          },
-          {
-            name: 'Private',
-            value: data.password,
+            name: 'Address',
+            value: '`' + host + ':' + port + '`',
             inline: true
           },
           {
             name: 'Players',
-            value: `${data.players.length}/${data.maxplayers}`,
+            value: '`' + data.players.length + '/' + data.maxplayers + '`',
             inline: true
           },
           {
             name: 'Map',
-            value: data.raw.map,
+            value: '`' + data.raw.map + '`',
             inline: true
           },
           {
-            name: 'Gametype',
-            value: data.raw.gametype,
+            name: 'Mode',
+            value: '`' + data.raw.gametype + '`',
             inline: true
           }
         ],
         footer: {
-          text: `Version: ${data.raw.version}`
+          text: lock + `Version: ${data.raw.version}`,
+          icon_url: lock_icon,
         }
       }
     }).catch(e => {

--- a/modules/game_stats/quake3.js
+++ b/modules/game_stats/quake3.js
@@ -39,57 +39,101 @@ exports.exec = (Bastion, message, args) => {
     host: host,
     port: port
   }).then(data => {
+    let gametype = '';
+        if (data.raw.g_gametype === '0') {
+            gametype = 'FFA';
+        } else if (data.raw.g_gametype === '1') {
+            gametype = '1v1';
+        } else if (data.raw.g_gametype === '2') {
+            gametype = '2';
+        } else if (data.raw.g_gametype === '3') {
+            gametype = 'TDM';
+        } else if (data.raw.g_gametype === '4') {
+            gametype = 'CTF';
+        } else if (data.raw.g_gametype === '5') {
+            gametype = 'CPM';
+        } else {
+            gametype = data.raw.g_gametype;
+        }
     let stats = [
       {
-        name: 'Server IP',
-        value: `[${host}:${port}](steam://connect/${host}:${port})`,
-        inline: true
-      },
-      {
-        name: 'Private',
-        value: data.password,
+        name: 'Address',
+        value: '`' + host + ':' + port + '`',
         inline: true
       },
       {
         name: 'Players',
-        value: `${data.players.length}/${data.maxplayers}`,
+        value: '`' + data.players.length + '/' + data.maxplayers + '`',
         inline: true
       },
       {
-        name: 'Map/Gametype',
-        value: `${data.map} - ${data.raw.g_gametype}`
+        name: 'Map',
+        value: '`' + data.map + ' - ' + gametype + '`',
+        inline: true
       }
     ];
 
     if (data.players.length > 0) {
       let players = [];
       let scores = [];
+      let pings = [];
       for (let i = 0; i < data.players.length; i++) {
-        players.push(data.players[i].name);
+        players.push(data.players[i].name.substring(0, 12));
       }
       for (let i = 0; i < data.players.length; i++) {
         scores.push(data.players[i].frags);
       }
+      for (let i = 0; i < data.players.length; i++) {
+        pings.push(data.players[i].ping);
+      }
       stats.push(
         {
-          name: 'Player',
-          value: players.join('\n'),
+          name: 'Player Name',
+          value: '```http\n' + players.join('\n') + '```',
           inline: true
         },
         {
           name: 'Score',
-          value: scores.join('\n'),
+          value: '```http\n' + scores.join('\n') + '```',
+          inline: true
+        },
+        {
+          name: 'Ping',
+          value: '```http\n' + pings.join('\n') + '```',
           inline: true
         }
       );
     }
 
+    stats.push(
+      {
+        name: 'Join Server',
+        value: 'steam://connect/' + host + ':' + port,
+        inline: false
+      }  
+    );
+    
+    let lock = data.password;
+    let lock_icon = '';
+    if (lock == true) {
+      lock = 'Password required to join server';
+      lock_icon = 'https://resources.bastionbot.org/images/lock.png';
+    } 
+    else {
+       lock = '';
+       lock_icon = '';
+    }
+    
     message.channel.send({
       embed: {
         color: Bastion.colors.BLUE,
         title: data.name,
         description: '[Quake III Arena](https://store.steampowered.com/app/2200)',
-        fields: stats
+        fields: stats,
+        footer: {
+          text: lock,
+          icon_url: lock_icon
+        }
       }
     }).catch(e => {
       Bastion.log.error(e);

--- a/modules/game_stats/teamFortress2.js
+++ b/modules/game_stats/teamFortress2.js
@@ -1,5 +1,5 @@
 /**
- * @file teamFortress2 command
+ * @file counterStrikeGlobalOffensive command
  * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
  * @license MIT
  */
@@ -41,55 +41,84 @@ exports.exec = (Bastion, message, args) => {
   }).then(data => {
     let stats = [
       {
-        name: 'Server IP',
-        value: `[${host}:${port}](steam://connect/${host}:${port})`,
-        inline: true
-      },
-      {
-        name: 'Private',
-        value: data.password,
+        name: 'Address',
+        value: '`' + host + ':' + port + '`',
         inline: true
       },
       {
         name: 'Players',
-        value: `${data.players.length}/${data.maxplayers}`,
+        value: '`' + data.players.length + '/' + data.maxplayers + '`',
         inline: true
       },
       {
         name: 'Map',
-        value: data.map
+        value: '`' + data.map + '`',
+        inline: true
       }
     ];
 
     if (data.players.length > 0) {
       let players = [];
       let scores = [];
+      let times = [];
       for (let i = 0; i < data.players.length; i++) {
-        players.push(data.players[i].name);
+        players.push(data.players[i].name.substring(0, 12));
       }
       for (let i = 0; i < data.players.length; i++) {
         scores.push(data.players[i].score);
       }
+      for (let i = 0; i < data.players.length; i++) {
+        times.push(new Date(data.players[i].time * 1000).toISOString().substr(11, 8));
+      }
       stats.push(
         {
-          name: 'Player',
-          value: players.join('\n'),
+          name: 'Player Name',
+          value: '```http\n' + players.join('\n') + '\n```',
           inline: true
         },
         {
           name: 'Score',
-          value: scores.join('\n'),
+          value: '```http\n' + scores.join('\n') + '\n```',
+          inline: true
+        },
+        {
+          name: 'Time',
+          value: '```http\n' + times.join('\n') + '\n```',
           inline: true
         }
+        
       );
     }
-
+    
+    stats.push(
+      {
+        name: 'Join Server',
+        value: 'steam://connect/' + host + ':' + port,
+        inline: false
+      }  
+    );
+    
+    let lock = data.password;
+    let lock_icon = '';
+    if (lock == true) {
+      lock = 'Password required to join server';
+      lock_icon = 'https://resources.bastionbot.org/images/lock.png';
+    } 
+    else {
+       lock = '';
+       lock_icon = '';
+    }
+    
     message.channel.send({
       embed: {
         color: Bastion.colors.BLUE,
         title: data.name,
-        description: '[Team Fortress 2](https://store.steampowered.com/app/440/)',
-        fields: stats
+        description: '[' + data.raw.game + '](https://store.steampowered.com/app/' + data.raw.gameid + '/)',
+        fields: stats,
+        footer: {
+          text: lock,
+          icon_url: lock_icon
+        }
       }
     }).catch(e => {
       Bastion.log.error(e);

--- a/modules/game_stats/teamFortress2.js
+++ b/modules/game_stats/teamFortress2.js
@@ -4,137 +4,130 @@
  * @license MIT
  */
 
-const TF2 = require('gamedig');
+const source = require('gamedig');
 
-exports.exec = (Bastion, message, args) => {
-  if (args.length < 1 || !/^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(:0*(?:6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9]))?$/.test(args = args[0])) {
-    /**
-     * The command was ran with invalid parameters.
-     * @fires commandUsage
-     */
-    return Bastion.emit('commandUsage', message, this.help);
-  }
+exports.exec = async (Bastion, message, args) => {
+  try {
+    if (!/^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(:0*(?:6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[1-9][0-9]{1,3}|[0-9]))?$/.test(args.address)) {
+      /**
+      * The command was ran with invalid parameters.
+      * @fires commandUsage
+      */
+      return Bastion.emit('commandUsage', message, this.help);
+    }
 
-  args = args.split(':');
-  let host = args[0];
+    args.address = args.address.split(':');
+    let host = args.address[0];
 
-  if (host === '127.0.0.1') {
-    return message.channel.send({
-      embed: {
-        description: 'There is no place like `127.0.0.1`'
-      }
+    if (host === '127.0.0.1') {
+      return message.channel.send({
+        embed: {
+          description: 'There is no place like `127.0.0.1`'
+        }
+      });
+    }
+
+    let port;
+    if (args.address[1]) {
+      port = parseInt(args.address[1]);
+    }
+    else {
+      port = 27015;
+    }
+
+    let data = await source.query({
+      type: 'tf2',
+      host: host,
+      port: port
     });
-  }
 
-  let port;
-  if (args[1]) {
-    port = parseInt(args[1]);
-  }
-  else {
-    port = 27015;
-  }
-
-  TF2.query({
-    type: 'tf2',
-    host: host,
-    port: port
-  }).then(data => {
     let stats = [
       {
-        name: 'Address',
-        value: '`' + host + ':' + port + '`',
+        name: 'Server IP',
+        value: `\`${host}:${port}\``,
         inline: true
       },
       {
         name: 'Players',
-        value: '`' + data.players.length + '/' + data.maxplayers + '`',
+        value: `${data.players.length}/${data.maxplayers}`,
         inline: true
       },
       {
         name: 'Map',
-        value: '`' + data.map + '`',
-        inline: true
+        value: data.map
       }
     ];
 
     if (data.players.length > 0) {
       let players = [];
       let scores = [];
-      let times = [];
+      let playtimes = [];
       for (let i = 0; i < data.players.length; i++) {
-        players.push(data.players[i].name.substring(0, 12));
+        players.push(data.players[i].name);
       }
       for (let i = 0; i < data.players.length; i++) {
         scores.push(data.players[i].score);
       }
       for (let i = 0; i < data.players.length; i++) {
-        times.push(new Date(data.players[i].time * 1000).toISOString().substr(11, 8));
+        playtimes.push(`${parseInt(data.players[i].time)}s`);
       }
       stats.push(
         {
-          name: 'Player Name',
-          value: '```http\n' + players.join('\n') + '\n```',
+          name: 'Player',
+          value: `\`\`\`http\n${players.join('\n')}\`\`\``,
           inline: true
         },
         {
           name: 'Score',
-          value: '```http\n' + scores.join('\n') + '\n```',
+          value: `\`\`\`http\n${scores.join('\n')}\`\`\``,
           inline: true
         },
         {
-          name: 'Time',
-          value: '```http\n' + times.join('\n') + '\n```',
+          name: 'Playtime',
+          value: `\`\`\`http\n${playtimes.join('\n')}\`\`\``,
           inline: true
+        },
+        {
+          name: 'Join',
+          value: `<steam://connect/${host}:${port}>`
         }
-        
       );
     }
-    
-    stats.push(
-      {
-        name: 'Join Server',
-        value: 'steam://connect/' + host + ':' + port,
-        inline: false
-      }  
-    );
-    
-    let lock = data.password;
-    let lock_icon = '';
-    if (lock == true) {
-      lock = 'Password required to join server';
-      lock_icon = 'https://resources.bastionbot.org/images/lock.png';
-    } 
-    else {
-       lock = '';
-       lock_icon = '';
+
+    let footer;
+    if (data.password) {
+      footer = {
+        text: 'Private Server',
+        icon_url: 'https://resources.bastionbot.org/images/lock.png'
+      };
     }
-    
+
     message.channel.send({
       embed: {
         color: Bastion.colors.BLUE,
         title: data.name,
-        description: '[' + data.raw.game + '](https://store.steampowered.com/app/' + data.raw.gameid + '/)',
+        description: '[Team Fortress 2](https://store.steampowered.com/app/440/)',
         fields: stats,
-        footer: {
-          text: lock,
-          icon_url: lock_icon
-        }
+        footer: footer
       }
     }).catch(e => {
       Bastion.log.error(e);
     });
-  }).catch(() => {
-    /**
-     * Error condition is encountered.
-     * @fires error
-     */
-    return Bastion.emit('error', Bastion.strings.error(message.guild.language, 'connection'), Bastion.strings.error(message.guild.language, 'invalidIPPort', true), message.channel);
-  });
+  }
+  catch (e) {
+    if (e.toString() === 'UDP Watchdog Timeout') {
+      return Bastion.emit('error', Bastion.strings.error(message.guild.language, 'connection'), Bastion.strings.error(message.guild.language, 'invalidIPPort', true), message.channel);
+    }
+    Bastion.log.error(e);
+  }
 };
 
 exports.config = {
   aliases: [ 'tf2' ],
-  enabled: true
+  enabled: true,
+  argsDefinitions: [
+    { name: 'address', type: String, defaultOption: true }
+  ]
 };
 
 exports.help = {
@@ -142,6 +135,6 @@ exports.help = {
   botPermission: '',
   userTextPermission: '',
   userVoicePermission: '',
-  usage: 'teamFortress2 <TF2_SERVER_IP>[:PORT]',
-  example: [ 'teamFortress2 139.59.31.129', 'teamFortress2 139.59.31.129:27019' ]
+  usage: 'teamFortress2 <TF2_SERVER_IP:PORT>',
+  example: [ 'teamFortress2 139.59.31.129:27019' ]
 };

--- a/modules/game_stats/teamFortress2.js
+++ b/modules/game_stats/teamFortress2.js
@@ -1,5 +1,5 @@
 /**
- * @file counterStrikeGlobalOffensive command
+ * @file teamFortress2 command
  * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
  * @license MIT
  */


### PR DESCRIPTION
### Description of the Change

This PR brings some additional fields to the `cod4`, `csgo`, `tf2`, `minecraft` and `quake3` commands along with some design changes and code improvements.

### Alternate Designs

Thought of combining all these commands into one, since all use the same library to get data. But that would have cost user friendliness due to varying protocol of different games that would have required some extra input from user.

### Why Should This Be Added?

Many commands look more prettier, *comparatively*.
Additional fields for some commands like ping, playtime, etc.

### Benefits

* Comparatively better UI
* Additional fields for:
    * `cod4`: Ping
    * `csgo`: Playtime
    * `q3`: Ping
    * `tf2`: Playtime

### Possible Drawbacks

No possible drawbacks.

### Applicable Issues
\-