### PR TITLE
No prefix requirement for commands used in DM

### DIFF
--- a/handlers/directMessageHandler.js
+++ b/handlers/directMessageHandler.js
@@ -10,39 +10,32 @@
  * @returns {void}
  */
 module.exports = message => {
-  let prefix = message.client.config.prefix[0];
-
-  if (message.content.startsWith(prefix)) {
-    let args = message.content.split(' ');
-    let command = args.shift().slice(prefix.length).toLowerCase();
-
-    if (command === 'help' || command === 'h') {
-      return message.channel.send({
-        embed: {
-          color: message.client.colors.BLUE,
-          title: 'The Bastion Bot',
-          url: 'https://bastionbot.org',
-          description: 'Join [**Bastion HQ**](https://discord.gg/fzx8fkt) to test Bastion and it\'s commands, for giveaway events, for chatting and for a lot of fun!',
-          fields: [
-            {
-              name: 'Bastion HQ Invite Link',
-              value: 'https://discord.gg/fzx8fkt'
-            },
-            {
-              name: 'Bastion Bot Invite Link',
-              value: `https://discordapp.com/oauth2/authorize?client_id=${message.client.user.id}&scope=bot&permissions=2146958463`
-            }
-          ],
-          thumbnail: {
-            url: message.client.user.displayAvatarURL
+  if (message.content.startsWith('help')) {
+    return message.channel.send({
+      embed: {
+        color: message.client.colors.BLUE,
+        title: 'The Bastion Bot',
+        url: 'https://bastionbot.org',
+        description: 'Join [**Bastion HQ**](https://discord.gg/fzx8fkt) to test Bastion and it\'s commands, for giveaway events, for chatting and for a lot of fun!',
+        fields: [
+          {
+            name: 'Bastion HQ Invite Link',
+            value: 'https://discord.gg/fzx8fkt'
           },
-          footer: {
-            text: '</> with ❤ by Sankarsan Kampa (a.k.a. k3rn31p4nic)'
+          {
+            name: 'Bastion Bot Invite Link',
+            value: `https://discordapp.com/oauth2/authorize?client_id=${message.client.user.id}&scope=bot&permissions=2146958463`
           }
+        ],
+        thumbnail: {
+          url: message.client.user.displayAvatarURL
+        },
+        footer: {
+          text: '</> with ❤ by Sankarsan Kampa (a.k.a. k3rn31p4nic)'
         }
-      }).catch(e => {
-        message.client.log.error(e);
-      });
-    }
+      }
+    }).catch(e => {
+      message.client.log.error(e);
+    });
   }
 };

--- a/handlers/directMessageHandler.js
+++ b/handlers/directMessageHandler.js
@@ -10,6 +10,8 @@
  * @returns {void}
  */
 module.exports = message => {
+  if (!message.content) return;
+
   if (message.content.toLowerCase().startsWith('help')) {
     return message.channel.send({
       embed: {

--- a/handlers/directMessageHandler.js
+++ b/handlers/directMessageHandler.js
@@ -10,7 +10,7 @@
  * @returns {void}
  */
 module.exports = message => {
-  if (message.content.startsWith('help')) {
+  if (message.content.toLowerCase().startsWith('help')) {
     return message.channel.send({
       embed: {
         color: message.client.colors.BLUE,


### PR DESCRIPTION
#### What is the purpose of this pull request?
- [ ] String updates
- [ ] Documentation update
- [ ] Bug fix
- [X] Improvement/enhancement
- [ ] Add a feature/command
- [ ] Remove a feature/command
- [ ] Add something to the core
- [ ] Remove something from the core
- [ ] Other, please explain:

#### Description of the changes you made
This PR updates the direct message command handler so that commands in direct messages won't require a prefix anymore.

#### Is there anything you'd like reviewers to focus on?
No

#### Are there any possible drawbacks?
If you think prefix should be required (and that it's useful) in DM commands, then yeah this is the drawback for you! Otherwise, there isn't any drawbacks.

#### Applicable Issues:
\-