### PR TITLE
Moderation log rewrite

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,11 +1,12 @@
 {
-  "date": "April 23, 2018",
+  "date": "April 24, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [],
   "THESE ABILITIES HAVE ENHANCED": [
     "Logs are now much prettier, than it was already!",
     "Commands that work in direct messages can now be used without a prefix.",
     "Multiple prefixes can be set from the config too",
+    "The `reason` command will now work with moderation case numbers, instead of moderation log message IDs.",
     "Tons of under-the-hood improvements and changes."
   ],
   "NEW FEATURES!": [
@@ -16,7 +17,8 @@
     "Levels and currencies aren't global anymore. Members have separate currency & level in every server.",
     "If you're a server owner, you can now `give` and `take` any amount of Bastion Currencies to/from any member of your server.",
     "And you can also give as much experience points as you want to your server members, using the `giveXP` command.",
-    "Not to forget, you can do Bastion Currency giveaways in your server, using the `currencyGiveaway` command."
+    "Not to forget, you can do Bastion Currency giveaways in your server, using the `currencyGiveaway` command.",
+    "Tired of looking through the moderation logs just to find a specific case? Don't worry, you can now use the `case` command to fetch any moderation action from the moderaion logs using the case number."
   ],
   "NEW COMMANDS!": [
     "Added `blacklist` command to blacklist users globally from using Bastion.",

--- a/events/moderationLog.js
+++ b/events/moderationLog.js
@@ -221,6 +221,15 @@ module.exports = async (message, action, target, reason, extras) => {
       message.client.log.error(e);
     });
 
+    await message.client.database.models.moderationCase.create({
+      guildID: guild.id,
+      number: modCaseNo,
+      messageID: message.id
+    },
+    {
+      fields: [ 'guildID', 'number', 'messageID' ]
+    });
+
     await message.client.database.models.guild.update({
       moderationCaseNo: modCaseNo + 1
     },

--- a/events/moderationLog.js
+++ b/events/moderationLog.js
@@ -207,7 +207,7 @@ module.exports = async (message, action, target, reason, extras) => {
         return message.client.log.error(`Moderation logging is not present for ${action} action.`);
     }
 
-    modLogChannel.send({
+    let modLogMessage = await modLogChannel.send({
       embed: {
         color: color,
         title: action,
@@ -217,14 +217,12 @@ module.exports = async (message, action, target, reason, extras) => {
         },
         timestamp: new Date()
       }
-    }).catch(e => {
-      message.client.log.error(e);
     });
 
     await message.client.database.models.moderationCase.create({
       guildID: guild.id,
       number: modCaseNo,
-      messageID: message.id
+      messageID: modLogMessage.id
     },
     {
       fields: [ 'guildID', 'number', 'messageID' ]

--- a/events/moderationLog.js
+++ b/events/moderationLog.js
@@ -17,7 +17,7 @@ module.exports = async (message, action, target, reason, extras) => {
     let guild = message.guild;
     let executor = message.author;
 
-    let guildModel = await guild.client.database.models.guild.findOne({
+    let guildModel = await message.client.database.models.guild.findOne({
       attributes: [ 'moderationLog', 'moderationCaseNo' ],
       where: {
         guildID: guild.id
@@ -59,8 +59,8 @@ module.exports = async (message, action, target, reason, extras) => {
 
     switch (action.toLowerCase()) {
       case 'addrole':
-        action = guild.client.strings.events(guild.language, 'addRole');
-        color = guild.client.colors.GREEN;
+        action = message.client.strings.events(guild.language, 'addRole');
+        color = message.client.colors.GREEN;
         logData.unshift(
           {
             name: 'Role',
@@ -70,13 +70,13 @@ module.exports = async (message, action, target, reason, extras) => {
         break;
 
       case 'ban':
-        action = guild.client.strings.events(guild.language, 'guildBanAdd');
-        color = guild.client.colors.RED;
+        action = message.client.strings.events(guild.language, 'guildBanAdd');
+        color = message.client.colors.RED;
         break;
 
       case 'clear':
-        action = guild.client.strings.events(guild.language, 'messageClear');
-        color = guild.client.colors.RED;
+        action = message.client.strings.events(guild.language, 'messageClear');
+        color = message.client.colors.RED;
         logData.splice(0, 3,
           {
             name: 'Channel',
@@ -96,36 +96,36 @@ module.exports = async (message, action, target, reason, extras) => {
         break;
 
       case 'deafen':
-        action = guild.client.strings.events(guild.language, 'deafAdd');
-        color = guild.client.colors.ORANGE;
+        action = message.client.strings.events(guild.language, 'deafAdd');
+        color = message.client.colors.ORANGE;
         break;
 
       case 'kick':
-        action = guild.client.strings.events(guild.language, 'kick');
-        color = guild.client.colors.RED;
+        action = message.client.strings.events(guild.language, 'kick');
+        color = message.client.colors.RED;
         break;
 
       case 'mute':
-        action = guild.client.strings.events(guild.language, 'voiceMuteAdd');
-        color = guild.client.colors.ORANGE;
+        action = message.client.strings.events(guild.language, 'voiceMuteAdd');
+        color = message.client.colors.ORANGE;
         break;
 
       /*
       case 'nickname':
         action = 'Updated User Nickname';
-        color = guild.client.colors.ORANGE;
+        color = message.client.colors.ORANGE;
         logData.push();
         break;
       */
 
       case 'removeallroles':
-        action = guild.client.strings.events(guild.language, 'removeAllRole');
-        color = guild.client.colors.RED;
+        action = message.client.strings.events(guild.language, 'removeAllRole');
+        color = message.client.colors.RED;
         break;
 
       case 'removerole':
-        action = guild.client.strings.events(guild.language, 'removeRole');
-        color = guild.client.colors.RED;
+        action = message.client.strings.events(guild.language, 'removeRole');
+        color = message.client.colors.RED;
         logData.unshift(
           {
             name: 'Role',
@@ -135,8 +135,8 @@ module.exports = async (message, action, target, reason, extras) => {
         break;
 
       case 'report':
-        action = guild.client.strings.events(guild.language, 'userReport');
-        color = guild.client.colors.ORANGE;
+        action = message.client.strings.events(guild.language, 'userReport');
+        color = message.client.colors.ORANGE;
         logData.splice(logData.length - 2, 2,
           {
             name: 'Reporter',
@@ -152,13 +152,13 @@ module.exports = async (message, action, target, reason, extras) => {
         break;
 
       case 'softban':
-        action = guild.client.strings.events(guild.language, 'userSoftBan');
-        color = guild.client.colors.RED;
+        action = message.client.strings.events(guild.language, 'userSoftBan');
+        color = message.client.colors.RED;
         break;
 
       case 'textmute':
-        action = guild.client.strings.events(guild.language, 'textMuteAdd');
-        color = guild.client.colors.ORANGE;
+        action = message.client.strings.events(guild.language, 'textMuteAdd');
+        color = message.client.colors.ORANGE;
         logData.splice(logData.length - 2, 0,
           {
             name: 'Channel',
@@ -168,8 +168,8 @@ module.exports = async (message, action, target, reason, extras) => {
         break;
 
       case 'textunmute':
-        action = guild.client.strings.events(guild.language, 'textMuteRemove');
-        color = guild.client.colors.GREEN;
+        action = message.client.strings.events(guild.language, 'textMuteRemove');
+        color = message.client.colors.GREEN;
         logData.splice(logData.length - 2, 0,
           {
             name: 'Channel',
@@ -179,32 +179,32 @@ module.exports = async (message, action, target, reason, extras) => {
         break;
 
       case 'unban':
-        action = guild.client.strings.events(guild.language, 'guildBanRemove');
-        color = guild.client.colors.GREEN;
+        action = message.client.strings.events(guild.language, 'guildBanRemove');
+        color = message.client.colors.GREEN;
         break;
 
       case 'undeafen':
-        action = guild.client.strings.events(guild.language, 'deafRemove');
-        color = guild.client.colors.GREEN;
+        action = message.client.strings.events(guild.language, 'deafRemove');
+        color = message.client.colors.GREEN;
         break;
 
       case 'unmute':
-        action = guild.client.strings.events(guild.language, 'voiceMuteRemove');
-        color = guild.client.colors.GREEN;
+        action = message.client.strings.events(guild.language, 'voiceMuteRemove');
+        color = message.client.colors.GREEN;
         break;
 
       case 'warn':
-        action = guild.client.strings.events(guild.language, 'userWarnAdd');
-        color = guild.client.colors.ORANGE;
+        action = message.client.strings.events(guild.language, 'userWarnAdd');
+        color = message.client.colors.ORANGE;
         break;
 
       case 'clearwarn':
-        action = guild.client.strings.events(guild.language, 'userWarnRemove');
-        color = guild.client.colors.GREEN;
+        action = message.client.strings.events(guild.language, 'userWarnRemove');
+        color = message.client.colors.GREEN;
         break;
 
       default:
-        return guild.client.log.error(`Moderation logging is not present for ${action} action.`);
+        return message.client.log.error(`Moderation logging is not present for ${action} action.`);
     }
 
     modLogChannel.send({
@@ -218,10 +218,10 @@ module.exports = async (message, action, target, reason, extras) => {
         timestamp: new Date()
       }
     }).catch(e => {
-      guild.client.log.error(e);
+      message.client.log.error(e);
     });
 
-    await guild.client.database.models.guild.update({
+    await message.client.database.models.guild.update({
       moderationCaseNo: modCaseNo + 1
     },
     {
@@ -232,6 +232,6 @@ module.exports = async (message, action, target, reason, extras) => {
     });
   }
   catch (e) {
-    guild.client.log.error(e);
+    message.client.log.error(e);
   }
 };

--- a/events/moderationLog.js
+++ b/events/moderationLog.js
@@ -5,16 +5,18 @@
  */
 
 /**
- * @param {Guild} guild The guild where this moderation action was fired
- * @param {User} executor The user who fired this moderation action
+ * @param {Message} message The message that fired this moderation action
  * @param {string} action The moderation action's name
  * @param {User|Channel} target The target on which this action was taken
  * @param {string} reason The reason for the moderation action
  * @param {object} extras An object containing any extra data of the moderation action
  * @returns {void}
  */
-module.exports = async (guild, executor, action, target, reason, extras) => {
+module.exports = async (message, action, target, reason, extras) => {
   try {
+    let guild = message.guild;
+    let executor = message.author;
+
     let guildModel = await guild.client.database.models.guild.findOne({
       attributes: [ 'moderationLog', 'moderationCaseNo' ],
       where: {

--- a/locales/en/modules.json
+++ b/locales/en/modules.json
@@ -186,6 +186,7 @@
   "moderation": {
     "addRole": "Adds the specified role to a specified user of your Discord server.",
     "ban": "Bans the specified user from your Discord server and removes 7 days of their message history.",
+    "case": "Fetches any moderation action, logged in the moderation log channel, using the moderation log case number.",
     "clear": "Deletes a bulk of specified messages from a text channel of your Discord server.",
     "clearWarn": "Clears all warnings from the given user.",
     "deafen": "Deafens a specified user server-wide in your Discord server.",

--- a/modules/moderation/addRole.js
+++ b/modules/moderation/addRole.js
@@ -51,7 +51,7 @@ exports.exec = async (Bastion, message, args) => {
     * Logs moderation events if it is enabled
     * @fires moderationLog
     */
-    Bastion.emit('moderationLog', message.guild, message.author, this.help.name, user, reason, {
+    Bastion.emit('moderationLog', message, this.help.name, user, reason, {
       role: role
     });
   }

--- a/modules/moderation/ban.js
+++ b/modules/moderation/ban.js
@@ -57,7 +57,7 @@ exports.exec = async (Bastion, message, args) => {
     * Logs moderation events if it is enabled
     * @fires moderationLog
     */
-    Bastion.emit('moderationLog', message.guild, message.author, this.help.name, user, args.reason);
+    Bastion.emit('moderationLog', message, this.help.name, user, args.reason);
 
     let DMChannel = await user.createDM();
     DMChannel.send({

--- a/modules/moderation/case.js
+++ b/modules/moderation/case.js
@@ -1,0 +1,83 @@
+/**
+ * @file case command
+ * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
+ * @license MIT
+ */
+
+exports.exec = async (Bastion, message, args) => {
+  try {
+    if (!args.number) {
+      /**
+      * The command was ran with invalid parameters.
+      * @fires commandUsage
+      */
+      return Bastion.emit('commandUsage', message, this.help);
+    }
+
+    let guildModel = await message.client.database.models.guild.findOne({
+      attributes: [ 'moderationLog' ],
+      where: {
+        guildID: message.guild.id
+      },
+      include: [
+        {
+          model: message.client.database.models.moderationCase,
+          attributes: [ 'guildID', 'number', 'messageID' ],
+          where: {
+            number: args.number
+          }
+        }
+      ]
+    });
+
+    if (!guildModel || !guildModel.dataValues.moderationLog || !guildModel.moderationCases.length) return;
+
+    let modLogChannel = message.guild.channels.get(guildModel.dataValues.moderationLog);
+    if (!modLogChannel) return;
+
+    let modMessage = await modLogChannel.fetchMessage(guildModel.moderationCases[0].dataValues.messageID);
+
+    if (modMessage && modMessage.embeds.length) {
+      let embed = {
+        color: Bastion.colors.BLUE,
+        title: modMessage.embeds[0].title,
+        description: modMessage.embeds[0].description,
+        fields: modMessage.embeds[0].fields.map(field => {
+          return {
+            name: field.name,
+            value: field.value,
+            inline: field.inline
+          };
+        }),
+        footer: {
+          text: `Requested ${modMessage.embeds[0].footer.text}`
+        },
+        timestamp: modMessage.embeds[0].createdTimestamp
+      };
+
+      message.channel.send({
+        embed: embed
+      });
+    }
+  }
+  catch (e) {
+    Bastion.log.error(e);
+  }
+};
+
+exports.config = {
+  aliases: [],
+  enabled: true,
+  argsDefinitions: [
+    { name: 'number', type: String, defaultOption: true }
+  ]
+};
+
+exports.help = {
+  name: 'case',
+  botPermission: '',
+  userTextPermission: '',
+  userVoicePermission: '',
+  usage: 'case <MOD_LOG_CASE_NO>',
+  example: [ 'case 1337' ]
+};

--- a/modules/moderation/clear.js
+++ b/modules/moderation/clear.js
@@ -64,7 +64,7 @@ exports.exec = async (Bastion, message, args) => {
     * Logs moderation events if it is enabled
     * @fires moderationLog
     */
-    Bastion.emit('moderationLog', message.guild, message.author, this.help.name, message.channel, reason, {
+    Bastion.emit('moderationLog', message, this.help.name, message.channel, reason, {
       cleared: `${msgs.size || msgs.length}${args.includes('--nonpinned') ? ' non pinned' : ''} messages from ${user ? user : args.includes('--bots') ? 'BOTs' : 'everyone'}`
     });
   }

--- a/modules/moderation/clearWarn.js
+++ b/modules/moderation/clearWarn.js
@@ -55,7 +55,7 @@ exports.exec = async (Bastion, message, args) => {
     * Logs moderation events if it is enabled
     * @fires moderationLog
     */
-    Bastion.emit('moderationLog', message.guild, message.author, this.help.name, user, args.reason);
+    Bastion.emit('moderationLog', message, this.help.name, user, args.reason);
   }
   catch (e) {
     Bastion.log.error(e);

--- a/modules/moderation/deafen.js
+++ b/modules/moderation/deafen.js
@@ -41,7 +41,7 @@ exports.exec = async (Bastion, message, args) => {
     * Logs moderation events if it is enabled
     * @fires moderationLog
     */
-    Bastion.emit('moderationLog', message.guild, message.author, this.help.name, user, args.reason);
+    Bastion.emit('moderationLog', message, this.help.name, user, args.reason);
   }
   catch (e) {
     Bastion.log.error(e);

--- a/modules/moderation/kick.js
+++ b/modules/moderation/kick.js
@@ -52,7 +52,7 @@ exports.exec = async (Bastion, message, args) => {
     * Logs moderation events if it is enabled
     * @fires moderationLog
     */
-    Bastion.emit('moderationLog', message.guild, message.author, this.help.name, member, args.reason);
+    Bastion.emit('moderationLog', message, this.help.name, member, args.reason);
 
     member.send({
       embed: {

--- a/modules/moderation/mute.js
+++ b/modules/moderation/mute.js
@@ -41,7 +41,7 @@ exports.exec = async (Bastion, message, args) => {
     * Logs moderation events if it is enabled
     * @fires moderationLog
     */
-    Bastion.emit('moderationLog', message.guild, message.author, this.help.name, user, args.reason);
+    Bastion.emit('moderationLog', message, this.help.name, user, args.reason);
   }
   catch (e) {
     Bastion.log.error(e);

--- a/modules/moderation/removeAllRoles.js
+++ b/modules/moderation/removeAllRoles.js
@@ -46,7 +46,7 @@ exports.exec = async (Bastion, message, args) => {
     * Logs moderation events if it is enabled
     * @fires moderationLog
     */
-    Bastion.emit('moderationLog', message.guild, message.author, this.help.name, user);
+    Bastion.emit('moderationLog', message, this.help.name, user);
   }
   catch (e) {
     Bastion.log.error(e);

--- a/modules/moderation/removeRole.js
+++ b/modules/moderation/removeRole.js
@@ -51,7 +51,7 @@ exports.exec = async (Bastion, message, args) => {
     * Logs moderation events if it is enabled
     * @fires moderationLog
     */
-    Bastion.emit('moderationLog', message.guild, message.author, this.help.name, user, reason, {
+    Bastion.emit('moderationLog', message, this.help.name, user, reason, {
       role: role
     });
   }

--- a/modules/moderation/report.js
+++ b/modules/moderation/report.js
@@ -52,7 +52,7 @@ exports.exec = async (Bastion, message, args) => {
      * Logs moderation events if it is enabled
      * @fires moderationLog
      */
-    Bastion.emit('moderationLog', message.guild, message.author, this.help.name, user, reason);
+    Bastion.emit('moderationLog', message, this.help.name, user, reason);
   }
   catch (e) {
     Bastion.log.error(e);

--- a/modules/moderation/softBan.js
+++ b/modules/moderation/softBan.js
@@ -80,7 +80,7 @@ exports.exec = async (Bastion, message, args) => {
     * Logs moderation events if it is enabled
     * @fires moderationLog
     */
-    Bastion.emit('moderationLog', message.guild, message.author, this.help.name, user, args.reason);
+    Bastion.emit('moderationLog', message, this.help.name, user, args.reason);
 
     let DMChannel = await user.createDM();
     DMChannel.send({

--- a/modules/moderation/textMute.js
+++ b/modules/moderation/textMute.js
@@ -82,7 +82,7 @@ exports.exec = async (Bastion, message, args) => {
     * Logs moderation events if it is enabled
     * @fires moderationLog
     */
-    Bastion.emit('moderationLog', message.guild, message.author, this.help.name, user, args.reason, {
+    Bastion.emit('moderationLog', message, this.help.name, user, args.reason, {
       channel: message.channel
     });
   }

--- a/modules/moderation/textUnMute.js
+++ b/modules/moderation/textUnMute.js
@@ -43,7 +43,7 @@ exports.exec = async (Bastion, message, args) => {
       * Logs moderation events if it is enabled
       * @fires moderationLog
       */
-      Bastion.emit('moderationLog', message.guild, message.author, this.help.name, user, args.reason, {
+      Bastion.emit('moderationLog', message, this.help.name, user, args.reason, {
         channel: message.channel
       });
     }

--- a/modules/moderation/unBan.js
+++ b/modules/moderation/unBan.js
@@ -31,7 +31,7 @@ exports.exec = async (Bastion, message, args) => {
     * Logs moderation events if it is enabled
     * @fires moderationLog
     */
-    Bastion.emit('moderationLog', message.guild, message.author, this.help.name, user, args.reason);
+    Bastion.emit('moderationLog', message, this.help.name, user, args.reason);
   }
   catch (e) {
     if (e.code === 10013) {

--- a/modules/moderation/unDeafen.js
+++ b/modules/moderation/unDeafen.js
@@ -41,7 +41,7 @@ exports.exec = async (Bastion, message, args) => {
     * Logs moderation events if it is enabled
     * @fires moderationLog
     */
-    Bastion.emit('moderationLog', message.guild, message.author, this.help.name, user, args.reason);
+    Bastion.emit('moderationLog', message, this.help.name, user, args.reason);
   }
   catch (e) {
     Bastion.log.error(e);

--- a/modules/moderation/unMute.js
+++ b/modules/moderation/unMute.js
@@ -41,7 +41,7 @@ exports.exec = async (Bastion, message, args) => {
     * Logs moderation events if it is enabled
     * @fires moderationLog
     */
-    Bastion.emit('moderationLog', message.guild, message.author, this.help.name, user, args.reason);
+    Bastion.emit('moderationLog', message, this.help.name, user, args.reason);
   }
   catch (e) {
     Bastion.log.error(e);

--- a/modules/moderation/warn.js
+++ b/modules/moderation/warn.js
@@ -106,7 +106,7 @@ exports.exec = async (Bastion, message, args) => {
             Bastion.log.error(e);
           });
 
-          Bastion.emit('moderationLog', message.guild, message.author, guildModel.dataValues.warnAction, user, 'Warned 3 times!');
+          Bastion.emit('moderationLog', message, guildModel.dataValues.warnAction, user, 'Warned 3 times!');
 
           member.send({
             embed: {
@@ -152,7 +152,7 @@ exports.exec = async (Bastion, message, args) => {
     * Logs moderation events if it is enabled
     * @fires moderationLog
     */
-    Bastion.emit('moderationLog', message.guild, message.author, this.help.name, user, args.reason);
+    Bastion.emit('moderationLog', message, this.help.name, user, args.reason);
   }
   catch (e) {
     Bastion.log.error(e);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.3",
+  "version": "7.0.0-alpha.4",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",


### PR DESCRIPTION
#### What is the purpose of this pull request?
- [ ] String updates
- [ ] Documentation update
- [ ] Bug fix
- [X] Improvement/enhancement
- [X] Add a feature/command
- [ ] Remove a feature/command
- [X] Add something to the core
- [ ] Remove something from the core
- [ ] Other, please explain:

#### Description of the changes you made
This PR adds the functionality of storing moderation log case metadata in the DB, which allows the `reason` command to work with case nos., instead of message IDs. It also adds a new command `case` that can be used to fetch any moderation actions from the moderation logs using the case no.

#### Is there anything you'd like reviewers to focus on?
No

#### Are there any possible drawbacks?
`reason` won't work with message IDs anymore. So, it'll be a drawback for users who thought that was a good option.

#### Applicable Issues:
Closes #110 