### PR TITLE
Persistent claims

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -7,6 +7,7 @@
     "Commands that work in direct messages can now be used without a prefix.",
     "Multiple prefixes can be set from the config too",
     "The `reason` command will now work with moderation case numbers, instead of moderation log message IDs.",
+    "Your daily reward claim cooldowns will be in effect even after Bastion restarts.",
     "Tons of under-the-hood improvements and changes."
   ],
   "NEW FEATURES!": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.4",
+  "version": "7.0.0-alpha.5",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",

--- a/utils/models.js
+++ b/utils/models.js
@@ -260,6 +260,9 @@ module.exports = (Sequelize, database) => {
       type: Sequelize.BOOLEAN,
       allowNull: false,
       defaultValue: false
+    },
+    lastClaimed: {
+      type: Sequelize.INTEGER
     }
   },
   {

--- a/utils/models.js
+++ b/utils/models.js
@@ -262,7 +262,7 @@ module.exports = (Sequelize, database) => {
       defaultValue: false
     },
     lastClaimed: {
-      type: Sequelize.INTEGER
+      type: Sequelize.DATE
     }
   },
   {


### PR DESCRIPTION
#### What is the purpose of this pull request?
- [ ] String updates
- [ ] Documentation update
- [ ] Bug fix
- [X] Improvement/enhancement
- [ ] Add a feature/command
- [ ] Remove a feature/command
- [X] Add something to the core
- [ ] Remove something from the core
- [ ] Other, please explain:

#### Description of the changes you made
This PR adds the functionality of storing the last date a user used the `claim` command in the database. So that it will persist even after restart and the claim cooldown will still be in effect.

#### Is there anything you'd like reviewers to focus on?
No

#### Are there any possible drawbacks?
No

#### Applicable Issues:
Closes #164 