### PR TITLE
Claim streak and streak rewards

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "April 24, 2018",
+  "date": "April 25, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [],
   "THESE ABILITIES HAVE ENHANCED": [
@@ -19,7 +19,8 @@
     "If you're a server owner, you can now `give` and `take` any amount of Bastion Currencies to/from any member of your server.",
     "And you can also give as much experience points as you want to your server members, using the `giveXP` command.",
     "Not to forget, you can do Bastion Currency giveaways in your server, using the `currencyGiveaway` command.",
-    "Tired of looking through the moderation logs just to find a specific case? Don't worry, you can now use the `case` command to fetch any moderation action from the moderaion logs using the case number."
+    "Tired of looking through the moderation logs just to find a specific case? Don't worry, you can now use the `case` command to fetch any moderation action from the moderaion logs using the case number.",
+    "Using the `claim` or `daily` command daily will count towards your daily streaks. If you get a consecutive claim streak of 7, you'll can get a bonus of upto 700 BC."
   ],
   "NEW COMMANDS!": [
     "Added `blacklist` command to blacklist users globally from using Bastion.",

--- a/changes.json
+++ b/changes.json
@@ -12,15 +12,15 @@
   ],
   "NEW FEATURES!": [
     "A complete redesign/rewrite of the database.",
-    "You can now set any number of channels as voting channels. No limitations!",
-    "You can add any number of level up roles. No limitations here, too!",
-    "You can now set the amount of data shown in the terminal logs by modifying the value of `logLevel` key in config.",
+    "Set any number of channels as voting channels. No limitations!",
+    "Add any number of level up roles. No limitations here, too!",
+    "Set the amount of data shown in the terminal logs by modifying the value of `logLevel` key in config.",
     "Levels and currencies aren't global anymore. Members have separate currency & level in every server.",
-    "If you're a server owner, you can now `give` and `take` any amount of Bastion Currencies to/from any member of your server.",
-    "And you can also give as much experience points as you want to your server members, using the `giveXP` command.",
-    "Not to forget, you can do Bastion Currency giveaways in your server, using the `currencyGiveaway` command.",
-    "Tired of looking through the moderation logs just to find a specific case? Don't worry, you can now use the `case` command to fetch any moderation action from the moderaion logs using the case number.",
-    "Using the `claim` or `daily` command daily will count towards your daily streaks. If you get a consecutive claim streak of 7, you'll can get a bonus of upto 700 BC."
+    "You can now `give` and `take` any amount of Bastion Currencies to/from any member of your server.",
+    "Give as much XP as you want to your server members, using the `giveXP` command.",
+    "You can also do Bastion Currency giveaways in your server, using the `currencyGiveaway` command.",
+    "Tired of looking through the moderation logs just to find a specific case? Don't worry, you can now use the `case` command to fetch any case from the moderation logs, using the case number.",
+    "Using the `claim` command daily will count towards your daily streak. If you get a consecutive streak of 7 days, you'll can get a bonus of upto 700 BC."
   ],
   "NEW COMMANDS!": [
     "Added `blacklist` command to blacklist users globally from using Bastion.",

--- a/modules/money/claim.js
+++ b/modules/money/claim.js
@@ -52,6 +52,7 @@ exports.exec = async (Bastion, message) => {
       description = `${description}\n\nJust one day left for your 7 day streak to complete!`;
     }
     else if (guildMemberModel.dataValues.claimStreak === 7) {
+      guildMemberModel.dataValues.claimStreak = 0;
       rewardAmount += Bastion.functions.getRandomInt(350, 700);
       description = `${description}\n\nCongratulations! You've completed your 7 day streak! Check for a DM from me for your bonus reward.`;
     }

--- a/modules/money/claim.js
+++ b/modules/money/claim.js
@@ -31,7 +31,7 @@ exports.exec = async (Bastion, message) => {
        * Otherwise set the streak to 0.
        */
       let nextDay = moment(guildMemberModel.dataValues.lastClaimed).add(1, 'd');
-      if (moment().isSame(nextDay, 'day')) {
+      if (guildMemberModel.dataValues.claimStreak < 7 && moment().isSame(nextDay, 'day')) {
         guildMemberModel.dataValues.claimStreak++;
       }
       else {

--- a/modules/money/claim.js
+++ b/modules/money/claim.js
@@ -40,9 +40,20 @@ exports.exec = async (Bastion, message) => {
     }
 
     let rewardAmount = Bastion.functions.getRandomInt(50, 100);
+    let description = `${message.author} You've claimed your daily reward.`;
 
-    if (guildMemberModel.dataValues.claimStreak === 7) {
+    if (guildMemberModel.dataValues.claimStreak === 1) {
+      description = `${description}\n\nKeep using this command every day and you'll get a bonus reward on completion of your 7 day streak!`;
+    }
+    else if (guildMemberModel.dataValues.claimStreak > 1 && guildMemberModel.dataValues.claimStreak < 6) {
+      description = `${description}\n\n${7 - guildMemberModel.dataValues.claimStreak} days to get your bonus reward! Keep Going!`;
+    }
+    else if (guildMemberModel.dataValues.claimStreak === 6) {
+      description = `${description}\n\nJust one day left for your 7 day streak to complete!`;
+    }
+    else if (guildMemberModel.dataValues.claimStreak === 7) {
       rewardAmount += Bastion.functions.getRandomInt(350, 700);
+      description = `${description}\n\nCongratulations! You've completed your 7 day streak! Check for a DM from me for your bonus reward.`;
     }
 
     if (Bastion.user.id === '267035345537728512') {
@@ -76,7 +87,7 @@ exports.exec = async (Bastion, message) => {
     message.channel.send({
       embed: {
         color: Bastion.colors.GREEN,
-        description: `${message.author} You've claimed your daily reward. Please check my message in your DM to see the reward amount.`
+        description: description
       }
     }).catch(e => {
       Bastion.log.error(e);

--- a/modules/money/claim.js
+++ b/modules/money/claim.js
@@ -41,6 +41,10 @@ exports.exec = async (Bastion, message) => {
 
     let rewardAmount = Bastion.functions.getRandomInt(50, 100);
 
+    if (guildMemberModel.dataValues.claimStreak === 7) {
+      rewardAmount += Bastion.functions.getRandomInt(350, 700);
+    }
+
     if (Bastion.user.id === '267035345537728512') {
       if (message.guild.id === specialIDs.bastionGuild) {
         if (message.member && message.member.roles.has(specialIDs.patronsRole)) {

--- a/modules/money/claim.js
+++ b/modules/money/claim.js
@@ -4,24 +4,38 @@
  * @license MIT
  */
 
+const moment = require('moment');
 const specialIDs = require('../../data/specialIDs.json');
 
 exports.exec = async (Bastion, message) => {
   try {
     let guildMemberModel = await Bastion.database.models.guildMember.findOne({
-      attributes: [ 'lastClaimed' ],
+      attributes: [ 'lastClaimed', 'claimStreak' ],
       where: {
         userID: message.author.id,
         guildID: message.guild.id
       }
     });
 
-    /**
-     * If current date is same as the last claimed date, you can't use this!
-     */
     if (guildMemberModel && guildMemberModel.dataValues.lastClaimed) {
+      /**
+       * If current date is same as the last claimed date, you can't use this!
+       */
       if (guildMemberModel.dataValues.lastClaimed.toDateString() === new Date().toDateString()) {
         return Bastion.emit('error', Bastion.strings.error(message.guild.language, 'cooldown'), Bastion.strings.error(message.guild.language, 'claimCooldown', true, message.author), message.channel);
+      }
+
+
+      /**
+       * If it's a consecutive day, increase the claim streak of user.
+       * Otherwise set the streak to 0.
+       */
+      let nextDay = moment(guildMemberModel.dataValues.lastClaimed).add(1, 'd');
+      if (moment().isSame(nextDay, 'day')) {
+        guildMemberModel.dataValues.claimStreak++;
+      }
+      else {
+        guildMemberModel.dataValues.claimStreak = 0;
       }
     }
 
@@ -41,14 +55,15 @@ exports.exec = async (Bastion, message) => {
     Bastion.emit('userDebit', message.member, rewardAmount);
 
     await Bastion.database.models.guildMember.update({
-      lastClaimed: Date.now()
+      lastClaimed: Date.now(),
+      claimStreak: guildMemberModel.dataValues.claimStreak
     },
     {
       where: {
         userID: message.author.id,
         guildID: message.guild.id
       },
-      fields: [ 'lastClaimed' ]
+      fields: [ 'lastClaimed', 'claimStreak' ]
     });
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.5",
+  "version": "7.0.0-alpha.6",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",

--- a/utils/models.js
+++ b/utils/models.js
@@ -263,6 +263,10 @@ module.exports = (Sequelize, database) => {
     },
     lastClaimed: {
       type: Sequelize.DATE
+    },
+    claimStreak: {
+      type: Sequelize.TINYINT(3),
+      defaultValue: 0
     }
   },
   {


### PR DESCRIPTION
#### What is the purpose of this pull request?
- [ ] String updates
- [ ] Documentation update
- [ ] Bug fix
- [ ] Improvement/enhancement
- [X] Add a feature/command
- [ ] Remove a feature/command
- [X] Add something to the core
- [ ] Remove something from the core
- [ ] Other, please explain:

#### Description of the changes you made
This PR adds the functionality to store consecutive streaks of user's usage of `claim` command. And rewards them up to 700 Bastion Currencies if they get a 7 day streak.

#### Is there anything you'd like reviewers to focus on?
No

#### Are there any possible drawbacks?
No

#### Applicable Issues:
\-