### PR TITLE
Module handler patch

### DIFF
--- a/handlers/moduleHandler.js
+++ b/handlers/moduleHandler.js
@@ -15,7 +15,8 @@ let Commands = new Collection();
 let Aliases = new Collection();
 
 let commandFiles = fs.readdirSync(path.resolve('./commands/')).
-  filter(file => !fs.statSync(path.resolve('./commands/', file)).isDirectory());
+  filter(file => !fs.statSync(path.resolve('./commands/', file)).isDirectory()).
+  filter(file => file.endsWith('.js'));
 
 for (let file of commandFiles) {
   file = file.substr(0, file.length - 3);

--- a/handlers/moduleHandler.js
+++ b/handlers/moduleHandler.js
@@ -20,9 +20,17 @@ let commandFiles = fs.readdirSync(path.resolve('./commands/')).
 for (let file of commandFiles) {
   file = file.substr(0, file.length - 3);
   process.stdout.write(`${color.cyan('[Bastion]:')} Loading ${file} command...\n`);
+
   file = require(path.resolve(`./commands/${file}`));
   Commands.set(file.help.name.toLowerCase(), file);
-  file.config.module = commandInfo[file.help.name].module;
+
+  if (commandInfo[file.help.name]) {
+    file.config.module = commandInfo[file.help.name].module;
+  }
+  else {
+    throw new Error(`The \`${file.help.name}\` command has not been described in the default locale strings.`);
+  }
+
   for (let alias of file.config.aliases) {
     Aliases.set(alias.toLowerCase(), file.help.name);
   }


### PR DESCRIPTION
This PR improves the module handler:
 - Show proper message if the command hasn't been described in the default locale (`en_us`) strings.
 - Load only JavaScript files from the `commands` directory.

#### Possible drawbacks
None

#### Applicable Issues:
\-

#### Checklist
- [X] Test scripts passes
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
