### PR TITLE
Role Store Rewrite

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "April 30, 2018",
+  "date": "May 12, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [],
   "THESE ABILITIES HAVE ENHANCED": [
@@ -32,10 +32,12 @@
     "Added `ignoreWordFilter` command. You can now set channels and/or roles to be ignored by the word filter.",
     "Added `ignoreMentionFilter` command. You can now set channels and/or roles to be ignored by the mention filter.",
     "Added `ignoreSlowMode` command. You can now set channels and/or roles to be ignored by the slow mode.",
-    "Added `ignoreStarboard` command. You can now set channels and/or roles to be ignored by the starboard."
+    "Added `ignoreStarboard` command. You can now set channels and/or roles to be ignored by the starboard.",
+    "Added `sellRole` command to let server managers sell roles in their server's Role Store."
   ],
   "COMMANDS WITH NEW USAGE": [
-    "The `addTrigger` command's usage syntax has been changed. It won't work the way it used to before, please check the help message for it, using the `help addTrigger` command, to see the new usage details."
+    "The `addTrigger` command's usage syntax has been changed. It won't work the way it used to before, please check the help message for it, using the `help addTrigger` command, to see the new usage details.",
+    "The `roleStore` command will only show the roles being sold in the server's Role Store. Use the new `sellRole` command to sell roles instead."
   ],
   "RENAMED COMMANDS": [
     "Renamed the `ignoreChannel` and `ignoreRole` commands to `ignoreChannels` and `ignoreRoles`, respectively.",

--- a/commands/buyRole.js
+++ b/commands/buyRole.js
@@ -8,9 +8,9 @@ exports.exec = async (Bastion, message, args) => {
   try {
     if (!args.role) {
       /**
-      * The command was ran with invalid parameters.
-      * @fires commandUsage
-      */
+       * The command was ran with invalid parameters.
+       * @fires commandUsage
+       */
       return Bastion.emit('commandUsage', message, this.help);
     }
 
@@ -27,23 +27,20 @@ exports.exec = async (Bastion, message, args) => {
       return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'roleNotFound'), message.channel);
     }
 
-    let shopModel = await Bastion.database.models.shop.findOne({
-      attributes: [ 'roles' ],
+    let roleModel = await Bastion.database.models.role.findOne({
+      attributes: [ 'price' ],
       where: {
-        guildID: message.guild.id
+        roleID: role.id,
+        guildID: message.guild.id,
+        price: {
+          [Bastion.database.Op.not]: null
+        }
       }
     });
 
-    let rolesInStore;
-    if (shopModel && shopModel.dataValues.roles) {
-      rolesInStore = shopModel.dataValues.roles;
-    }
-    else {
-      rolesInStore = {};
-    }
+    if (roleModel) {
+      let price = roleModel.dataValues.price;
 
-    let buyableRoles = Object.keys(rolesInStore).filter(role => message.guild.roles.has(role));
-    if (buyableRoles.includes(role.id)) {
       let guildMemberModel = await Bastion.database.models.guildMember.findOne({
         attributes: [ 'bastionCurrencies' ],
         where: {
@@ -53,21 +50,21 @@ exports.exec = async (Bastion, message, args) => {
       });
       guildMemberModel.dataValues.bastionCurrencies = parseInt(guildMemberModel.dataValues.bastionCurrencies);
 
-      if (rolesInStore[role.id] > guildMemberModel.dataValues.bastionCurrencies) {
+      if (price > guildMemberModel.dataValues.bastionCurrencies) {
         return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'insufficientBalance', guildMemberModel.dataValues.bastionCurrencies), message.channel);
       }
 
       message.member.addRole(role);
 
-      Bastion.emit('userCredit', message.member, rolesInStore[role.id]);
+      Bastion.emit('userCredit', message.member, price);
       if (message.author.id !== message.guild.owner.id) {
-        Bastion.emit('userDebit', message.guild.members.get(message.guild.owner.id), (0.9) * rolesInStore[role.id]);
+        Bastion.emit('userDebit', message.guild.members.get(message.guild.owner.id), (0.9) * price);
       }
 
       message.channel.send({
         embed: {
           color: Bastion.colors.BLUE,
-          description: `${message.author.tag} bought the **${role.name}** role for **${rolesInStore[role.id]}** Bastion Currencies.`
+          description: `${message.author.tag} bought the **${role.name}** role for **${price}** Bastion Currencies.`
         }
       }).catch(e => {
         Bastion.log.error(e);

--- a/commands/roleStore.js
+++ b/commands/roleStore.js
@@ -4,131 +4,53 @@
  * @license GPL-3.0
  */
 
-exports.exec = async (Bastion, message, args) => {
+exports.exec = async (Bastion, message) => {
   try {
-    let shopModel = await Bastion.database.models.shop.findOne({
-      attributes: [ 'roles' ],
+    let buyableRoleModels = await Bastion.database.models.role.findAll({
+      attributes: [ 'roleID', 'price' ],
       where: {
-        guildID: message.guild.id
+        guildID: message.guild.id,
+        price: {
+          [Bastion.database.Op.not]: null
+        }
       }
     });
 
-    let rolesInStore;
-    if (shopModel && shopModel.dataValues.roles) {
-      rolesInStore = shopModel.dataValues.roles;
-    }
-    else {
-      rolesInStore = {};
-    }
+    let rolesInStore = buyableRoleModels.
+      map(model => model.dataValues).
+      filter(role => message.guild.roles.has(role.roleID));
 
-    if (args.add) {
-      if (!message.member || !message.member.hasPermission('MANAGE_ROLES')) {
-        return message.client.emit('userMissingPermissions', 'MANAGE_ROLES');
+    if (rolesInStore.length) {
+      let fields = [];
+
+      for (let role of rolesInStore) {
+        fields.push({
+          name: `${message.guild.roles.get(role.roleID).name} (${role.roleID})`,
+          value: `${role.price} Bastion Currencies`
+        });
       }
-
-      if (Object.keys(rolesInStore).length >= 25) {
-        return Bastion.emit('error', '', 'You can\'t add more than 25 roles for sale.', message.channel);
-      }
-
-      args.add = Math.abs(args.add);
-
-      let role = message.guild.roles.get(args.role);
-
-      if (!role) {
-        return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'roleNotFound'), message.channel);
-      }
-
-      rolesInStore[role.id] = args.add;
-
-      await Bastion.database.models.shop.upsert({
-        guildID: message.guild.id,
-        roles: rolesInStore
-      },
-      {
-        where: {
-          guildID: message.guild.id
-        },
-        fields: [ 'guildID', 'roles' ]
-      });
 
       message.channel.send({
         embed: {
-          color: Bastion.colors.GREEN,
-          description: `Listed **${role.name}** role for sale in the Role Store for **${args.add}** Bastion Currencies.`
+          color: Bastion.colors.BLUE,
+          title: 'Role Store',
+          description: 'Buy a role using the `buyRole` command.\nUse `help buyRole` command for more info.',
+          fields: fields
         }
       }).catch(e => {
         Bastion.log.error(e);
       });
     }
-    else if (args.remove) {
-      if (!message.member || !message.member.hasPermission('MANAGE_ROLES')) {
-        return message.client.emit('userMissingPermissions', 'MANAGE_ROLES');
-      }
-
-      delete rolesInStore[args.role];
-
-      await Bastion.database.models.shop.upsert({
-        guildID: message.guild.id,
-        roles: rolesInStore
-      },
-      {
-        where: {
-          guildID: message.guild.id
-        },
-        fields: [ 'guildID', 'roles' ]
-      });
-
-      let role;
-      if (message.guild.roles.has(args.role)) {
-        role = message.guild.roles.get(args.role).name;
-      }
-      else {
-        role = args.role;
-      }
-
+    else {
       message.channel.send({
         embed: {
           color: Bastion.colors.RED,
-          description: `Unlisted **${role}** role from the Role Store.`
+          title: 'Role Store',
+          description: 'No role\'s for sale in this server at this time.'
         }
       }).catch(e => {
         Bastion.log.error(e);
       });
-    }
-    else {
-      let roles = Object.keys(rolesInStore).filter(role => message.guild.roles.has(role)).map(role => message.guild.roles.get(role));
-
-      if (roles.length) {
-        let fields = [];
-        for (let role of roles) {
-          fields.push({
-            name: `${role.name} (${role.id})`,
-            value: `${rolesInStore[role.id]} Bastion Currencies`
-          });
-        }
-
-        message.channel.send({
-          embed: {
-            color: Bastion.colors.BLUE,
-            title: 'Role Store',
-            description: 'Buy a role using the `buyRole` command.\nUse `help buyRole` command for more info.',
-            fields: fields
-          }
-        }).catch(e => {
-          Bastion.log.error(e);
-        });
-      }
-      else {
-        message.channel.send({
-          embed: {
-            color: Bastion.colors.RED,
-            title: 'Role Store',
-            description: 'No role\'s for sale in this server at this time.'
-          }
-        }).catch(e => {
-          Bastion.log.error(e);
-        });
-      }
     }
   }
   catch (e) {
@@ -138,12 +60,7 @@ exports.exec = async (Bastion, message, args) => {
 
 exports.config = {
   aliases: [ 'roleShop' ],
-  enabled: true,
-  argsDefinitions: [
-    { name: 'role', type: String, defaultOption: true },
-    { name: 'add', type: Number, alias: 'a' },
-    { name: 'remove', type: Boolean, alias: 'r' }
-  ]
+  enabled: true
 };
 
 exports.help = {
@@ -151,6 +68,6 @@ exports.help = {
   botPermission: '',
   userTextPermission: '',
   userVoicePermission: '',
-  usage: 'roleStore [ --add AMOUNT ROLE_ID | --remove ROLE_ID ]',
-  example: [ 'roleStore', 'roleStore --add 100 277132449585713251', 'roleStore --remove 277132449585713251' ]
+  usage: 'roleStore',
+  example: []
 };

--- a/commands/sellRole.js
+++ b/commands/sellRole.js
@@ -1,0 +1,97 @@
+/**
+ * @file sellRole command
+ * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
+ * @license GPL-3.0
+ */
+
+exports.exec = async (Bastion, message, args) => {
+  try {
+    if (!args.role || !(args.price || args.remove)) {
+      /**
+       * The command was ran with invalid parameters.
+       * @fires commandUsage
+       */
+      return Bastion.emit('commandUsage', message, this.help);
+    }
+
+    args.role = args.role.join(' ');
+
+    let role;
+    if (message.guild.roles.has(args.role)) {
+      role = message.guild.roles.get(args.role);
+    }
+    else {
+      role = message.guild.roles.find('name', args.role);
+    }
+    if (!role) {
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'roleNotFound'), message.channel);
+    }
+
+    if (args.remove) {
+      await Bastion.database.models.role.update({
+        price: null
+      },
+      {
+        where: {
+          roleID: role.id,
+          guildID: message.guild.id
+        },
+        fields: [ 'price' ]
+      });
+
+      message.channel.send({
+        embed: {
+          color: Bastion.colors.RED,
+          description: `Unlisted **${role}** role from the Role Store.`
+        }
+      }).catch(e => {
+        Bastion.log.error(e);
+      });
+    }
+    else {
+      await Bastion.database.models.role.upsert({
+        roleID: role.id,
+        guildID: message.guild.id,
+        price: Math.abs(args.price)
+      },
+      {
+        where: {
+          roleID: role.id,
+          guildID: message.guild.id
+        },
+        fields: [ 'roleID', 'guildID', 'price' ]
+      });
+
+      message.channel.send({
+        embed: {
+          color: Bastion.colors.GREEN,
+          description: `Listed **${role.name}** role for sale in the Role Store for **${args.price}** Bastion Currencies.`
+        }
+      }).catch(e => {
+        Bastion.log.error(e);
+      });
+    }
+  }
+  catch (e) {
+    Bastion.log.error(e);
+  }
+};
+
+exports.config = {
+  aliases: [],
+  enabled: true,
+  argsDefinitions: [
+    { name: 'role', type: String, multiple: true, defaultOption: true },
+    { name: 'price', type: Number, alias: 'p' },
+    { name: 'remove', type: Boolean, alias: 'r' }
+  ]
+};
+
+exports.help = {
+  name: 'sellRole',
+  botPermission: '',
+  userTextPermission: 'MANAGE_GUILD',
+  userVoicePermission: '',
+  usage: 'sellRole < ROLE_ID | ROLE NAME > < -p PRICE | --remove >',
+  example: [ 'sellRole 277132449585713251 -p 100', 'sellRole 277132449585713251 --remove' ]
+};

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -820,7 +820,7 @@
     "module": "info"
   },
   "roleStore": {
-    "description": "Lists/Adds/Removes roles from the Role Store of your server. Listed roles in the Role Store can be bought by anyone, with %currency.name_plural%, in your server using the `buyRole` command. When users buy roles, the server owner gets 90% of the profit.",
+    "description": "Lists the roles that are available for sale in the Role Store of the server. Listed roles in the Role Store can be bought by anyone, with %currency.name_plural%, in your server using the `buyRole` command. When users buy roles, the server owner gets 90% of the profit.",
     "module": "money"
   },
   "roles": {
@@ -850,6 +850,10 @@
   "selfDestruct": {
     "description": "Sends the same message that you had sent, but it will get auto deleted after a specific amount of time.",
     "module": "fun"
+  },
+  "sellRole": {
+    "description": "Sell roles in your server so that server members can buy them with %currency.name_plural%, using the `buyRole` command. When users buy roles, the server owner gets 90% of the profit.",
+    "module": "money"
   },
   "sendEmbed": {
     "description": "Sends an embed message from the specified embed (JavaScript) object. *To create an embed object, graphically, [click here](%website%/embedbuilder/).*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.11",
+  "version": "7.0.0-alpha.12",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",

--- a/utils/models.js
+++ b/utils/models.js
@@ -562,9 +562,6 @@ module.exports = (Sequelize, database) => {
       allowNull: false,
       primaryKey: true
     },
-    roles: {
-      type: Sequelize.JSON
-    },
     custom: {
       type: Sequelize.JSON
     }

--- a/utils/models.js
+++ b/utils/models.js
@@ -478,6 +478,9 @@ module.exports = (Sequelize, database) => {
     level: {
       type: Sequelize.STRING
     },
+    price: {
+      type: Sequelize.TEXT
+    },
     blacklisted: {
       type: Sequelize.BOOLEAN,
       allowNull: false,


### PR DESCRIPTION
This PR changes the how the role store works.
- Removed the `roles` field from the `Shop` DB model. So, apparently, the `roles` field isn't used anymore for storing buy-able roles.
- Added a `price` field to the `Role` DB model to store the price of buy-able roles.
- Rewrote the `roleStore` & `buyRole` command to implement new DB changes.
- `roleStore` command is now only used to show the buy-able roles in the guild's Role Store.
- Added `sellRole` command to sell roles in the guild's Role Store.

#### Possible drawbacks
None

#### Applicable Issues:
\-

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
