### PR TITLE
Music Rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ settings/credentials.json
 settings/config.json
 data/bastion.db
 data/Bastion.sqlite
-data/playlist.json
 data/backup*
 
 # Lock file

--- a/changes.json
+++ b/changes.json
@@ -4,30 +4,30 @@
   "THESE BUGS ARE DEAD": [],
   "THESE ABILITIES HAVE ENHANCED": [
     "Logs are now much prettier, than it was already!",
-    "Commands that work in direct messages can now be used without a prefix.",
-    "Multiple prefixes can be set from the config too",
-    "The `reason` command will now work with moderation case numbers, instead of moderation log message IDs.",
-    "Your daily reward claim cooldowns will be in effect even after Bastion restarts.",
-    "Set any number of channels as voting channels. No limitations!",
-    "Add any number of level up roles. No limitations here, too!",
-    "The `currencyGiveaway` command isn't bot owner only anymore! Now, you can use it, in your own servers, to do Bastion Currency giveaways.",
-    "Trigger response supports a whole bunch of variables now.",
+    "Commands that work in direct messages doesn't need any prefix",
+    "Multiple prefixes can be set from the config too!",
+    "`reason` command will now work with moderation case nos., instead of moderation log message IDs",
+    "daily claim reward cooldowns still be in effect even after Bastion restarts",
+    "Set any no. of channels as voting channels. No limitations!",
+    "Add any no. of level up roles. No limitations here, too!",
+    "`currencyGiveaway` command isn't bot owner only anymore! You can now use it in your own servers to do Bastion Currency giveaways",
+    "Trigger response supports a whole bunch of variables now",
     "`roleInfo` & `serverInfo` commands will now show the role & server description, if you've set it.",
     "Show if a server is a Bastion premium server in the `serverInfo` command. Premium servers & perks are coming soon™!",
     "Adding music from user playlist to the queue is now faster than ever.",
-    "Tons of under-the-hood improvements and changes."
+    "Tons of under-the-hood improvements & changes."
   ],
   "NEW FEATURES!": [
-    "Set the amount of data shown in the terminal logs by modifying the value of `logLevel` key in config.",
-    "Levels and currencies aren't global anymore. Members have separate currency & level in every server.",
-    "You can now `give` and `take` any amount of Bastion Currencies to/from any member of your server.",
-    "Give as much XP as you want to your server members, using the `giveXP` command.",
-    "Tired of looking through the moderation logs just to find a specific case? Don't worry, you can now use the `case` command to fetch any case from the moderation logs, using the case number.",
-    "Using the `claim` command daily will count towards your daily streak. If you get a consecutive streak of 7 days, you'll can get a bonus of upto 700 BC.",
-    "Triggers aren't global anymore. There are now different triggers & responses for different servers.",
-    "Triggers aren't owner only anymore! You can now set triggers & responses in the servers you manage.",
-    "Triggers can now respond with reactions & embeds along with plain text responses.",
-    "Users can now have different music playlists in different servers."
+    "Set the amount of data shown in the terminal logs by modifying the value of `logLevel` key in config",
+    "Levels & currencies aren't global anymore. Members have separate currency & level in every server",
+    "You can now `give` & `take` any amount of Bastion Currencies to/from any member of your server",
+    "Give as much XP as you want to your server members, using the `giveXP` command",
+    "Tired of looking through the moderation logs just to find a specific case? Use the `case` command to fetch any case from the moderation logs",
+    "Using the `claim` command daily will count towards your daily streak. If you get a streak of 7 days, you'll can get a bonus of upto 700 BC",
+    "Triggers aren't global anymore. There are now different triggers & responses for different servers",
+    "Triggers aren't owner only anymore! You can now set triggers & responses in the servers you manage",
+    "Triggers can now respond with reactions & embeds along with plain text responses",
+    "Users can now have different music playlists in different servers"
   ],
   "NEW COMMANDS!": [
     "Added `blacklist` command to blacklist users globally from using Bastion.",
@@ -42,19 +42,19 @@
     "Added `music` command to toggle music support for any specified server."
   ],
   "COMMANDS WITH NEW USAGE": [
-    "The `addTrigger` command's usage syntax has been changed. It won't work the way it used to before, please check the help message for it, using the `help addTrigger` command, to see the new usage details.",
-    "The `roleStore` command will only show the roles being sold in the server's Role Store. Use the new `sellRole` command to sell roles instead."
+    "`addTrigger` command's usage syntax has been changed. It won't work the way it used to before, please check the help message for it, using the `help addTrigger` command, to see the new usage details.",
+    "`roleStore` command will only show the roles being sold in the server's Role Store. Use the new `sellRole` command to sell roles instead."
   ],
   "RENAMED COMMANDS": [
-    "Renamed the `ignoreChannel` and `ignoreRole` commands to `ignoreChannels` and `ignoreRoles`, respectively.",
-    "Renamed the `votingChannel` command to `votingChannels`.",
-    "Renamed the `resetModLogs` command to `resetModerationLogs`."
+    "Renamed `ignoreChannel` & `ignoreRole` commands to `ignoreChannels` & `ignoreRoles`, respectively.",
+    "Renamed `votingChannel` command to `votingChannels`.",
+    "Renamed `resetModLogs` command to `resetModerationLogs`."
   ],
   "NOT AVAILABLE ANYMORE": [
-    "Removed `todo`, `listTodo` and `deleteTodo` commands.",
-    "Removed the `userBlacklist` command, because same thing can be done with the new `blacklist` command.",
-    "Removed the `buyGift`, `gift`, `giftShop` and `myGifts` commands. Why do you need a gift shop when you can have a custom shop!",
-    "Removed `whitelistChannel` and `whitelistRole` commands."
+    "Removed `todo`, `listTodo` & `deleteTodo` commands.",
+    "Removed `userBlacklist` command, because same thing can be done with the new `blacklist` command.",
+    "Removed `buyGift`, `gift`, `giftShop` & `myGifts` commands. Why do you need a gift shop when you can have a custom shop!",
+    "Removed `whitelistChannel` & `whitelistRole` commands."
   ],
   "BUGS HIDING IN THE CLOSET": []
 }

--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "May 16, 2018",
+  "date": "May 19, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [],
   "THESE ABILITIES HAVE ENHANCED": [
@@ -14,6 +14,7 @@
     "Trigger response supports a whole bunch of variables now.",
     "`roleInfo` & `serverInfo` commands will now show the role & server description, if you've set it.",
     "Show if a server is a Bastion premium server in the `serverInfo` command. Premium servers & perks are coming soon™!",
+    "Adding music from user playlist to the queue is now faster than ever.",
     "Tons of under-the-hood improvements and changes."
   ],
   "NEW FEATURES!": [
@@ -25,7 +26,8 @@
     "Using the `claim` command daily will count towards your daily streak. If you get a consecutive streak of 7 days, you'll can get a bonus of upto 700 BC.",
     "Triggers aren't global anymore. There are now different triggers & responses for different servers.",
     "Triggers aren't owner only anymore! You can now set triggers & responses in the servers you manage.",
-    "Triggers can now respond with reactions & embeds along with plain text responses."
+    "Triggers can now respond with reactions & embeds along with plain text responses.",
+    "Users can now have different music playlists in different servers."
   ],
   "NEW COMMANDS!": [
     "Added `blacklist` command to blacklist users globally from using Bastion.",

--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "May 14, 2018",
+  "date": "May 16, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [],
   "THESE ABILITIES HAVE ENHANCED": [
@@ -36,7 +36,8 @@
     "Added `ignoreSlowMode` command. You can now set channels and/or roles to be ignored by the slow mode.",
     "Added `ignoreStarboard` command. You can now set channels and/or roles to be ignored by the starboard.",
     "Added `sellRole` command to let server managers sell roles in their server's Role Store.",
-    "Added `roleDescription` & `serverDescription` commands to set a description for the server & any role in the server."
+    "Added `roleDescription` & `serverDescription` commands to set a description for the server & any role in the server.",
+    "Added `music` command to toggle music support for any specified server."
   ],
   "COMMANDS WITH NEW USAGE": [
     "The `addTrigger` command's usage syntax has been changed. It won't work the way it used to before, please check the help message for it, using the `help addTrigger` command, to see the new usage details.",

--- a/commands/airhorn.js
+++ b/commands/airhorn.js
@@ -59,6 +59,10 @@ exports.exec = async (Bastion, message) => {
       }
 
       let connection = await message.member.voiceChannel.join();
+
+      connection.on('error', Bastion.log.error);
+      connection.on('failed', Bastion.log.error);
+
       const dispatcher = connection.playFile('./assets/airhorn.wav', { passes: (Bastion.config.music && Bastion.config.music.passes) || 1, bitrate: 'auto' });
 
       dispatcher.on('error', error => {

--- a/commands/clean.js
+++ b/commands/clean.js
@@ -12,13 +12,11 @@ exports.exec = (Bastion, message) => {
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
   }
 
-  if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
+  if (message.guild.music.textChannelID && message.guild.music.textChannelID !== message.channel.id) {
+    return Bastion.log.info('Music channels have been set, so music commands will only work in the Music Text Channel.');
+  }
 
   if (!message.guild.music.songs || !message.guild.music.songs.length) {
-    /**
-     * Error condition is encountered.
-     * @fires error
-     */
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notPlaying'), message.channel);
   }
 

--- a/commands/clean.js
+++ b/commands/clean.js
@@ -5,6 +5,13 @@
  */
 
 exports.exec = (Bastion, message) => {
+  if (!message.guild.music.enabled) {
+    if (Bastion.user.id === '267035345537728512') {
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabledPublic'), message.channel);
+    }
+    return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
+  }
+
   if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
 
   if (!message.guild.music.songs || !message.guild.music.songs.length) {

--- a/commands/lyrics.js
+++ b/commands/lyrics.js
@@ -8,6 +8,13 @@ const request = require('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {
+    if (!message.guild.music.enabled) {
+      if (Bastion.user.id === '267035345537728512') {
+        return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabledPublic'), message.channel);
+      }
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
+    }
+
     if (!args.song) {
       /**
       * The command was ran with invalid parameters.

--- a/commands/music.js
+++ b/commands/music.js
@@ -1,0 +1,70 @@
+/**
+ * @file music command
+ * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
+ * @license GPL-3.0
+ */
+
+exports.exec = async (Bastion, message, args) => {
+  try {
+    if (!args.guildID) {
+      args.guildID = message.guild.id;
+    }
+
+    let guildModels = await message.client.database.models.guild.findAll({
+      attributes: [ 'guildID', 'music' ]
+    });
+    let guilds = guildModels.map(model => model.dataValues.guildID);
+
+    if (!guilds.includes(args.guildID)) {
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notFound', 'server'), message.channel);
+    }
+
+    let guild = guildModels.filter(model => model.dataValues.guildID === args.guildID);
+    guild = guild[0];
+
+    let musicStatus = !guild.dataValues.music;
+
+    await message.client.database.models.guild.update({
+      music: musicStatus
+    },
+    {
+      where: {
+        guildID: args.guildID
+      },
+      fields: [ 'music' ]
+    });
+
+    guild = Bastion.resolver.resolveGuild(guild.guildID);
+    let guildDetails = guild ? `**${guild.name}** / ${args.guildID}` : `**${args.guildID}**`;
+
+    message.channel.send({
+      embed: {
+        color: musicStatus ? Bastion.colors.GREEN : Bastion.colors.RED,
+        description: `Music support has been ${musicStatus ? 'enabled' : 'disabled'} in the server ${guildDetails}`
+      }
+    }).catch(e => {
+      Bastion.log.error(e);
+    });
+  }
+  catch (e) {
+    Bastion.log.error(e);
+  }
+};
+
+exports.config = {
+  aliases: [],
+  enabled: true,
+  argsDefinitions: [
+    { name: 'guildID', type: String, defaultOption: true }
+  ],
+  ownerOnly: true
+};
+
+exports.help = {
+  name: 'music',
+  botPermission: '',
+  userTextPermission: '',
+  userVoicePermission: '',
+  usage: 'music <GUILD_ID>',
+  example: [ 'music 441122339988775566' ]
+};

--- a/commands/musicChannel.js
+++ b/commands/musicChannel.js
@@ -6,6 +6,13 @@
 
 exports.exec = async (Bastion, message, args) => {
   try {
+    if (!message.guild.music.enabled) {
+      if (Bastion.user.id === '267035345537728512') {
+        return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabledPublic'), message.channel);
+      }
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
+    }
+
     let musicTextChannel, musicVoiceChannel, color, description;
 
     if (args.remove) {

--- a/commands/musicChannel.js
+++ b/commands/musicChannel.js
@@ -10,14 +10,14 @@ exports.exec = async (Bastion, message, args) => {
 
     if (args.remove) {
       await message.client.database.models.guild.update({
-        musicTextChannels: null,
+        musicTextChannel: null,
         musicVoiceChannel: null
       },
       {
         where: {
           guildID: message.guild.id
         },
-        fields: [ 'musicTextChannels', 'musicVoiceChannel' ]
+        fields: [ 'musicTextChannel', 'musicVoiceChannel' ]
       });
       color = Bastion.colors.RED;
       description = Bastion.i18n.info(message.guild.language, 'removeMusicChannels', message.author.tag);
@@ -27,14 +27,14 @@ exports.exec = async (Bastion, message, args) => {
       musicVoiceChannel = message.guild.channels.filter(c => c.type === 'voice').get(args.id);
       if (musicVoiceChannel) {
         await message.client.database.models.guild.update({
-          musicTextChannels: musicTextChannel.id,
+          musicTextChannel: musicTextChannel.id,
           musicVoiceChannel: musicVoiceChannel.id
         },
         {
           where: {
             guildID: message.guild.id
           },
-          fields: [ 'musicTextChannels', 'musicVoiceChannel' ]
+          fields: [ 'musicTextChannel', 'musicVoiceChannel' ]
         });
         color = Bastion.colors.GREEN;
         description = Bastion.i18n.info(message.guild.language, 'addMusicChannels', message.author.tag, musicTextChannel, musicVoiceChannel.name);

--- a/commands/musicMasterRole.js
+++ b/commands/musicMasterRole.js
@@ -6,6 +6,13 @@
 
 exports.exec = async (Bastion, message, args) => {
   try {
+    if (!message.guild.music.enabled) {
+      if (Bastion.user.id === '267035345537728512') {
+        return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabledPublic'), message.channel);
+      }
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
+    }
+
     if (!(parseInt(args[0]) < 9223372036854775807)) {
       await message.client.database.models.guild.update({
         musicMasterRole: null

--- a/commands/nowPlaying.js
+++ b/commands/nowPlaying.js
@@ -12,13 +12,11 @@ exports.exec = (Bastion, message) => {
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
   }
 
-  if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
+  if (message.guild.music.textChannelID && message.guild.music.textChannelID !== message.channel.id) {
+    return Bastion.log.info('Music channels have been set, so music commands will only work in the Music Text Channel.');
+  }
 
   if (!message.guild.music.songs || !message.guild.music.songs.length) {
-    /**
-     * Error condition is encountered.
-     * @fires error
-     */
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notPlaying'), message.channel);
   }
 

--- a/commands/nowPlaying.js
+++ b/commands/nowPlaying.js
@@ -5,6 +5,13 @@
  */
 
 exports.exec = (Bastion, message) => {
+  if (!message.guild.music.enabled) {
+    if (Bastion.user.id === '267035345537728512') {
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabledPublic'), message.channel);
+    }
+    return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
+  }
+
   if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
 
   if (!message.guild.music.songs || !message.guild.music.songs.length) {

--- a/commands/pause.js
+++ b/commands/pause.js
@@ -12,13 +12,11 @@ exports.exec = (Bastion, message) => {
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
   }
 
-  if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
+  if (message.guild.music.textChannelID && message.guild.music.textChannelID !== message.channel.id) {
+    return Bastion.log.info('Music channels have been set, so music commands will only work in the Music Text Channel.');
+  }
 
   if (!message.guild.music.songs || !message.guild.music.songs.length) {
-    /**
-     * Error condition is encountered.
-     * @fires error
-     */
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notPlaying'), message.channel);
   }
 

--- a/commands/pause.js
+++ b/commands/pause.js
@@ -5,6 +5,13 @@
  */
 
 exports.exec = (Bastion, message) => {
+  if (!message.guild.music.enabled) {
+    if (Bastion.user.id === '267035345537728512') {
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabledPublic'), message.channel);
+    }
+    return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
+  }
+
   if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
 
   if (!message.guild.music.songs || !message.guild.music.songs.length) {

--- a/commands/play.js
+++ b/commands/play.js
@@ -97,7 +97,7 @@ exports.exec = async (Bastion, message, args) => {
     message.guild.music.skipVotes = [];
   }
 
-
+  args.song = args.song.join(' ');
   let songURL = /^http[s]?:[/]{2}(?:[a-z0-9](?:[a-zA-Z0-9-]{0,249}(?:[a-zA-Z0-9]))?\.?){1,127}[-a-z0-9@:%_+.~#?&/=]{0,2045}$/i.test(args.song) ? args.song : `ytsearch:${args.song}`;
 
   let youtubeDLOptions = [
@@ -118,7 +118,7 @@ exports.exec = async (Bastion, message, args) => {
 
 
     message.guild.music.songs.push({
-      url: info.formats[info.formats.length - 1].url,
+      url: info.url,
       id: info.id,
       title: info.title,
       thumbnail: info.thumbnail,

--- a/commands/play.js
+++ b/commands/play.js
@@ -217,6 +217,9 @@ exports.exec = async (Bastion, message, args) => {
     if (!message.guild.music.playing) {
       startStreamDispatcher(message.guild, voiceConnection);
     }
+
+    voiceConnection.on('error', Bastion.log.error);
+    voiceConnection.on('failed', Bastion.log.error);
   }
   catch (e) {
     Bastion.log.error(e);

--- a/commands/play.js
+++ b/commands/play.js
@@ -9,6 +9,13 @@ const jsonDB = require('node-json-db');
 const db = new jsonDB('./data/playlist', true, true);
 
 exports.exec = (Bastion, message, args) => {
+  if (!message.guild.music.enabled) {
+    if (Bastion.user.id === '267035345537728512') {
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabledPublic'), message.channel);
+    }
+    return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
+  }
+
   if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
 
   if (!args.song && !args.ytpl && !args.playlist) {

--- a/commands/play.js
+++ b/commands/play.js
@@ -4,11 +4,9 @@
  * @license GPL-3.0
  */
 
-const yt = require('youtube-dl');
-const jsonDB = require('node-json-db');
-const db = new jsonDB('./data/playlist', true, true);
+const youtubeDL = require('youtube-dl');
 
-exports.exec = (Bastion, message, args) => {
+exports.exec = async (Bastion, message, args) => {
   if (!message.guild.music.enabled) {
     if (Bastion.user.id === '267035345537728512') {
       return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabledPublic'), message.channel);
@@ -16,9 +14,12 @@ exports.exec = (Bastion, message, args) => {
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
   }
 
-  if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
+  if (message.guild.music.textChannelID && message.guild.music.textChannelID !== message.channel.id) {
+    return Bastion.log.info('Music channels have been set, so music commands will only work in the Music Text Channel.');
+  }
 
-  if (!args.song && !args.ytpl && !args.playlist) {
+
+  if (!args.song) {
     /**
      * The command was ran with invalid parameters.
      * @fires commandUsage
@@ -26,55 +27,62 @@ exports.exec = (Bastion, message, args) => {
     return Bastion.emit('commandUsage', message, this.help);
   }
 
-  let voiceChannel, textChannel, vcStats;
-  if (message.guild.voiceConnection) {
-    voiceChannel = message.guild.voiceConnection.channel;
-    textChannel = message.channel;
+
+  let voiceConnection = message.guild.voiceConnection, voiceChannel, textChannel, vcStats;
+
+  if (voiceConnection) {
+    voiceChannel = voiceConnection.channel;
+    textChannel = message.guild.music.textChannel || message.channel;
+
     vcStats = Bastion.i18n.error(message.guild.language, 'userNoSameVC', message.author.tag);
   }
-  else if (message.guild.music.textChannelID && message.guild.music.voiceChannelID) {
-    if (!(voiceChannel = message.guild.channels.filter(c => c.type === 'voice').get(message.guild.music.voiceChannelID)) || !(textChannel = message.guild.channels.filter(c => c.type === 'text').get(message.guild.music.textChannelID))) {
-      /**
-      * Error condition is encountered.
-      * @fires error
-      */
-      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'invalidMusicChannel'), message.channel);
+  else {
+    if (message.guild.music.textChannelID && message.guild.music.voiceChannelID) {
+      voiceChannel = message.guild.channels.filter(c => c.type === 'voice').get(message.guild.music.voiceChannelID);
+      textChannel = message.guild.channels.filter(c => c.type === 'text').get(message.guild.music.textChannelID);
+
+      if (!voiceChannel || !textChannel) {
+        return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'invalidMusicChannel'), message.channel);
+      }
+
+      vcStats = Bastion.i18n.error(message.guild.language, 'userNoMusicChannel', message.author.tag, voiceChannel.name);
+    }
+    else if (Bastion.credentials.ownerId.includes(message.author.id) || message.member.roles.has(message.guild.music.masterRoleID)) {
+      voiceChannel = message.member.voiceChannel;
+      textChannel = message.channel;
+
+      if (!voiceChannel) {
+        return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'userNoVC', message.author.tag), message.channel);
+      }
+    }
+    else {
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicChannelNotFound'), message.channel);
     }
     if (!voiceChannel.joinable) {
-      /**
-      * Error condition is encountered.
-      * @fires error
-      */
       return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'noPermission', 'join', voiceChannel.name), message.channel);
     }
-    if (!voiceChannel.speakable) {
-      /**
-      * Error condition is encountered.
-      * @fires error
-      */
-      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'noPermission', 'speak', `in ${voiceChannel.name}`), message.channel);
-    }
-    vcStats = Bastion.i18n.error(message.guild.language, 'userNoMusicChannel', message.author.tag, voiceChannel.name);
-  }
-  else {
-    /**
-    * Error condition is encountered.
-    * @fires error
-    */
-    return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicChannelNotFound'), message.channel);
+
+    voiceConnection = await voiceChannel.join();
   }
 
-  if (textChannel.id !== message.channel.id) return Bastion.log.info(`Music commands will only work in ${textChannel.name} for this session.`);
-  if (voiceChannel.members.get(message.author.id) === undefined) {
-    /**
-    * Error condition is encountered.
-    * @fires error
-    */
+
+  if (!voiceChannel.speakable) {
+    return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'noPermission', 'speak', `in ${voiceChannel.name}`), message.channel);
+  }
+  if (textChannel.id !== message.channel.id) {
+    return Bastion.log.info(`Music commands will only work in the ${textChannel.name} text channel for this session.`);
+  }
+  if (!voiceChannel.members.get(message.author.id)) {
     return Bastion.emit('error', '', vcStats, message.channel);
   }
 
+  message.guild.me.setMute(false).catch(() => {});
+  message.guild.me.setDeaf(true).catch(() => {});
+
+
   message.guild.music.voiceChannel = voiceChannel;
   message.guild.music.textChannel = textChannel;
+
 
   if (!message.guild.music.hasOwnProperty('songs')) {
     message.guild.music.songs = [];
@@ -89,175 +97,65 @@ exports.exec = (Bastion, message, args) => {
     message.guild.music.skipVotes = [];
   }
 
-  let song = '';
-  try {
-    if (args.song) {
-      song = args.song.join(' ');
+
+  let songURL = /^http[s]?:[/]{2}(?:[a-z0-9](?:[a-zA-Z0-9-]{0,249}(?:[a-zA-Z0-9]))?\.?){1,127}[-a-z0-9@:%_+.~#?&/=]{0,2045}$/i.test(args.song) ? args.song : `ytsearch:${args.song}`;
+
+  let youtubeDLOptions = [
+    '--quiet',
+    '--ignore-errors',
+    '--simulate',
+    '--no-warnings',
+    '--format=bestaudio[protocol^=http]',
+    `--user-agent=BastionDiscordBot/v${Bastion.package.version} (https://bastionbot.org)`,
+    '--referer=https://bastionbot.org',
+    '--youtube-skip-dash-manifest'
+  ];
+  youtubeDL.getInfo(songURL, youtubeDLOptions, (error, info) => {
+    if (error || !info.format_id || info.format_id.startsWith('0')) {
+      Bastion.log.error(error || info);
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notFound', 'result'), message.channel);
     }
-    else if (args.ytpl) {
-      if (!/^(http[s]?:\/\/)?(www\.)?youtube\.com\/playlist\?list=([-a-zA-Z0-9@:%_+.~#?&/=]*)$/i.test(args.ytpl)) {
-        /**
-        * Error condition is encountered.
-        * @fires error
-        */
-        return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'invalidInput', 'YouTube Playlist URL'), textChannel);
-      }
-      message.channel.send({
-        embed: {
-          description: 'Processing playlist...'
-        }
-      }).catch(e => {
-        Bastion.log.error(e);
-      });
 
-      yt.getInfo(args.ytpl, [ '-q', '-i', '--skip-download', '--no-warnings', '--flat-playlist', '--format=bestaudio[protocol^=http]' ], (err, info) => {
-        if (err) {
-          Bastion.log.error(err);
-          /**
-          * Error condition is encountered.
-          * @fires error
-          */
-          return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'connection'), textChannel);
-        }
-        if (info) {
-          if (info.length === 0) {
-            /**
-            * Error condition is encountered.
-            * @fires error
-            */
-            return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'playlistNotFound'), textChannel);
-          }
-          song = info.shift().title;
-          message.channel.send({
-            embed: {
-              description: `Adding ${info.length} songs to the queue...`
-            }
-          }).catch(e => {
-            Bastion.log.error(e);
-          });
-          // TODO: This executes before `args` is added to the queue, so the first song (`args`) is added later in the queue. Using setTimeout or flags is inefficient, find an efficient way to fix this!
-          info.forEach(e => {
-            message.guild.music.songs.push({
-              url: `https://www.youtube.com/watch?v=${e.url}`,
-              id: e.url,
-              title: e.title,
-              thumbnail: '',
-              duration: e.duration,
-              requester: message.author.tag
-            });
-          });
-        }
-      });
-    }
-    else if (args.playlist) {
-      let playlist;
 
-      db.reload();
-      playlist = db.getData('/');
-      playlist = playlist[args.playlist.join(' ')];
-
-      if (!playlist || playlist.length === 0) {
-        /**
-        * Error condition is encountered.
-        * @fires error
-        */
-        return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notFound', 'song/playlist'), textChannel);
-      }
-
-      song = playlist.shift();
-
-      message.channel.send({
-        embed: {
-          description: `Adding ${playlist.length + 1} favourite songs to the queue...`
-        }
-      }).catch(e => {
-        Bastion.log.error(e);
-      });
-
-      // TODO: This executes before `args` is added to the queue, so the first song (`args`) is added later in the queue. Using setTimeout or flags is inefficient, find an efficient way to fix this!
-      playlist.forEach(e => {
-        e = /^(http[s]?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&/=]*)$/i.test(e) ? e : `ytsearch:${e}`;
-        yt.getInfo(e, [ '-q', '-i', '--skip-download', '--no-warnings', '--format=bestaudio[protocol^=http]' ], (err, info) => {
-          if (err || info.format_id === undefined || info.format_id.startsWith('0')) return;
-          message.guild.music.songs.push({
-            url: info.formats[info.formats.length - 1].url,
-            id: info.id,
-            title: info.title,
-            thumbnail: info.thumbnail,
-            duration: info.duration,
-            requester: message.author.tag
-          });
-        });
-      });
-    }
-    else return;
-
-    song = /^(http[s]?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&/=]*)$/i.test(song) ? song : `ytsearch:${song}`;
-
-    yt.getInfo(song, [ '-q', '-i', '--skip-download', '--no-warnings', '--format=bestaudio[protocol^=http]' ], (err, info) => {
-      if (err || info.format_id === undefined || info.format_id.startsWith('0')) {
-        return message.channel.send({
-          embed: {
-            color: Bastion.colors.RED,
-            description: Bastion.i18n.error(message.guild.language, 'notFound', 'result')
-          }
-        }).catch(e => {
-          Bastion.log.error(e);
-        });
-      }
-
-      message.guild.music.songs.push({
-        url: info.formats[info.formats.length - 1].url,
-        id: info.id,
-        title: info.title,
-        thumbnail: info.thumbnail,
-        duration: info.duration,
-        requester: message.author.tag
-      });
-      textChannel.send({
-        embed: {
-          color: Bastion.colors.GREEN,
-          title: 'Added to the queue',
-          url: info.id ? `https://youtu.be/${info.id}` : '',
-          description: info.title,
-          thumbnail: {
-            url: info.thumbnail
-          },
-          footer: {
-            text: `Position: ${message.guild.music.songs.length} • Duration: ${info.duration || 'N/A'} • Requester: ${message.author.tag}`
-          }
-        }
-      }).catch(e => {
-        Bastion.log.error(e);
-      });
-      if (message.guild.music && message.guild.music.playing) return;
-
-      voiceChannel.join().then(connection => {
-        message.guild.me.setDeaf(true).catch(() => {});
-
-        startStreamDispatcher(message.guild, connection);
-      }).catch(e => {
-        Bastion.log.error(e);
-      });
+    message.guild.music.songs.push({
+      url: info.formats[info.formats.length - 1].url,
+      id: info.id,
+      title: info.title,
+      thumbnail: info.thumbnail,
+      duration: info.duration,
+      requester: message.author.tag
     });
-  }
-  catch (e) {
-    Bastion.log.error(e);
-    /**
-    * Error condition is encountered.
-    * @fires error
-    */
-    return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'unknown'), textChannel);
-  }
+
+    textChannel.send({
+      embed: {
+        color: Bastion.colors.GREEN,
+        title: 'Added to the queue',
+        url: info.id ? `https://youtu.be/${info.id}` : '',
+        description: info.title,
+        thumbnail: {
+          url: info.thumbnail
+        },
+        footer: {
+          text: `Position: ${message.guild.music.songs.length} • Duration: ${info.duration || 'N/A'} • Requester: ${message.author.tag}`
+        }
+      }
+    }).catch(e => {
+      Bastion.log.error(e);
+    });
+
+
+    if (message.guild.music.playing) return;
+
+
+    startStreamDispatcher(message.guild, voiceConnection);
+  });
 };
 
 exports.config = {
   aliases: [],
   enabled: true,
   argsDefinitions: [
-    { name: 'song', type: String, multiple: true, defaultOption: true },
-    { name: 'ytpl', type: String, alias: 'l' },
-    { name: 'playlist', type: String, multiple: true, alias: 'p', defaultValue: [ 'default' ] }
+    { name: 'song', type: String, multiple: true, defaultOption: true }
   ]
 };
 
@@ -266,8 +164,8 @@ exports.help = {
   botPermission: '',
   userTextPermission: '',
   userVoicePermission: '',
-  usage: 'play < name | song_link | -l <playlist_link> | -p [Playlist Name] >',
-  example: [ 'play Shape of you', 'play -l https://www.youtube.com/playlist?list=PL4zQ6RXLMCJx4RD3pyzRX4QYFubtCdn_k', 'play -p My Favs', 'play -p' ]
+  usage: 'play < SONG NAME | SONG_LINK >',
+  example: [ 'play Shape of you', 'play https://www.youtube.com/watch?v=fNVUTgd4pio' ]
 };
 
 /**
@@ -278,7 +176,7 @@ exports.help = {
  * @returns {void}
  */
 function startStreamDispatcher(guild, connection) {
-  if ((connection.channel && connection.channel.members.size < 2) || guild.music.songs[0] === undefined) {
+  if (!guild.music.songs[0] || connection.channel.members.size <= 1) {
     if (guild.client.config.music && guild.client.config.music.status) {
       guild.client.user.setActivity(typeof guild.client.config.game.name === 'string' ? guild.client.config.game.name : guild.client.config.game.name.length ? guild.client.config.game.name[0] : null,
         {
@@ -289,7 +187,7 @@ function startStreamDispatcher(guild, connection) {
     }
 
     let description;
-    if (guild.music.songs[0] === undefined) {
+    if (!guild.music.songs[0]) {
       description = 'Exiting voice channel.';
     }
     else {
@@ -310,7 +208,12 @@ function startStreamDispatcher(guild, connection) {
     });
   }
 
-  guild.music.dispatcher = connection.playStream(yt(guild.music.songs[0].url), { passes: (guild.client.config.music && guild.client.config.music.passes) || 1, bitrate: 'auto' });
+  let stream = youtubeDL(guild.music.songs[0].url);
+  let streamOptions = {
+    passes: (guild.client.config.music && guild.client.config.music.passes) || 1,
+    bitrate: 'auto'
+  };
+  guild.music.dispatcher = connection.playStream(stream, streamOptions);
   guild.music.playing = true;
 
   guild.music.textChannel.send({
@@ -351,7 +254,7 @@ function startStreamDispatcher(guild, connection) {
   guild.music.dispatcher.on('error', (err) => {
     guild.music.playing = false;
     guild.music.songs.shift();
-    startStreamDispatcher(guild, connection);
-    return guild.client.log.error(err);
+    guild.client.log.error(err);
+    return startStreamDispatcher(guild, connection);
   });
 }

--- a/commands/playlist.js
+++ b/commands/playlist.js
@@ -32,34 +32,32 @@ exports.exec = async (Bastion, message, args) => {
         creator: message.author.id
       },
       defaults: {
-        songs: [ args.song ]
+        songs: []
       }
     });
     if (initialized) {
-      if (!args.remove) {
-        await playlistModel.save();
-      }
+      await playlistModel.save();
+    }
+
+
+    if (args.remove) {
+      playlistModel.dataValues.songs = playlistModel.dataValues.songs.filter(song => !song.toLowerCase().includes(args.song.toLowerCase()));
     }
     else {
-      if (args.remove) {
-        playlistModel.dataValues.songs = playlistModel.dataValues.songs.filter(song => !song.toLowerCase().includes(args.song.toLowerCase()));
-      }
-      else {
-        playlistModel.dataValues.songs = playlistModel.dataValues.songs.concat(args.song);
-      }
-
-      await message.client.database.models.playlist.update({
-        songs: playlistModel.dataValues.songs
-      },
-      {
-        where: {
-          guildID: message.guild.id,
-          name: message.author.id,
-          creator: message.author.id
-        },
-        fields: [ 'songs' ]
-      });
+      playlistModel.dataValues.songs = playlistModel.dataValues.songs.concat(args.song);
     }
+
+    await message.client.database.models.playlist.update({
+      songs: playlistModel.dataValues.songs
+    },
+    {
+      where: {
+        guildID: message.guild.id,
+        name: message.author.id,
+        creator: message.author.id
+      },
+      fields: [ 'songs' ]
+    });
 
 
     message.channel.send({

--- a/commands/playlist.js
+++ b/commands/playlist.js
@@ -8,6 +8,13 @@ const jsonDB = require('node-json-db');
 const db = new jsonDB('./data/playlist', true, true);
 
 exports.exec = (Bastion, message, args) => {
+  if (!message.guild.music.enabled) {
+    if (Bastion.user.id === '267035345537728512') {
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabledPublic'), message.channel);
+    }
+    return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
+  }
+
   if (!args.song) {
     db.reload();
     let title = 'Saved Playlists', color = Bastion.colors.BLUE, playlist = db.getData('/');

--- a/commands/playlist.js
+++ b/commands/playlist.js
@@ -4,10 +4,7 @@
  * @license GPL-3.0
  */
 
-const jsonDB = require('node-json-db');
-const db = new jsonDB('./data/playlist', true, true);
-
-exports.exec = (Bastion, message, args) => {
+exports.exec = async (Bastion, message, args) => {
   if (!message.guild.music.enabled) {
     if (Bastion.user.id === '267035345537728512') {
       return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabledPublic'), message.channel);
@@ -15,72 +12,94 @@ exports.exec = (Bastion, message, args) => {
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
   }
 
-  if (!args.song) {
-    db.reload();
-    let title = 'Saved Playlists', color = Bastion.colors.BLUE, playlist = db.getData('/');
 
-    if (!args.playlist) {
-      playlist = Object.keys(playlist);
+  if (args.song) {
+    args.song = args.song.join(' ');
+
+    /**
+     * Using <Model>.findOrCreate() won't require the use of
+     * <ModelInstance>.save() but <Model>.findOrBuild() is used instead because
+     * <Model>.findOrCreate() creates a race condition where a matching row is
+     * created by another connection after the `find` but before the `insert`
+     * call. However, it is not always possible to handle this case in SQLite,
+     * specifically if one transaction inserts and another tries to select
+     * before the first one has committed. TimeoutError is thrown instead.
+     */
+    let [ playlistModel, initialized ] = await Bastion.database.models.playlist.findOrBuild({
+      where: {
+        guildID: message.guild.id,
+        name: message.author.id,
+        creator: message.author.id
+      },
+      defaults: {
+        songs: [ args.song ]
+      }
+    });
+    if (initialized) {
+      if (!args.remove) {
+        await playlistModel.save();
+      }
     }
     else {
       if (args.remove) {
-        db.delete(`/${args.playlist.join(' ')}`);
-        title = 'Deleted Playlist';
-        color = Bastion.colors.RED;
-        playlist = [ args.playlist.join(' ') ];
+        playlistModel.dataValues.songs = playlistModel.dataValues.songs.filter(song => !song.toLowerCase().includes(args.song.toLowerCase()));
       }
       else {
-        title = 'Saved Songs';
-        playlist = playlist[args.playlist.join(' ')];
+        playlistModel.dataValues.songs = playlistModel.dataValues.songs.concat(args.song);
       }
-    }
 
-    if (playlist && playlist.length !== 0) {
-      message.channel.send({
-        embed: {
-          color: color,
-          title: title,
-          description: playlist.join('\n')
-        }
-      }).catch(e => {
-        Bastion.log.error(e);
+      await message.client.database.models.playlist.update({
+        songs: playlistModel.dataValues.songs
+      },
+      {
+        where: {
+          guildID: message.guild.id,
+          name: message.author.id,
+          creator: message.author.id
+        },
+        fields: [ 'songs' ]
       });
     }
-    else {
-      /**
-       * Error condition is encountered.
-       * @fires error
-       */
-      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notFound', 'song/playlist'), message.channel);
-    }
-  }
-  else {
-    args.song = args.song.join(' ');
-    args.playlist = args.playlist ? args.playlist.join(' ') : 'default';
 
-    db.reload();
-    db.push(`/${args.playlist}`, [ args.song ], false);
 
     message.channel.send({
       embed: {
-        color: Bastion.colors.GREEN,
-        title: 'Added to playlist',
-        fields: [
-          {
-            name: 'Song',
-            value: args.song
-          },
-          {
-            name: 'Playlist',
-            value: args.playlist
-          }
-        ]
+        color: Bastion.colors[args.remove ? 'RED' : 'GREEN'],
+        description: args.remove ? `Removed all songs, matching **${args.song}**, from your playlist.` : `Added **${args.song}** to your playlist.`
       }
     }).catch(e => {
       Bastion.log.error(e);
     });
   }
+  else {
+    let playlistModel = await Bastion.database.models.playlist.findOne({
+      attributes: [ 'songs' ],
+      where: {
+        guildID: message.guild.id,
+        name: message.author.id,
+        creator: message.author.id
+      }
+    });
 
+    if (!playlistModel) {
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'playlistNotFound'), message.channel);
+    }
+
+    let songs = playlistModel.dataValues.songs;
+
+    message.channel.send({
+      embed: {
+        color: Bastion.colors.BLUE,
+        title: 'Bastion Music Playlist',
+        description: songs.join(', '),
+        footer: {
+          text: `Created by ${message.author.tag}`
+        }
+      }
+    }).catch(e => {
+      Bastion.log.error(e);
+    });
+  }
 };
 
 exports.config = {
@@ -88,7 +107,6 @@ exports.config = {
   enabled: true,
   argsDefinitions: [
     { name: 'song', type: String, multiple: true, defaultOption: true },
-    { name: 'playlist', type: String, multiple: true, alias: 'p' },
     { name: 'remove', type: Boolean, alias: 'r' }
   ],
   musicMasterOnly: true
@@ -99,6 +117,6 @@ exports.help = {
   botPermission: '',
   userTextPermission: '',
   userVoicePermission: '',
-  usage: 'playlist [Song Name] [ -p Playlist Name [ --remove ] ]',
-  example: [ 'playlist', 'playlist -p Jazz Collection', 'playlist -p Jazz Collection --remove', 'playlist Shape of You -p My Favs', 'playlist https://www.youtube.com/watch?v=JGwWNGJdvx8' ]
+  usage: 'playlist [ SONG NAME | SONG_LINK ] [--remove]',
+  example: [ 'playlist', 'playlist Rather Be', 'playlist https://www.youtube.com/watch?v=JGwWNGJdvx8', 'playlist Symphony --remove' ]
 };

--- a/commands/queue.js
+++ b/commands/queue.js
@@ -12,13 +12,11 @@ exports.exec = (Bastion, message, args) => {
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
   }
 
-  if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
+  if (message.guild.music.textChannelID && message.guild.music.textChannelID !== message.channel.id) {
+    return Bastion.log.info('Music channels have been set, so music commands will only work in the Music Text Channel.');
+  }
 
   if (!message.guild.music.songs || !message.guild.music.songs.length) {
-    /**
-     * Error condition is encountered.
-     * @fires error
-     */
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notPlaying'), message.channel);
   }
 

--- a/commands/queue.js
+++ b/commands/queue.js
@@ -5,6 +5,13 @@
  */
 
 exports.exec = (Bastion, message, args) => {
+  if (!message.guild.music.enabled) {
+    if (Bastion.user.id === '267035345537728512') {
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabledPublic'), message.channel);
+    }
+    return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
+  }
+
   if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
 
   if (!message.guild.music.songs || !message.guild.music.songs.length) {

--- a/commands/removeSong.js
+++ b/commands/removeSong.js
@@ -12,13 +12,11 @@ exports.exec = (Bastion, message, args) => {
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
   }
 
-  if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
+  if (message.guild.music.textChannelID && message.guild.music.textChannelID !== message.channel.id) {
+    return Bastion.log.info('Music channels have been set, so music commands will only work in the Music Text Channel.');
+  }
 
   if (!message.guild.music.songs || !message.guild.music.songs.length) {
-    /**
-    * Error condition is encountered.
-    * @fires error
-    */
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notPlaying'), message.channel);
   }
 
@@ -31,10 +29,6 @@ exports.exec = (Bastion, message, args) => {
   }
 
   if (args.index >= message.guild.music.songs.length || args.index < 1) {
-    /**
-     * Error condition is encountered.
-     * @fires error
-     */
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'indexRange'), message.channel);
   }
 

--- a/commands/removeSong.js
+++ b/commands/removeSong.js
@@ -5,6 +5,13 @@
  */
 
 exports.exec = (Bastion, message, args) => {
+  if (!message.guild.music.enabled) {
+    if (Bastion.user.id === '267035345537728512') {
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabledPublic'), message.channel);
+    }
+    return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
+  }
+
   if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
 
   if (!message.guild.music.songs || !message.guild.music.songs.length) {

--- a/commands/repeat.js
+++ b/commands/repeat.js
@@ -12,13 +12,11 @@ exports.exec = (Bastion, message) => {
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
   }
 
-  if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
+  if (message.guild.music.textChannelID && message.guild.music.textChannelID !== message.channel.id) {
+    return Bastion.log.info('Music channels have been set, so music commands will only work in the Music Text Channel.');
+  }
 
   if (!message.guild.music.songs || !message.guild.music.songs.length) {
-    /**
-     * Error condition is encountered.
-     * @fires error
-     */
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notPlaying'), message.channel);
   }
 

--- a/commands/repeat.js
+++ b/commands/repeat.js
@@ -5,6 +5,13 @@
  */
 
 exports.exec = (Bastion, message) => {
+  if (!message.guild.music.enabled) {
+    if (Bastion.user.id === '267035345537728512') {
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabledPublic'), message.channel);
+    }
+    return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
+  }
+
   if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
 
   if (!message.guild.music.songs || !message.guild.music.songs.length) {

--- a/commands/resume.js
+++ b/commands/resume.js
@@ -12,13 +12,11 @@ exports.exec = (Bastion, message) => {
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
   }
 
-  if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
+  if (message.guild.music.textChannelID && message.guild.music.textChannelID !== message.channel.id) {
+    return Bastion.log.info('Music channels have been set, so music commands will only work in the Music Text Channel.');
+  }
 
   if (!message.guild.music.songs || !message.guild.music.songs.length) {
-    /**
-     * Error condition is encountered.
-     * @fires error
-     */
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notPlaying'), message.channel);
   }
 

--- a/commands/resume.js
+++ b/commands/resume.js
@@ -5,6 +5,13 @@
  */
 
 exports.exec = (Bastion, message) => {
+  if (!message.guild.music.enabled) {
+    if (Bastion.user.id === '267035345537728512') {
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabledPublic'), message.channel);
+    }
+    return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
+  }
+
   if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
 
   if (!message.guild.music.songs || !message.guild.music.songs.length) {

--- a/commands/shuffle.js
+++ b/commands/shuffle.js
@@ -12,20 +12,17 @@ exports.exec = (Bastion, message) => {
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
   }
 
-  if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
+  if (message.guild.music.textChannelID && message.guild.music.textChannelID !== message.channel.id) {
+    return Bastion.log.info('Music channels have been set, so music commands will only work in the Music Text Channel.');
+  }
 
   if (!message.guild.music.songs || !message.guild.music.songs.length) {
-    /**
-     * Error condition is encountered.
-     * @fires error
-     */
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notPlaying'), message.channel);
   }
 
   let nowPlaying = message.guild.music.songs.shift();
   message.guild.music.songs = shuffle(message.guild.music.songs);
   message.guild.music.songs.unshift(nowPlaying);
-  // message.guild.music.songs.shuffle();
 
   message.guild.music.textChannel.send({
     embed: {

--- a/commands/shuffle.js
+++ b/commands/shuffle.js
@@ -5,6 +5,13 @@
  */
 
 exports.exec = (Bastion, message) => {
+  if (!message.guild.music.enabled) {
+    if (Bastion.user.id === '267035345537728512') {
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabledPublic'), message.channel);
+    }
+    return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
+  }
+
   if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
 
   if (!message.guild.music.songs || !message.guild.music.songs.length) {

--- a/commands/skip.js
+++ b/commands/skip.js
@@ -12,13 +12,11 @@ exports.exec = (Bastion, message) => {
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
   }
 
-  if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
+  if (message.guild.music.textChannelID && message.guild.music.textChannelID !== message.channel.id) {
+    return Bastion.log.info('Music channels have been set, so music commands will only work in the Music Text Channel.');
+  }
 
   if (!message.guild.music.songs || !message.guild.music.songs.length) {
-    /**
-     * Error condition is encountered.
-     * @fires error
-     */
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notPlaying'), message.channel);
   }
 
@@ -26,7 +24,7 @@ exports.exec = (Bastion, message) => {
     if (!message.guild.music.skipVotes.includes(message.author.id)) {
       message.guild.music.skipVotes.push(message.author.id);
     }
-    if (message.guild.music.skipVotes.length >= parseInt((message.guild.voiceConnection.channel/* voiceChannel */.members.size - 1) / 2)) {
+    if (message.guild.music.skipVotes.length >= parseInt((message.guild.voiceConnection.channel.members.size - 1) / 2)) {
       message.guild.music.textChannel.send({
         embed: {
           color: Bastion.colors.GREEN,
@@ -41,7 +39,7 @@ exports.exec = (Bastion, message) => {
     else {
       message.guild.music.textChannel.send({
         embed: {
-          description: `${parseInt((message.guild.voiceConnection.channel/* voiceChannel */.members.size - 1) / 2) - message.guild.music.skipVotes.length} votes required to skip the current song.`
+          description: `${parseInt((message.guild.voiceConnection.channel.members.size - 1) / 2) - message.guild.music.skipVotes.length} votes required to skip the current song.`
         }
       }).catch(e => {
         Bastion.log.error(e);

--- a/commands/skip.js
+++ b/commands/skip.js
@@ -5,6 +5,13 @@
  */
 
 exports.exec = (Bastion, message) => {
+  if (!message.guild.music.enabled) {
+    if (Bastion.user.id === '267035345537728512') {
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabledPublic'), message.channel);
+    }
+    return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
+  }
+
   if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
 
   if (!message.guild.music.songs || !message.guild.music.songs.length) {

--- a/commands/stop.js
+++ b/commands/stop.js
@@ -12,13 +12,11 @@ exports.exec = (Bastion, message) => {
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
   }
 
-  if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
+  if (message.guild.music.textChannelID && message.guild.music.textChannelID !== message.channel.id) {
+    return Bastion.log.info('Music channels have been set, so music commands will only work in the Music Text Channel.');
+  }
 
   if (!message.guild.music.songs || !message.guild.music.songs.length) {
-    /**
-     * Error condition is encountered.
-     * @fires error
-     */
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notPlaying'), message.channel);
   }
 

--- a/commands/stop.js
+++ b/commands/stop.js
@@ -5,6 +5,13 @@
  */
 
 exports.exec = (Bastion, message) => {
+  if (!message.guild.music.enabled) {
+    if (Bastion.user.id === '267035345537728512') {
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabledPublic'), message.channel);
+    }
+    return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
+  }
+
   if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
 
   if (!message.guild.music.songs || !message.guild.music.songs.length) {

--- a/commands/summon.js
+++ b/commands/summon.js
@@ -6,6 +6,13 @@
 
 exports.exec = async (Bastion, message) => {
   try {
+    if (!message.guild.music.enabled) {
+      if (Bastion.user.id === '267035345537728512') {
+        return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabledPublic'), message.channel);
+      }
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
+    }
+
     let voiceChannel;
     if (Bastion.credentials.ownerId.includes(message.author.id) || message.member.roles.has(message.guild.music.masterRoleID)) {
       voiceChannel = message.member.voiceChannel;

--- a/commands/summon.js
+++ b/commands/summon.js
@@ -66,6 +66,10 @@ exports.exec = async (Bastion, message) => {
         bitrate: 'auto'
       });
     }
+
+
+    voiceConnection.on('error', Bastion.log.error);
+    voiceConnection.on('failed', Bastion.log.error);
   }
   catch (e) {
     Bastion.log.error(e);

--- a/commands/summon.js
+++ b/commands/summon.js
@@ -36,6 +36,9 @@ exports.exec = async (Bastion, message) => {
           return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'invalidMusicChannel'), message.channel);
         }
       }
+      else {
+        return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicChannelNotFound'), message.channel);
+      }
 
       if (!voiceChannel) {
         return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'userNoVC', message.author.tag), message.channel);

--- a/commands/summon.js
+++ b/commands/summon.js
@@ -13,52 +13,55 @@ exports.exec = async (Bastion, message) => {
       return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
     }
 
-    let voiceChannel;
-    if (Bastion.credentials.ownerId.includes(message.author.id) || message.member.roles.has(message.guild.music.masterRoleID)) {
-      voiceChannel = message.member.voiceChannel;
-      if (!voiceChannel) {
-        /**
-        * Error condition is encountered.
-        * @fires error
-        */
-        return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'userNoVC', message.author.tag), message.channel);
+    if (message.guild.music.textChannelID && message.guild.music.textChannelID !== message.channel.id) {
+      return Bastion.log.info('Music channels have been set, so music commands will only work in the Music Text Channel.');
+    }
+
+
+    let voiceConnection = message.guild.voiceConnection, voiceChannel;
+
+    if (voiceConnection) {
+      if (voiceConnection.speaking) {
+        return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'isSpeaking'), message.channel);
       }
+      voiceChannel = voiceConnection.channel;
     }
     else {
-      if (message.guild.music.textChannelID !== message.channel.id) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
-
-      voiceChannel = message.guild.channels.filter(c => c.type === 'voice').get(message.guild.music.voiceChannelID);
-      if (!voiceChannel) {
-        /**
-        * Error condition is encountered.
-        * @fires error
-        */
-        return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'invalidMusicChannel'), message.channel);
+      if (Bastion.credentials.ownerId.includes(message.author.id) || message.member.roles.has(message.guild.music.masterRoleID)) {
+        voiceChannel = message.member.voiceChannel;
       }
+      else if (message.guild.music.voiceChannelID) {
+        voiceChannel = message.guild.channels.filter(c => c.type === 'voice').get(message.guild.music.voiceChannelID);
+        if (!voiceChannel) {
+          return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'invalidMusicChannel'), message.channel);
+        }
+      }
+
+      if (!voiceChannel) {
+        return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'userNoVC', message.author.tag), message.channel);
+      }
+      if (!voiceChannel.joinable) {
+        return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'noPermission', 'join', voiceChannel.name), message.channel);
+      }
+
+      voiceConnection = await voiceChannel.join();
     }
 
-    if (!voiceChannel.joinable) {
-      /**
-      * Error condition is encountered.
-      * @fires error
-      */
-      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'noPermission', 'join', voiceChannel.name), message.channel);
-    }
+
     if (!voiceChannel.speakable) {
-      /**
-      * Error condition is encountered.
-      * @fires error
-      */
       return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'noPermission', 'speak', `in ${voiceChannel.name}`), message.channel);
     }
 
-    let connection = await voiceChannel.join();
 
     message.guild.me.setMute(false).catch(() => {});
     message.guild.me.setDeaf(true).catch(() => {});
 
-    if (!connection.speaking) {
-      connection.playFile('./assets/greeting.mp3', { passes: (Bastion.config.music && Bastion.config.music.passes) || 1, bitrate: 'auto' });
+
+    if (!voiceConnection.speaking) {
+      voiceConnection.playFile('./assets/greeting.mp3', {
+        passes: (Bastion.config.music && Bastion.config.music.passes) || 1,
+        bitrate: 'auto'
+      });
     }
   }
   catch (e) {

--- a/commands/volume.js
+++ b/commands/volume.js
@@ -12,13 +12,11 @@ exports.exec = (Bastion, message, args) => {
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
   }
 
-  if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
+  if (message.guild.music.textChannelID && message.guild.music.textChannelID !== message.channel.id) {
+    return Bastion.log.info('Music channels have been set, so music commands will only work in the Music Text Channel.');
+  }
 
   if (!message.guild.music.songs || !message.guild.music.songs.length) {
-    /**
-     * Error condition is encountered.
-     * @fires error
-     */
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notPlaying'), message.channel);
   }
 

--- a/commands/volume.js
+++ b/commands/volume.js
@@ -5,6 +5,13 @@
  */
 
 exports.exec = (Bastion, message, args) => {
+  if (!message.guild.music.enabled) {
+    if (Bastion.user.id === '267035345537728512') {
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabledPublic'), message.channel);
+    }
+    return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
+  }
+
   if (message.guild.music.textChannelID && message.channel.id !== message.guild.music.textChannelID) return Bastion.log.info('Music channels have been set, so music commands will only work in the music text channel.');
 
   if (!message.guild.music.songs || !message.guild.music.songs.length) {

--- a/handlers/commandHandler.js
+++ b/handlers/commandHandler.js
@@ -17,7 +17,7 @@ const activeUsers = {};
 module.exports = async message => {
   try {
     let guildModel = await message.client.database.models.guild.findOne({
-      attributes: [ 'enabled', 'prefix', 'language', 'musicTextChannels', 'musicVoiceChannel', 'musicMasterRole', 'disabledCommands' ],
+      attributes: [ 'enabled', 'prefix', 'language', 'musicTextChannel', 'musicVoiceChannel', 'musicMasterRole', 'disabledCommands' ],
       where: {
         guildID: message.guild.id
       },
@@ -49,18 +49,18 @@ module.exports = async message => {
       message.guild.music = {};
     }
     // If any of the music channels have been removed, delete them from the database.
-    if (!message.guild.channels.has(guildModel.dataValues.musicTextChannels) || !message.guild.channels.has(guildModel.dataValues.musicVoiceChannel)) {
+    if (!message.guild.channels.has(guildModel.dataValues.musicTextChannel) || !message.guild.channels.has(guildModel.dataValues.musicVoiceChannel)) {
       await message.client.database.models.guild.update({
-        musicTextChannels: null,
+        musicTextChannel: null,
         musicVoiceChannel: null
       },
       {
         where: {
           guildID: message.guild.id
         },
-        fields: [ 'musicTextChannels', 'musicVoiceChannel' ]
+        fields: [ 'musicTextChannel', 'musicVoiceChannel' ]
       });
-      guildModel.dataValues.musicTextChannels = null;
+      guildModel.dataValues.musicTextChannel = null;
       guildModel.dataValues.musicVoiceChannel = null;
     }
     // If any of the music channels have been removed, delete them from the database.
@@ -77,7 +77,7 @@ module.exports = async message => {
       guildModel.dataValues.musicMasterRole = null;
     }
     // Add music configs to the guild music object.
-    message.guild.music.textChannelID = guildModel.dataValues.musicTextChannels;
+    message.guild.music.textChannelID = guildModel.dataValues.musicTextChannel;
     message.guild.music.voiceChannelID = guildModel.dataValues.musicVoiceChannel;
     message.guild.music.masterRoleID = guildModel.dataValues.musicMasterRole;
 

--- a/handlers/commandHandler.js
+++ b/handlers/commandHandler.js
@@ -17,7 +17,7 @@ const activeUsers = {};
 module.exports = async message => {
   try {
     let guildModel = await message.client.database.models.guild.findOne({
-      attributes: [ 'enabled', 'prefix', 'language', 'musicTextChannel', 'musicVoiceChannel', 'musicMasterRole', 'disabledCommands' ],
+      attributes: [ 'enabled', 'prefix', 'language', 'music', 'musicTextChannel', 'musicVoiceChannel', 'musicMasterRole', 'disabledCommands' ],
       where: {
         guildID: message.guild.id
       },
@@ -48,6 +48,8 @@ module.exports = async message => {
     if (!message.guild.music) {
       message.guild.music = {};
     }
+    // Set music support status of the guild.
+    message.guild.music.enabled = guildModel.dataValues.music;
     // If any of the music channels have been removed, delete them from the database.
     if (!message.guild.channels.has(guildModel.dataValues.musicTextChannel) || !message.guild.channels.has(guildModel.dataValues.musicVoiceChannel)) {
       await message.client.database.models.guild.update({

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -607,6 +607,10 @@
     "description": "Searches for the details of a movie.",
     "module": "queries"
   },
+  "music": {
+    "description": "Toggle music support for a specified server.",
+    "module": "music"
+  },
   "musicChannel": {
     "description": "Shows/Removes/Adds a voice channel specified by the ID and a text channel (the channel this command was used in) of you Discord server as default for the music module. Bastion will only accept music commands in that text channel and if anyone asks him to join a voice channel, it will automatically join the specified voice channel.",
     "module": "music"

--- a/locales/en_us/error.json
+++ b/locales/en_us/error.json
@@ -35,7 +35,7 @@
   "lowerRole": "You do not have permission to use this command on that role.",
   "messageNotFound": "The specified message was not found.",
   "minBet": "Minimum bet amount is %var% %currency.symbol%.",
-  "musicChannelNotFound": "No default music channels has been set. So, only the bot owner or users in the Music Master role can use this command.",
+  "musicChannelNotFound": "No default music channels has been set. So, only the bot owner or users in the Music Master role can use this command when I'm not already in a voice channel.",
   "noCredentials": "No credentials were found for %var%.",
   "noDeletableMessage": "No message was found that could be deleted.",
   "noLiveStream": "No live stream found for the channel %var%.",

--- a/locales/en_us/error.json
+++ b/locales/en_us/error.json
@@ -10,6 +10,8 @@
   "commandUsage": "That's not how you use the `%var%` command. See the usage below to know how to use the command.",
   "connection": "Some error has occurred while receiving data from the server. Please try again later.",
   "cooldown": "%var% you've recently used this command. Please try again later.\n`%var%` command can only be used once in **%var%** minutes.",
+  "musicDisabled": "Music is not enabled in this server. Ask the bot owner to enable it before you can use music commands.",
+  "musicDisabledPublic": "Music is disabled in the Public Bastion due to the maintenance cost of supporting music in soooo many Discord servers that Bastion is in.\n\nBut don't worry, you can host Bastion yourself if you want music.\nOtherwise our team can host a private Bastion for you, if you [become a Patron](%patreon%) for the respective tier.\n\nFor more info. ask in [%bastion.hq.name%](%bastion.hq.invite%)",
   "serverNotFound": "%bastion% cannot find the server at %var%.\n• Check the address for typing errors such as **ww**.example.com instead of **www**.example.com\n• Connection may have been timed out, try again later.",
   "eitherOneInVC": "Either one of us should be in a voice channel.",
   "favSongsNotFound": "There are no songs in your favorite songs list.",

--- a/locales/en_us/error.json
+++ b/locales/en_us/error.json
@@ -35,7 +35,7 @@
   "lowerRole": "You do not have permission to use this command on that role.",
   "messageNotFound": "The specified message was not found.",
   "minBet": "Minimum bet amount is %var% %currency.symbol%.",
-  "musicChannelNotFound": "No default music channel has been set. And I need to be in a voice channel to be able to play.",
+  "musicChannelNotFound": "No default music channels has been set. So, only the bot owner or users in the Music Master role can use this command.",
   "noCredentials": "No credentials were found for %var%.",
   "noDeletableMessage": "No message was found that could be deleted.",
   "noLiveStream": "No live stream found for the channel %var%.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.13",
+  "version": "7.0.0-alpha.14",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",

--- a/utils/models.js
+++ b/utils/models.js
@@ -539,6 +539,10 @@ module.exports = (Sequelize, database) => {
       type: Sequelize.STRING,
       allowNull: false
     },
+    creator: {
+      type: Sequelize.STRING,
+      allowNull: false
+    },
     songs: {
       type: Sequelize.JSON
     }

--- a/utils/models.js
+++ b/utils/models.js
@@ -101,7 +101,7 @@ module.exports = (Sequelize, database) => {
       allowNull: false,
       defaultValue: false
     },
-    musicTextChannels: {
+    musicTextChannel: {
       type: Sequelize.TEXT,
       unique: true
     },

--- a/utils/models.js
+++ b/utils/models.js
@@ -530,6 +530,20 @@ module.exports = (Sequelize, database) => {
     }
   });
 
+  const Playlist = database.define('playlist', {
+    guildID: {
+      type: Sequelize.STRING,
+      allowNull: false
+    },
+    name: {
+      type: Sequelize.STRING,
+      allowNull: false
+    },
+    songs: {
+      type: Sequelize.JSON
+    }
+  });
+
   const ScheduledCommand = database.define('scheduledCommand', {
     guildID: {
       type: Sequelize.STRING,
@@ -669,6 +683,11 @@ module.exports = (Sequelize, database) => {
     onUpdate: 'CASCADE'
   });
   Guild.Triggers = Guild.hasMany(Trigger, {
+    foreignKey: 'guildID',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE'
+  });
+  Guild.Playlist = Guild.hasMany(Playlist, {
     foreignKey: 'guildID',
     onDelete: 'CASCADE',
     onUpdate: 'CASCADE'

--- a/utils/models.js
+++ b/utils/models.js
@@ -102,7 +102,7 @@ module.exports = (Sequelize, database) => {
       defaultValue: false
     },
     musicTextChannel: {
-      type: Sequelize.TEXT,
+      type: Sequelize.STRING,
       unique: true
     },
     musicVoiceChannel: {


### PR DESCRIPTION
Improvements/changes:
- Added `music` command to toggle music support for any specified server.
- Rewritten `play` & `playlist` commands.
- Adding music from Bastion playlists to the queue is now faster than ever!
- Users can now have different music playlists in different servers.

<!--
    Thank you for your Pull Request. Please provide a description above and fill
    in as much of the template below as you're able.
-->

#### Possible drawbacks
No more global playlist and multiple playlist per user (yet).

#### Applicable Issues:
\-

#### Checklist
<!-- For completed items, change [ ] to [x]. -->

- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
