### PR TITLE
User Color

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "May 23, 2018",
+  "date": "May 24, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [],
   "THESE ABILITIES HAVE ENHANCED": [
@@ -40,7 +40,8 @@
     "`sellRole` - Sell roles in your server's Role Store.",
     "`serverDescription` & `roleDescription` - Set a description for the server & any role in the server.",
     "`music` - Toggle music support for any specified server.",
-    "`toggleBastion` - Toggle Bastion in the server."
+    "`toggleBastion` - Toggle Bastion in the server.",
+    "`setColor` - Set User Color to use the specified color for yourself in appropriate places like in your Bastion Profile."
   ],
   "COMMANDS WITH NEW USAGE": [
     "`addTrigger` command's usage syntax has been changed. It won't work the way it used to before, please check the help message for it, using the `help addTrigger` command, to see the new usage details.",

--- a/commands/info/profile.js
+++ b/commands/info/profile.js
@@ -33,7 +33,7 @@ exports.exec = async (Bastion, message, args) => {
     });
 
     let userModel = await Bastion.database.models.user.findOne({
-      attributes: [ 'bio', 'birthDate', 'location' ],
+      attributes: [ 'bio', 'birthDate', 'color', 'location' ],
       where: {
         userID: user.id
       }
@@ -95,7 +95,7 @@ exports.exec = async (Bastion, message, args) => {
 
     message.channel.send({
       embed: {
-        color: Bastion.colors.BLUE,
+        color: userModel.dataValues.color ? userModel.dataValues.color : Bastion.colors.BLUE,
         author: {
           name: user.tag,
           icon_url: await getUserIcon(user)

--- a/commands/info/setColor.js
+++ b/commands/info/setColor.js
@@ -1,0 +1,63 @@
+/**
+ * @file setColor command
+ * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
+ * @license GPL-3.0
+ */
+
+exports.exec = async (Bastion, message, args) => {
+  try {
+    if (!args.color || !/^#?(?:[0-9a-f]{3}|[0-9a-f]{6})$/i.test(args.color)) {
+      /**
+       * The command was ran with invalid parameters.
+       * @fires commandUsage
+       */
+      return Bastion.emit('commandUsage', message, this.help);
+    }
+
+
+    args.color = args.color.replace('#', '');
+    args.color = args.color.length === 3 ? args.color.replace(/(.)/g, '$1$1') : args.color;
+    let color = parseInt(args.color, 16);
+
+    await Bastion.database.models.user.update({
+      color: color
+    },
+    {
+      where: {
+        userID: message.author.id
+      },
+      fields: [ 'color' ]
+    });
+
+
+    message.channel.send({
+      embed: {
+        color: Bastion.colors.GREEN,
+        description: `${message.author}, your User Color has been set to **#${args.color}** and will be used in appropriate places.`
+      }
+    }).catch(e => {
+      Bastion.log.error(e);
+    });
+  }
+  catch (e) {
+    Bastion.log.error(e);
+  }
+};
+
+exports.config = {
+  aliases: [],
+  enabled: true,
+  argsDefinitions: [
+    { name: 'color', type: String, defaultOption: true }
+  ]
+};
+
+exports.help = {
+  name: 'setColor',
+  description: 'Sets your user color that is used in the Bastion user profile.',
+  botPermission: '',
+  userTextPermission: '',
+  userVoicePermission: '',
+  usage: 'setColor < #HEX_COLOR_CODE >',
+  example: [ 'setColor #000000' ]
+};

--- a/data/commands.json
+++ b/data/commands.json
@@ -895,6 +895,10 @@
     "description": "Sets your birth date that shows up in the Bastion user profile. Don't worry Bastion will never show your age/year to public.",
     "module": "Info"
   },
+  "setColor": {
+    "description": "Sets your user color that is used in the Bastion user profile.",
+    "module": "Info"
+  },
   "setLanguage": {
     "description": "Sets %bastion%'s language for the server.",
     "module": "Guild Admin"

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -671,6 +671,9 @@
   "setBirthDate": {
     "description": "Sets your birth date that shows up in the Bastion user profile. Don't worry Bastion will never show your age/year to public."
   },
+  "setColor": {
+    "description": "Sets your user color that is used in the Bastion user profile."
+  },
   "setLanguage": {
     "description": "Sets %bastion%'s language for the server."
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.15",
+  "version": "7.0.0-alpha.16",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",

--- a/utils/models.js
+++ b/utils/models.js
@@ -246,6 +246,9 @@ module.exports = (Sequelize, database) => {
     location: {
       type: Sequelize.STRING
     },
+    color: {
+      type: Sequelize.STRING
+    },
     blacklisted: {
       type: Sequelize.BOOLEAN,
       allowNull: false,


### PR DESCRIPTION
This PR adds the `setColor` command so that users can set their User Color which will be used in appropriate places related to them. For now, the User Color is used in a user's Bastion Profile's embed color.

#### Possible drawbacks
None

#### Applicable Issues:
\-

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
