### PR TITLE
Levelup Toggle

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "May 24, 2018",
+  "date": "June 2, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [],
   "THESE ABILITIES HAVE ENHANCED": [
@@ -41,7 +41,8 @@
     "`serverDescription` & `roleDescription` - Set a description for the server & any role in the server.",
     "`music` - Toggle music support for any specified server.",
     "`toggleBastion` - Toggle Bastion in the server.",
-    "`setColor` - Set User Color to use the specified color for yourself in appropriate places like in your Bastion Profile."
+    "`setColor` - Set User Color to use the specified color for yourself in appropriate places like in your Bastion Profile.",
+    "`toggleLevelUps` - Toggle gaining XP and leveling up while chatting."
   ],
   "COMMANDS WITH NEW USAGE": [
     "`addTrigger` command's usage syntax has been changed. It won't work the way it used to before, please check the help message for it, using the `help addTrigger` command, to see the new usage details.",

--- a/commands/guild_admin/toggleLevelUps.js
+++ b/commands/guild_admin/toggleLevelUps.js
@@ -1,0 +1,55 @@
+/**
+ * @file toggleLevelUps command
+ * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
+ * @license GPL-3.0
+ */
+
+exports.exec = async (Bastion, message) => {
+  try {
+    let guildModels = await message.client.database.models.guild.findOne({
+      attributes: [ 'levelUps' ],
+      where: {
+        guildID: message.guild.id
+      }
+    });
+
+    let levelUpStatus = !guildModels.dataValues.levelUps;
+
+    await message.client.database.models.guild.update({
+      levelUps: levelUpStatus
+    },
+    {
+      where: {
+        guildID: message.guild.id
+      },
+      fields: [ 'levelUps' ]
+    });
+
+    message.channel.send({
+      embed: {
+        color: levelUpStatus ? Bastion.colors.GREEN : Bastion.colors.RED,
+        description: Bastion.i18n.info(message.guild.language, levelUpStatus ? 'enableLevelUps' : 'disableLevelUps', message.author.tag)
+      }
+    }).catch(e => {
+      Bastion.log.error(e);
+    });
+  }
+  catch (e) {
+    Bastion.log.error(e);
+  }
+};
+
+exports.config = {
+  aliases: [ 'levelUps' ],
+  enabled: true
+};
+
+exports.help = {
+  name: 'toggleLevelUps',
+  description: 'Toggle level ups in the server. Turning off level ups will prevent users from gaining experience points and leveling up while chatting.',
+  botPermission: '',
+  userTextPermission: 'MANAGE_GUILD',
+  userVoicePermission: '',
+  usage: 'toggleLevelUps',
+  example: []
+};

--- a/data/commands.json
+++ b/data/commands.json
@@ -1059,6 +1059,10 @@
     "description": "Enable or disable Bastion in your server. Disabling Bastion will prevent everyone, including the server owner, from using it. But if you have enabled any settings that does not need user interaction, it will still work, like starboard, filters, auto assignable roles etc.",
     "module": "Guild Admin"
   },
+  "toggleLevelUps": {
+    "description": "Toggle level ups in the server. Turning off level ups will prevent users from gaining experience points and leveling up while chatting.",
+    "module": "Guild Admin"
+  },
   "translate": {
     "description": "Translates your message to the specified language.",
     "module": "Queries"

--- a/events/message.js
+++ b/events/message.js
@@ -51,7 +51,7 @@ module.exports = async message => {
       if (await mentionSpamFilter(message)) return;
 
       let guildModel = await message.client.database.models.guild.findOne({
-        attributes: [ 'slowMode' ],
+        attributes: [ 'slowMode', 'levelUps' ],
         where: {
           guildID: message.guild.id
         },
@@ -159,7 +159,7 @@ module.exports = async message => {
       /**
       * Cooldown for experience points, to prevent spam
       */
-      if (!recentLevelUps.includes(message.author.id)) {
+      if (guildModel.dataValues.levelUps && !recentLevelUps.includes(message.author.id)) {
         recentLevelUps.push(message.author.id);
         setTimeout(function () {
           recentLevelUps.splice(recentLevelUps.indexOf(message.author.id), 1);

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -794,6 +794,9 @@
   "toggleBastion": {
     "description": "Enable or disable Bastion in your server. Disabling Bastion will prevent everyone, including the server owner, from using it. But if you have enabled any settings that does not need user interaction, it will still work, like starboard, filters, auto assignable roles etc."
   },
+  "toggleLevelUps": {
+    "description": "Toggle level ups in the server. Turning off level ups will prevent users from gaining experience points and leveling up while chatting."
+  },
   "translate": {
     "description": "Translates your message to the specified language."
   },

--- a/locales/en_us/info.json
+++ b/locales/en_us/info.json
@@ -42,6 +42,8 @@
   "enableLevelUpMessages": "%var% enabled level up messages in this server. I will send messages, congratulating users, when they level up in this server.",
   "addLevelUpRole": "%var% added a level up role **%var%** to be added to users at level **%var%**.",
   "removeLevelUpRoles": "%var% removed all level up roles from level **%var%**.",
+  "disableLevelUps": "%var% disabled level ups in this server. Users won't be able to gain experience points and level up while chatting.",
+  "enableLevelUps": "%var% enabled level ups in this server. Users will now be able to gain experience points and level up as they chat.",
   "disableServerLog": "%var% disabled logging of server events.",
   "enableServerLog": "%var% enabled logging of server events, in this channel.",
   "disableModerationLog": "%var% disabled logging of moderation actions in this server.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.16",
+  "version": "7.0.0-alpha.17",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",


### PR DESCRIPTION
This PR adds the feature of toggling level ups in a guild that's achieved by chatting and gaining experience points. This gives the control of giving XP/level to the server administrators/managers.
* Added `toggleLevelUps` command to allow users with **Manage Server** perms to toggle the level ups.

#### Possible drawbacks
None

#### Applicable Issues:
\-

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
