### PR TITLE
Bastion Globals

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,9 @@
     es6: true,
     node: true
   },
+  globals: {
+    xrequire: false
+  },
   extends: "eslint:recommended",
   parserOptions: {
     ecmaVersion: 8,

--- a/bastion.js
+++ b/bastion.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const Discord = require('discord.js');
+const Discord = xrequire('discord.js');
 const BASTION = new Discord.Client({
   disabledEvents: [
     'USER_NOTE_UPDATE',
@@ -21,47 +21,47 @@ else {
   process.title = 'BastionBot';
 }
 
-BASTION.package = require('./package.json');
-BASTION.credentials = require('./settings/credentials.json');
-BASTION.config = require('./settings/config.json');
+BASTION.package = xrequire('./package.json');
+BASTION.credentials = xrequire('./settings/credentials.json');
+BASTION.config = xrequire('./settings/config.json');
 BASTION.Constants = Discord.Constants;
 BASTION.colors = Discord.Constants.Colors;
 BASTION.permissions = Discord.Permissions.FLAGS;
 
-// require('./utils/Array.prototype');
-require('./utils/String.prototype');
-require('./utils/Number.prototype');
+// xrequire('./utils/Array.prototype');
+xrequire('./utils/String.prototype');
+xrequire('./utils/Number.prototype');
 
-const WebhookHandler = require('./handlers/webhookHandler.js');
+const WebhookHandler = xrequire('./handlers/webhookHandler.js');
 BASTION.webhook = new WebhookHandler(BASTION.credentials.webhooks);
-BASTION.log = require('./handlers/logHandler');
-BASTION.functions = require('./handlers/functionHandler');
+BASTION.log = xrequire('./handlers/logHandler');
+BASTION.functions = xrequire('./handlers/functionHandler');
 
-const StringHandler = require('./handlers/stringHandler');
+const StringHandler = xrequire('./handlers/stringHandler');
 BASTION.i18n = new StringHandler();
 
-const Sequelize = require('sequelize');
+const Sequelize = xrequire('sequelize');
 BASTION.database = new Sequelize(BASTION.credentials.database.URI, {
   operatorsAliases: false,
   logging: false
 });
 BASTION.database.authenticate().then(() => {
   // Populate Database/Implement model definitions
-  require('./utils/models')(Sequelize, BASTION.database);
+  xrequire('./utils/models')(Sequelize, BASTION.database);
 
   // Load Bastion Database (Depricated)
   // Will be removed once new database is completely implemented
-  BASTION.db = require('sqlite');
+  BASTION.db = xrequire('sqlite');
   BASTION.db.open('./data/Bastion.sqlite').then(db => {
     db.run('PRAGMA foreign_keys = ON');
-    require('./utils/populateDatabase')(BASTION.db);
+    xrequire('./utils/populateDatabase')(BASTION.db);
   });
 
   // Load Bastion Events
-  require('./handlers/eventHandler')(BASTION);
+  xrequire('./handlers/eventHandler')(BASTION);
 
   // Load Bastion Modules
-  const Modules = require('./handlers/moduleHandler');
+  const Modules = xrequire('./handlers/moduleHandler');
   BASTION.commands = Modules.commands;
   BASTION.aliases = Modules.aliases;
 

--- a/commands/fun/beLikeBill.js
+++ b/commands/fun/beLikeBill.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/fun/cat.js
+++ b/commands/fun/cat.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message) => {
   try {

--- a/commands/fun/catFact.js
+++ b/commands/fun/catFact.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const catFacts = require('../../assets/catFacts.json');
+const catFacts = xrequire('./assets/catFacts.json');
 
 exports.exec = (Bastion, message) => {
   message.channel.send({

--- a/commands/fun/catify.js
+++ b/commands/fun/catify.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/fun/dog.js
+++ b/commands/fun/dog.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message) => {
   try {

--- a/commands/fun/emoji.js
+++ b/commands/fun/emoji.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const fs = require('fs');
+const fs = xrequire('fs');
 
 exports.exec = (Bastion, message, args) => {
   if (!args.name && !args.list) {

--- a/commands/fun/flipText.js
+++ b/commands/fun/flipText.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const flipText = require('../../assets/flipText.json');
+const flipText = xrequire('./assets/flipText.json');
 
 exports.exec = (Bastion, message, args) => {
   if (args.length < 1) {

--- a/commands/fun/fortune.js
+++ b/commands/fun/fortune.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const fortuneCookies = require('../../assets/fortuneCookies.json');
+const fortuneCookies = xrequire('./assets/fortuneCookies.json');
 
 exports.exec = (Bastion, message) => {
   message.channel.send({

--- a/commands/fun/pirateSpeak.js
+++ b/commands/fun/pirateSpeak.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const dictionary = require('../../assets/piratePhrases.json');
+const dictionary = xrequire('./assets/piratePhrases.json');
 
 exports.exec = (Bastion, message, args) => {
   if (args.length < 1) {

--- a/commands/fun/quotes.js
+++ b/commands/fun/quotes.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const quotes = require('../../assets/quotes.json');
+const quotes = xrequire('./assets/quotes.json');
 
 exports.exec = (Bastion, message, args) => {
   /*

--- a/commands/fun/robotify.js
+++ b/commands/fun/robotify.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/fun/xkcd.js
+++ b/commands/fun/xkcd.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const xkcd = require('xkcd');
+const xkcd = xrequire('xkcd');
 
 exports.exec = (Bastion, message, args) => {
   if (args.latest) {

--- a/commands/game_stats/battlefield1.js
+++ b/commands/game_stats/battlefield1.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/game_stats/battlefield4.js
+++ b/commands/game_stats/battlefield4.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/game_stats/callOfDuty4.js
+++ b/commands/game_stats/callOfDuty4.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const source = require('gamedig');
+const source = xrequire('gamedig');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/game_stats/counterStrikeGlobalOffensive.js
+++ b/commands/game_stats/counterStrikeGlobalOffensive.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const source = require('gamedig');
+const source = xrequire('gamedig');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/game_stats/destiny2.js
+++ b/commands/game_stats/destiny2.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/game_stats/fortnite.js
+++ b/commands/game_stats/fortnite.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/game_stats/minecraft.js
+++ b/commands/game_stats/minecraft.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const source = require('gamedig');
+const source = xrequire('gamedig');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/game_stats/overwatch.js
+++ b/commands/game_stats/overwatch.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const ow = require('overwatch-js');
+const ow = xrequire('overwatch-js');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/game_stats/paladins.js
+++ b/commands/game_stats/paladins.js
@@ -4,8 +4,8 @@
  * @license GPL-3.0
  */
 
-const credentials = require('../../settings/credentials.json');
-const HiRez = require('hirez.js');
+const credentials = xrequire('./settings/credentials.json');
+const HiRez = xrequire('hirez.js');
 const hirez = new HiRez({
   devId: credentials.HiRezDevId,
   authKey: credentials.HiRezAuthKey

--- a/commands/game_stats/pubg.js
+++ b/commands/game_stats/pubg.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/game_stats/quake3.js
+++ b/commands/game_stats/quake3.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const source = require('gamedig');
+const source = xrequire('gamedig');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/game_stats/rainbow6.js
+++ b/commands/game_stats/rainbow6.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const RainbowSix = require('rainbowsix-api-node');
+const RainbowSix = xrequire('rainbowsix-api-node');
 const r6 = new RainbowSix();
 
 exports.exec = (Bastion, message, args) => {

--- a/commands/game_stats/rocketLeague.js
+++ b/commands/game_stats/rocketLeague.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/game_stats/smite.js
+++ b/commands/game_stats/smite.js
@@ -4,8 +4,8 @@
  * @license GPL-3.0
  */
 
-const credentials = require('../../settings/credentials.json');
-const HiRez = require('hirez.js');
+const credentials = xrequire('./settings/credentials.json');
+const HiRez = xrequire('hirez.js');
 const hirez = new HiRez({
   devId: credentials.HiRezDevId,
   authKey: credentials.HiRezAuthKey

--- a/commands/game_stats/teamFortress2.js
+++ b/commands/game_stats/teamFortress2.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const source = require('gamedig');
+const source = xrequire('gamedig');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/games/jumbledSentence.js
+++ b/commands/games/jumbledSentence.js
@@ -16,7 +16,7 @@ exports.exec = async (Bastion, message) => {
       return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'isGameInUse', 'jumbled sentence'), message.channel);
     }
 
-    let quotes = require('../../assets/quotes.json');
+    let quotes = xrequire('./assets/quotes.json');
 
     let quote = quotes[Bastion.functions.getRandomInt(1, Object.keys(quotes).length)];
 

--- a/commands/games/jumbledWord.js
+++ b/commands/games/jumbledWord.js
@@ -16,7 +16,7 @@ exports.exec = async (Bastion, message) => {
       return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'isGameInUse', 'jumbled word'), message.channel);
     }
 
-    let words = require('../../assets/words.json');
+    let words = xrequire('./assets/words.json');
 
     let word = words[Math.floor(Math.random() * words.length)];
 

--- a/commands/games/race.js
+++ b/commands/games/race.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const ProgressBar = require('../../utils/progress');
+const ProgressBar = xrequire('./utils/progress');
 
 exports.exec = async (Bastion, message) => {
   try {

--- a/commands/games/thisOrThat.js
+++ b/commands/games/thisOrThat.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const question = require('../../assets/thisOrThat.json');
+const question = xrequire('./assets/thisOrThat.json');
 
 exports.exec = (Bastion, message) => {
   message.channel.send({

--- a/commands/games/trivia.js
+++ b/commands/games/trivia.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 let activeChannels = [];
 
 exports.exec = async (Bastion, message, args) => {

--- a/commands/games/typingGame.js
+++ b/commands/games/typingGame.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const typingArticles = require('../../assets/typingArticles.json');
+const typingArticles = xrequire('./assets/typingArticles.json');
 let activeChannels = [];
 
 exports.exec = async (Bastion, message) => {

--- a/commands/games/wouldYouRather.js
+++ b/commands/games/wouldYouRather.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const question = require('../../assets/wouldYouRather.json');
+const question = xrequire('./assets/wouldYouRather.json');
 
 exports.exec = (Bastion, message) => {
   message.channel.send({

--- a/commands/guild_admin/addTrigger.js
+++ b/commands/guild_admin/addTrigger.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const emojis = require('../../assets/emojis.json');
+const emojis = xrequire('./assets/emojis.json');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/help/changelog.js
+++ b/commands/help/changelog.js
@@ -5,7 +5,7 @@
  */
 
 exports.exec = (Bastion, message) => {
-  const CHANGES = require('../../changes.json');
+  const CHANGES = xrequire('./changes.json');
 
   let changes = [];
   for (let section in CHANGES) {

--- a/commands/info/profile.js
+++ b/commands/info/profile.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const specialIDs = require('../../assets/specialIDs.json');
+const specialIDs = xrequire('./assets/specialIDs.json');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/money/claim.js
+++ b/commands/money/claim.js
@@ -4,8 +4,8 @@
  * @license GPL-3.0
  */
 
-const moment = require('moment');
-const specialIDs = require('../../assets/specialIDs.json');
+const moment = xrequire('moment');
+const specialIDs = xrequire('./assets/specialIDs.json');
 
 exports.exec = async (Bastion, message) => {
   try {

--- a/commands/music/lyrics.js
+++ b/commands/music/lyrics.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/music/play.js
+++ b/commands/music/play.js
@@ -4,8 +4,8 @@
  * @license GPL-3.0
  */
 
-const util = require('util');
-const youtubeDL = require('youtube-dl');
+const util = xrequire('util');
+const youtubeDL = xrequire('youtube-dl');
 const getSongInfo = util.promisify(youtubeDL.getInfo);
 
 exports.exec = async (Bastion, message, args) => {

--- a/commands/music/playlist.js
+++ b/commands/music/playlist.js
@@ -4,8 +4,8 @@
  * @license GPL-3.0
  */
 
-const util = require('util');
-const youtubeDL = require('youtube-dl');
+const util = xrequire('util');
+const youtubeDL = xrequire('youtube-dl');
 const getSongInfo = util.promisify(youtubeDL.getInfo);
 
 exports.exec = async (Bastion, message, args) => {

--- a/commands/owner/capture.js
+++ b/commands/owner/capture.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const capture = require('webshot');
+const capture = xrequire('webshot');
 
 exports.exec = (Bastion, message, args) => {
   if (args.length < 1) {

--- a/commands/owner/eval.js
+++ b/commands/owner/eval.js
@@ -25,7 +25,7 @@ exports.exec = async (Bastion, message, args) => {
     }
 
     if (typeof evaled !== 'string') {
-      evaled = require('util').inspect(evaled);
+      evaled = xrequire('util').inspect(evaled);
     }
 
     let output = await message.channel.send({

--- a/commands/owner/exec.js
+++ b/commands/owner/exec.js
@@ -4,8 +4,8 @@
  * @license GPL-3.0
  */
 
-const util = require('util');
-const exec = util.promisify(require('child_process').exec);
+const util = xrequire('util');
+const exec = util.promisify(xrequire('child_process').exec);
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/owner/reloadSettings.js
+++ b/commands/owner/reloadSettings.js
@@ -9,7 +9,7 @@ exports.exec = (Bastion, message) => {
     // eslint-disable-next-line no-sync
     let settings = Bastion.functions.listFilesSync('settings');
     for (let file of settings) {
-      delete require.cache[require.resolve(`../../settings/${file}`)];
+      delete xrequire.cache[xrequire.resolve(`./settings/${file}`)];
     }
     Bastion.config = xrequire('./settings/config.json');
     Bastion.credentials = xrequire('./settings/credentials.json');

--- a/commands/owner/reloadSettings.js
+++ b/commands/owner/reloadSettings.js
@@ -11,8 +11,8 @@ exports.exec = (Bastion, message) => {
     for (let file of settings) {
       delete require.cache[require.resolve(`../../settings/${file}`)];
     }
-    Bastion.config = require('../../settings/config.json');
-    Bastion.credentials = require('../../settings/credentials.json');
+    Bastion.config = xrequire('./settings/config.json');
+    Bastion.credentials = xrequire('./settings/credentials.json');
 
     message.channel.send({
       embed: {

--- a/commands/queries/anime.js
+++ b/commands/queries/anime.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const Kitsu = require('kitsu/node');
+const Kitsu = xrequire('kitsu/node');
 const kitsu = new Kitsu();
 
 exports.exec = async (Bastion, message, args) => {

--- a/commands/queries/calculate.js
+++ b/commands/queries/calculate.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const mathjs = require('mathjs');
+const mathjs = xrequire('mathjs');
 
 exports.exec = (Bastion, message, args) => {
   if (args.length < 1) {

--- a/commands/queries/coinMarketCap.js
+++ b/commands/queries/coinMarketCap.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/queries/colour.js
+++ b/commands/queries/colour.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const convert = require('color-convert');
+const convert = xrequire('color-convert');
 
 exports.exec = (Bastion, message, args) => {
   if (!/^#?[0-9a-fA-F]{6}$/.test(args.color)) {

--- a/commands/queries/date.js
+++ b/commands/queries/date.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const location = require('weather-js');
+const location = xrequire('weather-js');
 
 exports.exec = (Bastion, message, args) => {
   if (args.length < 1) {

--- a/commands/queries/define.js
+++ b/commands/queries/define.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const wd = require('word-definition');
+const wd = xrequire('word-definition');
 
 exports.exec = (Bastion, message, args) => {
   if (args.length < 1) {

--- a/commands/queries/followURL.js
+++ b/commands/queries/followURL.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const followURL = require('../../functions/followURL');
+const followURL = xrequire('./functions/followURL');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/queries/forecast.js
+++ b/commands/queries/forecast.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const weather = require('weather-js');
+const weather = xrequire('weather-js');
 
 exports.exec = (Bastion, message, args) => {
   if (args.length < 1) {

--- a/commands/queries/game.js
+++ b/commands/queries/game.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/queries/giphy.js
+++ b/commands/queries/giphy.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/queries/google.js
+++ b/commands/queries/google.js
@@ -4,8 +4,8 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
-const cheerio = require('cheerio');
+const request = xrequire('request-promise-native');
+const cheerio = xrequire('cheerio');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/queries/isBreached.js
+++ b/commands/queries/isBreached.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/queries/manga.js
+++ b/commands/queries/manga.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const Kitsu = require('kitsu/node');
+const Kitsu = xrequire('kitsu/node');
 const kitsu = new Kitsu();
 
 exports.exec = async (Bastion, message, args) => {

--- a/commands/queries/map.js
+++ b/commands/queries/map.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/queries/movie.js
+++ b/commands/queries/movie.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/queries/pokemon.js
+++ b/commands/queries/pokemon.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const Pokedex = require('pokedex-api');
+const Pokedex = xrequire('pokedex-api');
 const pokedex = new Pokedex({
   userAgent: 'Bastion: Discord Bot (https://bastionbot.org)',
   version: 'v1'

--- a/commands/queries/reminder.js
+++ b/commands/queries/reminder.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const moment = require('moment');
+const moment = xrequire('moment');
 const remindUsers = {};
 
 exports.exec = (Bastion, message, args) => {

--- a/commands/queries/shorten.js
+++ b/commands/queries/shorten.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/queries/steam.js
+++ b/commands/queries/steam.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/queries/translate.js
+++ b/commands/queries/translate.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const translate = require('@k3rn31p4nic/google-translate-api');
+const translate = xrequire('@k3rn31p4nic/google-translate-api');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/queries/tvShow.js
+++ b/commands/queries/tvShow.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/queries/twitch.js
+++ b/commands/queries/twitch.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/queries/urbanDictionary.js
+++ b/commands/queries/urbanDictionary.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/queries/weather.js
+++ b/commands/queries/weather.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const weather = require('weather-js');
+const weather = xrequire('weather-js');
 
 exports.exec = (Bastion, message, args) => {
   if (args.length < 1) {

--- a/commands/queries/wikipedia.js
+++ b/commands/queries/wikipedia.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 exports.exec = async (Bastion, message, args) => {
   try {

--- a/commands/queries/youtubeSearch.js
+++ b/commands/queries/youtubeSearch.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const yt = require('youtube-dl');
+const yt = xrequire('youtube-dl');
 
 exports.exec = (Bastion, message, args) => {
   if (args.length < 1) {

--- a/events/error.js
+++ b/events/error.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const COLOR = require('chalk');
+const COLOR = xrequire('chalk');
 
 module.exports = (error, description, channel) => {
   if (channel) {

--- a/events/guildMemberAdd.js
+++ b/events/guildMemberAdd.js
@@ -6,7 +6,7 @@
 
 module.exports = async member => {
   try {
-    const greetMessages = require('../assets/greetingMessages.json');
+    const greetMessages = xrequire('./assets/greetingMessages.json');
 
     let guildModel = await member.client.database.models.guild.findOne({
       attributes: [ 'greet', 'greetMessage', 'greetTimeout', 'greetPrivate', 'greetPrivateMessage', 'autoAssignableRoles', 'serverLog' ],

--- a/events/message.js
+++ b/events/message.js
@@ -4,16 +4,16 @@
  * @license GPL-3.0
  */
 
-const credentialsFilter = require('../utils/credentialsFilter');
-const wordFilter = require('../utils/wordFilter');
-const linkFilter = require('../utils/linkFilter');
-const inviteFilter = require('../utils/inviteFilter');
-const mentionSpamFilter = require('../utils/mentionSpamFilter');
-const handleTrigger = require('../handlers/triggerHandler');
-const handleUserLevel = require('../handlers/levelHandler');
-const handleCommand = require('../handlers/commandHandler');
-const handleConversation = require('../handlers/conversationHandler');
-const handleDirectMessage = require('../handlers/directMessageHandler');
+const credentialsFilter = xrequire('./utils/credentialsFilter');
+const wordFilter = xrequire('./utils/wordFilter');
+const linkFilter = xrequire('./utils/linkFilter');
+const inviteFilter = xrequire('./utils/inviteFilter');
+const mentionSpamFilter = xrequire('./utils/mentionSpamFilter');
+const handleTrigger = xrequire('./handlers/triggerHandler');
+const handleUserLevel = xrequire('./handlers/levelHandler');
+const handleCommand = xrequire('./handlers/commandHandler');
+const handleConversation = xrequire('./handlers/conversationHandler');
+const handleDirectMessage = xrequire('./handlers/directMessageHandler');
 let recentLevelUps = [];
 let recentUsers = {};
 

--- a/events/messageUpdate.js
+++ b/events/messageUpdate.js
@@ -4,10 +4,10 @@
  * @license GPL-3.0
  */
 
-const credentialsFilter = require('../utils/credentialsFilter');
-const wordFilter = require('../utils/wordFilter');
-const linkFilter = require('../utils/linkFilter');
-const inviteFilter = require('../utils/inviteFilter');
+const credentialsFilter = xrequire('./utils/credentialsFilter');
+const wordFilter = xrequire('./utils/wordFilter');
+const linkFilter = xrequire('./utils/linkFilter');
+const inviteFilter = xrequire('./utils/inviteFilter');
 
 module.exports = (oldMessage, newMessage) => {
   // If message content hasn't been changed, do nothing

--- a/events/ready.js
+++ b/events/ready.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const COLOR = require('chalk');
+const COLOR = xrequire('chalk');
 
 module.exports = async Bastion => {
   try {
@@ -96,8 +96,8 @@ module.exports = async Bastion => {
      * }
      */
 
-    require('../handlers/scheduledCommandHandler')(Bastion);
-    require('../handlers/streamNotifier')(Bastion);
+    xrequire('./handlers/scheduledCommandHandler')(Bastion);
+    xrequire('./handlers/streamNotifier')(Bastion);
 
     if (Bastion.shard) {
       Bastion.log.console(`${COLOR.cyan(`[${Bastion.user.username}]:`)} Shard ${Bastion.shard.id} is ready with ${Bastion.guilds.size} servers.`);

--- a/events/warn.js
+++ b/events/warn.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const COLOR = require('chalk');
+const COLOR = xrequire('chalk');
 
 module.exports = info => {
   /* eslint-disable no-console */

--- a/functions/decodeString.js
+++ b/functions/decodeString.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const lzutf8 = require('lzutf8');
+const lzutf8 = xrequire('lzutf8');
 
 /**
  * Decodes/Decompresses a BinaryString, with LZUTF8, to String

--- a/functions/encodeString.js
+++ b/functions/encodeString.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const lzutf8 = require('lzutf8');
+const lzutf8 = xrequire('lzutf8');
 
 /**
  * Encodes/Compresses a string to BinaryString with LZUTF8

--- a/functions/followURL.js
+++ b/functions/followURL.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
+const request = xrequire('request-promise-native');
 
 module.exports = (url) => {
   return new Promise(async (resolve, reject) => {

--- a/functions/getContributors.js
+++ b/functions/getContributors.js
@@ -4,8 +4,8 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
-const github = require('../settings/credentials.json').github;
+const request = xrequire('request-promise-native');
+const github = xrequire('./settings/credentials.json').github;
 
 module.exports = () => {
   return new Promise(async (resolve, reject) => {

--- a/functions/getDirSync.js
+++ b/functions/getDirSync.js
@@ -4,8 +4,8 @@
  * @license GPL-3.0
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = xrequire('fs');
+const path = xrequire('path');
 
 module.exports = src => {
   // eslint-disable-next-line no-sync

--- a/functions/getPatrons.js
+++ b/functions/getPatrons.js
@@ -4,8 +4,8 @@
  * @license GPL-3.0
  */
 
-const request = require('request-promise-native');
-const patreon = require('../settings/credentials.json').patreon;
+const request = xrequire('request-promise-native');
+const patreon = xrequire('./settings/credentials.json').patreon;
 
 module.exports = () => {
   return new Promise(async (resolve, reject) => {

--- a/functions/isSnowflake.js
+++ b/functions/isSnowflake.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const { Snowflake } = require('discord.js');
+const { Snowflake } = xrequire('discord.js');
 
 module.exports = (snowflake) => {
   snowflake = Snowflake.deconstruct(snowflake);

--- a/functions/listFilesSync.js
+++ b/functions/listFilesSync.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const fs = require('fs');
+const fs = xrequire('fs');
 
 module.exports = dir => {
   // eslint-disable-next-line no-sync

--- a/handlers/commandHandler.js
+++ b/handlers/commandHandler.js
@@ -4,9 +4,9 @@
  * @license GPL-3.0
  */
 
-const parseArgs = require('command-line-args');
-const COLOR = require('chalk');
-const _ = require('lodash/core');
+const parseArgs = xrequire('command-line-args');
+const COLOR = xrequire('chalk');
+const _ = xrequire('lodash/core');
 const activeUsers = {};
 
 /**

--- a/handlers/conversationHandler.js
+++ b/handlers/conversationHandler.js
@@ -4,8 +4,8 @@
  * @license GPL-3.0
  */
 
-const CLEVERBOT = require('cleverbot.js');
-const CREDENTIALS = require('../settings/credentials.json');
+const CLEVERBOT = xrequire('cleverbot.js');
+const CREDENTIALS = xrequire('./settings/credentials.json');
 const BOT = new CLEVERBOT({
   APIKey: CREDENTIALS.cleverbotAPIkey
 });

--- a/handlers/eventHandler.js
+++ b/handlers/eventHandler.js
@@ -10,7 +10,7 @@
  * @param {string} event Name of the event.
  * @returns {function} The event's function.
  */
-const LOAD_EVENTS = event => require(`../events/${event}`);
+const LOAD_EVENTS = event => xrequire('./events/', event);
 
 /**
  * Handles/Loads all the events.

--- a/handlers/functionHandler.js
+++ b/handlers/functionHandler.js
@@ -4,10 +4,10 @@
  * @license GPL-3.0
  */
 
-const fs = require('fs');
+const fs = xrequire('fs');
 
 // eslint-disable-next-line no-sync
 let functions = fs.readdirSync('./functions/');
 for (let method of functions) {
-  exports[method.replace('.js', '')] = require(`../functions/${method}`);
+  exports[method.replace('.js', '')] = xrequire('./functions/', method);
 }

--- a/handlers/logHandler.js
+++ b/handlers/logHandler.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const COLOR = require('chalk');
+const COLOR = xrequire('chalk');
 
 /* eslint-disable no-console*/
 /**

--- a/handlers/moduleHandler.js
+++ b/handlers/moduleHandler.js
@@ -4,10 +4,10 @@
  * @license GPL-3.0
  */
 
-const fs = require('fs');
-const path = require('path');
-const color = require('chalk');
-const { Collection } = require('discord.js');
+const fs = xrequire('fs');
+const path = xrequire('path');
+const color = xrequire('chalk');
+const { Collection } = xrequire('discord.js');
 
 /* eslint-disable no-sync */
 let Commands = new Collection();
@@ -26,7 +26,7 @@ for (let module of modules) {
     file = file.substr(0, file.length - 3);
     process.stdout.write(`${color.cyan('[Bastion]:')} Loading ${file} command...\n`);
 
-    file = require(path.resolve('./commands/', module, file));
+    file = xrequire('./commands/', module, file);
     Commands.set(file.help.name.toLowerCase(), file);
 
     file.config.module = module;

--- a/handlers/scheduledCommandHandler.js
+++ b/handlers/scheduledCommandHandler.js
@@ -4,8 +4,8 @@
  * @license GPL-3.0
  */
 
-const CronJob = require('cron').CronJob;
-const parseArgs = require('command-line-args');
+const CronJob = xrequire('cron').CronJob;
+const parseArgs = xrequire('command-line-args');
 
 /**
  * Handles Bastion's scheduled commands

--- a/handlers/streamNotifier.js
+++ b/handlers/streamNotifier.js
@@ -4,8 +4,8 @@
  * @license GPL-3.0
  */
 
-const CronJob = require('cron').CronJob;
-const request = require('request-promise-native');
+const CronJob = xrequire('cron').CronJob;
+const request = xrequire('request-promise-native');
 
 /**
  * Handles Bastion's scheduled commands

--- a/handlers/stringHandler.js
+++ b/handlers/stringHandler.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const Locke = require('locke');
+const Locke = xrequire('locke');
 
 const StringHandler = class StringHandler extends Locke {
   /**

--- a/handlers/webhookHandler.js
+++ b/handlers/webhookHandler.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const Discord = require('discord.js');
+const Discord = xrequire('discord.js');
 
 module.exports = class WebhookHandler {
   /**

--- a/index.js
+++ b/index.js
@@ -4,14 +4,14 @@
  * @license GPL-3.0
  */
 
-const Discord = require('discord.js');
-const credentials = require('./settings/credentials.json');
-const config = require('./settings/config.json');
+const Discord = xrequire('discord.js');
+const credentials = xrequire('./settings/credentials.json');
+const config = xrequire('./settings/config.json');
 const Manager = new Discord.ShardingManager('./bastion.js', {
   totalShards: config.shardCount,
   token: credentials.token
 });
-const log = require('./handlers/logHandler');
+const log = xrequire('./handlers/logHandler');
 
 Manager.spawn();
 

--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
   "url": "https://bastionbot.org/",
   "main": "index.js",
   "scripts": {
-    "build:commandStrings": "node utils/generateCommandStrings.js",
+    "build:commandStrings": "node -r ./utils/globals.js utils/generateCommandStrings.js",
     "build": "npm run build:commandStrings",
     "test:lint": "./node_modules/.bin/eslint .",
-    "test:modules": "node tests/modules.js",
-    "test:boot": "node tests/boot.js",
+    "test:modules": "node -r ./utils/globals.js tests/modules.js",
+    "test:boot": "node -r ./utils/globals.js tests/boot.js",
     "test": "npm run test:lint && npm run test:modules && npm run test:boot",
-    "start": "node index.js"
+    "start": "node -r ./utils/globals.js index.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.17",
+  "version": "7.0.0-alpha.18",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",

--- a/scripts/bash/methods.sh
+++ b/scripts/bash/methods.sh
@@ -17,7 +17,7 @@ function method::debug () {
     print::error "$NAME is already running!"
     print::info "Stop Bastion before you run it in dubug mode!"
   else
-    node .
+    node -r ./utils/globals.js .
   fi
 }
 
@@ -110,7 +110,7 @@ function method::start () {
 
       print::message "Booting up..."
 
-      screen -L -dmS "$NAME" /bin/bash -c "until node .; do sleep 1; done"
+      screen -L -dmS "$NAME" /bin/bash -c "until node -r ./utils/globals.js .; do sleep 1; done"
 
       print::info "$NAME was successfully started!"
     else

--- a/scripts/powershell/Start.ps1
+++ b/scripts/powershell/Start.ps1
@@ -6,7 +6,7 @@ If (Test-Path ".\index.js") {
   Write-Host "[Bastion]: Booting up..."
   Write-Host
 
-  node .
+  node -r ./utils/globals.js .
 }
 Else {
   Write-Host "[Bastion]: System check failed."

--- a/tests/boot.js
+++ b/tests/boot.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const Discord = require('discord.js');
+const Discord = xrequire('discord.js');
 const BASTION = new Discord.Client({
   disabledEvents: [
     'USER_NOTE_UPDATE',
@@ -14,50 +14,50 @@ const BASTION = new Discord.Client({
   ]
 });
 
-BASTION.package = require('../package.json');
-BASTION.credentials = require('../settings/credentials.json');
-BASTION.config = require('../settings/config.json');
+BASTION.package = xrequire('./package.json');
+BASTION.credentials = xrequire('./settings/credentials.json');
+BASTION.config = xrequire('./settings/config.json');
 BASTION.Constants = Discord.Constants;
 BASTION.colors = Discord.Constants.Colors;
 BASTION.permissions = Discord.Permissions.FLAGS;
 
-// require('./utils/Array.prototype');
-require('../utils/String.prototype');
-require('../utils/Number.prototype');
+// xrequire('./utils/Array.prototype');
+xrequire('./utils/String.prototype');
+xrequire('./utils/Number.prototype');
 
-const WebhookHandler = require('../handlers/webhookHandler.js');
+const WebhookHandler = xrequire('./handlers/webhookHandler.js');
 BASTION.webhook = new WebhookHandler(BASTION.credentials.webhooks);
-BASTION.log = require('../handlers/logHandler');
-BASTION.functions = require('../handlers/functionHandler');
+BASTION.log = xrequire('./handlers/logHandler');
+BASTION.functions = xrequire('./handlers/functionHandler');
 
-const StringHandler = require('../handlers/stringHandler');
+const StringHandler = xrequire('./handlers/stringHandler');
 BASTION.i18n = new StringHandler();
 
-const Sequelize = require('sequelize');
+const Sequelize = xrequire('sequelize');
 BASTION.database = new Sequelize(BASTION.credentials.database.URI, {
   operatorsAliases: false,
   logging: false
 });
 BASTION.database.authenticate().then(() => {
   // Populate Database/Implement model definitions
-  require('../utils/models')(Sequelize, BASTION.database);
+  xrequire('./utils/models')(Sequelize, BASTION.database);
 
   // Load Bastion Database (Depricated)
   // Will be removed once new database is completely implemented
-  BASTION.db = require('sqlite');
+  BASTION.db = xrequire('sqlite');
   BASTION.db.open('./data/Bastion.sqlite').then(db => {
     db.run('PRAGMA foreign_keys = ON');
-    require('../utils/populateDatabase')(BASTION.db);
+    xrequire('./utils/populateDatabase')(BASTION.db);
   }).catch(e => {
     BASTION.log.error(e.stack);
     process.exit(1);
   });
 
   // Load Bastion Events
-  require('../handlers/eventHandler')(BASTION);
+  xrequire('./handlers/eventHandler')(BASTION);
 
   // Load Bastion Modules
-  const Modules = require('../handlers/moduleHandler');
+  const Modules = xrequire('./handlers/moduleHandler');
   BASTION.commands = Modules.commands;
   BASTION.aliases = Modules.aliases;
 

--- a/tests/modules.js
+++ b/tests/modules.js
@@ -4,11 +4,10 @@
  * @license GPL-3.0
  */
 
-const path = require('path');
-const _ = require('lodash');
-let chalk = require('chalk');
-let moduleHandler = require(path.resolve('./handlers/moduleHandler'));
-const commandInfo = require(path.resolve('./locales/en_us/command.json'));
+const _ = xrequire('lodash');
+let chalk = xrequire('chalk');
+let moduleHandler = xrequire('./handlers/moduleHandler');
+const commandInfo = xrequire('./locales/en_us/command.json');
 
 let describedCommands = Object.keys(commandInfo);
 describedCommands = describedCommands.map(command => command.toLowerCase());

--- a/utils/generateCommandStrings.js
+++ b/utils/generateCommandStrings.js
@@ -4,9 +4,9 @@
  * @license GPL-3.0
  */
 
-const fs = require('fs');
-const path = require('path');
-const util = require('util');
+const fs = xrequire('fs');
+const path = xrequire('path');
+const util = xrequire('util');
 const writeFile = util.promisify(fs.writeFile);
 
 /* eslint-disable no-sync */
@@ -22,7 +22,7 @@ for (let module of modules) {
   for (let file of commandFiles) {
     file = file.substr(0, file.length - 3);
 
-    file = require(path.resolve('./commands/', module, file));
+    file = xrequire('./commands/', module, file);
 
     commands[file.help.name] = {
       description: file.help.description,

--- a/utils/globals.js
+++ b/utils/globals.js
@@ -14,13 +14,13 @@ global.xrequire = (...module) => {
 global.xrequire.cache = require.cache;
 global.xrequire.main = require.main;
 global.xrequire.resolve = (request, options = null) => {
-  if (module.startsWith('.')) {
+  if (request.startsWith('.')) {
     return require.resolve(path.resolve(request), options);
   }
   return require.resolve(request, options);
 };
 global.xrequire.resolve.paths = request => {
-  if (module.startsWith('.')) {
+  if (request.startsWith('.')) {
     return require.resolve.paths(path.resolve(request));
   }
   return require.resolve.paths(request);

--- a/utils/globals.js
+++ b/utils/globals.js
@@ -1,0 +1,27 @@
+const path = require('path');
+
+/*
+ * xrequire - Same as `require` (https://nodejs.org/api/modules.html#modules_require)
+ * Except that it takes absolute path as arguments, unlike `require` which takes
+ * relative paths to modules.
+ */
+global.xrequire = module => {
+  if (module.startsWith('.')) {
+    return require(path.resolve(module));
+  }
+  return require(module);
+};
+global.xrequire.cache = require.cache;
+global.xrequire.main = require.main;
+global.xrequire.resolve = (request, options = null) => {
+  if (module.startsWith('.')) {
+    return require.resolve(path.resolve(request), options);
+  }
+  return require.resolve(request, options);
+};
+global.xrequire.resolve.paths = request => {
+  if (module.startsWith('.')) {
+    return require.resolve.paths(path.resolve(request));
+  }
+  return require.resolve.paths(request);
+};

--- a/utils/globals.js
+++ b/utils/globals.js
@@ -5,11 +5,11 @@ const path = require('path');
  * Except that it takes absolute path as arguments, unlike `require` which takes
  * relative paths to modules.
  */
-global.xrequire = module => {
-  if (module.startsWith('.')) {
-    return require(path.resolve(module));
+global.xrequire = (...module) => {
+  if (module[0] && module[0].startsWith('.')) {
+    return require(path.resolve(...module));
   }
-  return require(module);
+  return require(module[0]);
 };
 global.xrequire.cache = require.cache;
 global.xrequire.main = require.main;

--- a/utils/models.js
+++ b/utils/models.js
@@ -4,8 +4,8 @@
  * @license GPL-3.0
  */
 
-const logger = require('../handlers/logHandler');
-const { prefix } = require('../settings/config.json');
+const logger = xrequire('./handlers/logHandler');
+const { prefix } = xrequire('./settings/config.json');
 
 module.exports = (Sequelize, database) => {
   // Models

--- a/utils/populateDatabase.js
+++ b/utils/populateDatabase.js
@@ -4,7 +4,7 @@
  * @license GPL-3.0
  */
 
-const config = require('../settings/config.json');
+const config = xrequire('./settings/config.json');
 
 module.exports = async db => {
   await db.run('CREATE TABLE IF NOT EXISTS guildSettings' +
@@ -127,5 +127,5 @@ module.exports = async db => {
     'youtube TEXT,' +
     'FOREIGN KEY (guildID) REFERENCES guildSettings (guildID) ON DELETE CASCADE)');
 
-  require('./updateDatabase')(db);
+  xrequire('./utils/updateDatabase')(db);
 };


### PR DESCRIPTION
This PR introduces support for global objects that can be used throughout Bastion. Currently, only `xrequire` is implemented globally. `xrequire` is same as the native `require` except that it supports absolute paths for modules. The boot scripts have been updated to support this change. The ESLint configuration has been updated to allow `xrequire` globally.

#### Possible drawbacks
While running Bastion manually, simply running `node .` or `node index.js` or `node bastion.js` won't work anymore. Either the `globals.js` module is to be passed with the `--require` flag or `npm start` should be used. The boot scripts have been updated to automatically require the `globals.js` module at startup, so that's unaffected.

The tests for this PR will fail because of the old ESLint configuration used in the master branch. So I'm merging this PR without seeing the results of the tests.

#### Applicable Issues:
\-

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
