### PR TITLE
User Reporting Rewrite

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "June 2, 2018",
+  "date": "June 4, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [],
   "THESE ABILITIES HAVE ENHANCED": [
@@ -42,7 +42,8 @@
     "`music` - Toggle music support for any specified server.",
     "`toggleBastion` - Toggle Bastion in the server.",
     "`setColor` - Set User Color to use the specified color for yourself in appropriate places like in your Bastion Profile.",
-    "`toggleLevelUps` - Toggle gaining XP and leveling up while chatting."
+    "`toggleLevelUps` - Toggle gaining XP and leveling up while chatting.",
+    "`reportChannel` - (Un)Set report channel of the server."
   ],
   "COMMANDS WITH NEW USAGE": [
     "`addTrigger` command's usage syntax has been changed. It won't work the way it used to before, please check the help message for it, using the `help addTrigger` command, to see the new usage details.",

--- a/changes.json
+++ b/changes.json
@@ -31,10 +31,7 @@
   ],
   "NEW COMMANDS!": [
     "`blacklist` - Blacklist users globally from using Bastion.",
-    "`ignoreInviteFilter` - Set channels and/or roles to be ignored by the invite filter.",
-    "`ignoreLinkFilter` - Set channels and/or roles to be ignored by the link filter.",
-    "`ignoreWordFilter` - Set channels and/or roles to be ignored by the word filter.",
-    "`ignoreMentionFilter` - Set channels and/or roles to be ignored by the mention filter.",
+    "`ignoreInviteFilter`, `ignoreLinkFilter`, `ignoreWordFilter`, `ignoreMentionFilter`,  - Set channels and/or roles to be ignored by the invite, link, word & mention filters, respectively.",
     "`ignoreSlowMode` - Set channels and/or roles to be ignored by the slow mode.",
     "`ignoreStarboard` - Set channels and/or roles to be ignored by the starboard.",
     "`sellRole` - Sell roles in your server's Role Store.",

--- a/changes.json
+++ b/changes.json
@@ -44,7 +44,8 @@
   ],
   "COMMANDS WITH NEW USAGE": [
     "`addTrigger` command's usage syntax has been changed. It won't work the way it used to before, please check the help message for it, using the `help addTrigger` command, to see the new usage details.",
-    "`roleStore` command will only show the roles being sold in the server's Role Store. Use the new `sellRole` command to sell roles instead."
+    "`roleStore` command will only show the roles being sold in the server's Role Store. Use the new `sellRole` command to sell roles instead.",
+    "`report` command will now send user reports in the Report Channel, which can be set using the `reportChannel` command. The usage syntax has also been changed, please check the help message using `help report` to see the new usage details."
   ],
   "RENAMED COMMANDS": [
     "Renamed `ignoreChannel` & `ignoreRole` commands to `ignoreChannels` & `ignoreRoles`, respectively.",

--- a/commands/guild_admin/reportChannel.js
+++ b/commands/guild_admin/reportChannel.js
@@ -1,0 +1,53 @@
+/**
+ * @file reportChannel command
+ * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
+ * @license GPL-3.0
+ */
+
+exports.exec = async (Bastion, message) => {
+  try {
+    let guildModel = await Bastion.database.models.guild.findOne({
+      attributes: [ 'reportChannel' ],
+      where: {
+        guildID: message.guild.id
+      }
+    });
+
+    await Bastion.database.models.guild.update({
+      reportChannel: guildModel.dataValues.reportChannel ? null : message.channel.id
+    },
+    {
+      where: {
+        guildID: message.guild.id
+      },
+      fields: [ 'reportChannel' ]
+    });
+
+    message.channel.send({
+      embed: {
+        color: guildModel.dataValues.reportChannel ? Bastion.colors.RED : Bastion.colors.GREEN,
+        description: Bastion.i18n.info(message.guild.language, guildModel.dataValues.reportChannel ? 'disableReportChannel' : 'enableReportChannel', message.author.tag)
+      }
+    }).catch(e => {
+      Bastion.log.error(e);
+    });
+  }
+  catch (e) {
+    Bastion.log.error(e);
+  }
+};
+
+exports.config = {
+  aliases: [],
+  enabled: true
+};
+
+exports.help = {
+  name: 'reportChannel',
+  description: 'Adds/removes the channel as the report channel. If it\'s enabled, when users report server members using the `report` command, the reports will be posted in this channel.',
+  botPermission: '',
+  userTextPermission: 'MANAGE_GUILD',
+  userVoicePermission: '',
+  usage: 'reportChannel',
+  example: []
+};

--- a/commands/moderation/report.js
+++ b/commands/moderation/report.js
@@ -35,7 +35,7 @@ exports.exec = async (Bastion, message, args) => {
       }
 
       if (!user) {
-        return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notFound', 'users'), message.channel);
+        return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notFound', 'user'), message.channel);
       }
 
       if (message.author.id === user.id) return;

--- a/commands/moderation/report.js
+++ b/commands/moderation/report.js
@@ -6,7 +6,7 @@
 
 exports.exec = async (Bastion, message, args) => {
   try {
-    if (args.length < 2) {
+    if (!args.user || !args.reason) {
       /**
        * The command was ran with invalid parameters.
        * @fires commandUsage
@@ -14,45 +14,95 @@ exports.exec = async (Bastion, message, args) => {
       return Bastion.emit('commandUsage', message, this.help);
     }
 
-    let user;
-    if (message.mentions.users.size) {
-      user = message.mentions.users.first();
-    }
-    else if (args[0]) {
-      user = await Bastion.fetchUser(args[0]);
-    }
-    if (!user) {
-      /**
-       * The command was ran with invalid parameters.
-       * @fires commandUsage
-       */
-      return Bastion.emit('commandUsage', message, this.help);
-    }
 
-    if (message.author.id === user.id) return;
-
-    let reason = args.slice(1).join(' ');
-    if (reason.length < 1) {
-      reason = 'No reason given';
-    }
-
-    message.channel.send({
-      embed: {
-        color: Bastion.colors.GREEN,
-        title: 'User Reported',
-        description: Bastion.i18n.info(message.guild.language, 'report', message.author.tag, user.tag, reason)
+    let guildModel = await Bastion.database.models.guild.findOne({
+      attributes: [ 'reportChannel' ],
+      where: {
+        guildID: message.guild.id
       }
-    }).then(message => {
-      message.delete(5000).catch(() => {});
-    }).catch(e => {
-      Bastion.log.error(e);
     });
 
-    /**
-     * Logs moderation events if it is enabled
-     * @fires moderationLog
-     */
-    Bastion.emit('moderationLog', message, this.help.name, user, reason);
+    if (guildModel && guildModel.dataValues.reportChannel && message.guild.channels.has(guildModel.dataValues.reportChannel)) {
+      let user;
+      if (args.user.startsWith('<@') && message.mentions.users.size) {
+        user = message.mentions.users.first();
+      }
+      else {
+        let member = message.guild.members.get(args.user);
+        if (member) {
+          user = member.user;
+        }
+      }
+
+      if (!user) {
+        return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notFound', 'users'), message.channel);
+      }
+
+      if (message.author.id === user.id) return;
+
+      args.reason = args.reason.join(' ');
+
+
+      let reportChannel = message.guild.channels.get(guildModel.dataValues.reportChannel);
+      reportChannel.send({
+        embed: {
+          color: Bastion.colors.ORANGE,
+          title: 'User Report',
+          fields: [
+            {
+              name: 'User',
+              value: user.tag,
+              inline: true
+            },
+            {
+              name: 'User ID',
+              value: user.id,
+              inline: true
+            },
+            {
+              name: 'Report',
+              value: args.reason
+            }
+          ],
+          footer: {
+            text: `Reported by ${message.author.tag} / ${message.author.id}`
+          },
+          timestamp: new Date()
+        }
+      }).catch(e => {
+        Bastion.log.error(e);
+      });
+
+
+      message.channel.send({
+        embed: {
+          color: Bastion.colors.GREEN,
+          title: 'User Reported',
+          description: Bastion.i18n.info(message.guild.language, 'report', message.author.tag, user.tag, args.reason)
+        }
+      }).then(successMessage => {
+        if (message.deletable) {
+          message.delete().catch(() => {});
+        }
+        successMessage.delete(10000).catch(() => {});
+      }).catch(e => {
+        Bastion.log.error(e);
+      });
+    }
+    else {
+      message.channel.send({
+        embed: {
+          color: Bastion.colors.RED,
+          description: Bastion.i18n.error(message.guild.language, 'noReportChannel', message.author.tag)
+        }
+      }).then(() => {
+        if (message.deletable) {
+          message.delete().catch(() => {});
+        }
+      }).catch(e => {
+        Bastion.log.error(e);
+      });
+    }
   }
   catch (e) {
     Bastion.log.error(e);
@@ -61,15 +111,19 @@ exports.exec = async (Bastion, message, args) => {
 
 exports.config = {
   aliases: [],
-  enabled: true
+  enabled: true,
+  argsDefinitions: [
+    { name: 'user', type: String, defaultOption: true },
+    { name: 'reason', alias: 'r', type: String, multiple: true }
+  ]
 };
 
 exports.help = {
   name: 'report',
-  description: 'Reports a user of your Discord server. *Moderation logs needs to be enabled.*',
+  description: 'Reports a user of your Discord server to the server staffs. *Report Channel needs to be set.*',
   botPermission: '',
   userTextPermission: '',
   userVoicePermission: '',
-  usage: 'report < @USER_MENTION | USER_ID > <REASON >',
-  example: [ 'report 215052539542571701 Reason for reporting.', 'report @user#0001 Reason for reporting.' ]
+  usage: 'report < @USER_MENTION | USER_ID > < -r REASON >',
+  example: [ 'report 215052539542571701 -r DM advertisement', 'report @user#0001 -r Trolling everyone' ]
 };

--- a/data/commands.json
+++ b/data/commands.json
@@ -775,6 +775,10 @@
     "description": "Reports a user of your Discord server. *Moderation logs needs to be enabled.*",
     "module": "Moderation"
   },
+  "reportChannel": {
+    "description": "Adds/removes the channel as the report channel. If it's enabled, when users report server members using the `report` command, the reports will be posted in this channel.",
+    "module": "Guild Admin"
+  },
   "reputation": {
     "description": "Give reputations to other users. You can give reputation only once in 12 hours.",
     "module": "Fun"

--- a/data/commands.json
+++ b/data/commands.json
@@ -772,7 +772,7 @@
     "module": "Music"
   },
   "report": {
-    "description": "Reports a user of your Discord server. *Moderation logs needs to be enabled.*",
+    "description": "Reports a user of your Discord server to the server staffs. *Report Channel needs to be set.*",
     "module": "Moderation"
   },
   "reportChannel": {

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -579,7 +579,7 @@
     "description": "Adds the current song to the repeat queue, so it will repeat once again after the current playback is complete."
   },
   "report": {
-    "description": "Reports a user of your Discord server. *Moderation logs needs to be enabled.*"
+    "description": "Reports a user of your Discord server to the server staffs. *Report Channel needs to be set.*"
   },
   "reportChannel": {
     "description": "Adds/removes the channel as the report channel. If it's enabled, when users report server members using the `report` command, the reports will be posted in this channel."

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -581,6 +581,9 @@
   "report": {
     "description": "Reports a user of your Discord server. *Moderation logs needs to be enabled.*"
   },
+  "reportChannel": {
+    "description": "Adds/removes the channel as the report channel. If it's enabled, when users report server members using the `report` command, the reports will be posted in this channel."
+  },
   "reputation": {
     "description": "Give reputations to other users. You can give reputation only once in 12 hours."
   },

--- a/locales/en_us/error.json
+++ b/locales/en_us/error.json
@@ -40,6 +40,7 @@
   "noDeletableMessage": "No message was found that could be deleted.",
   "noLiveStream": "No live stream found for the channel %var%.",
   "noPermission": "I do not have permission to %var% %var%.",
+  "noReportChannel": "%var% your user report did not reach the server staffs. Please ask the server managers to enable user report channel using the `reportChannel` command.",
   "notFound": "No %var% was found for the specified parameters.",
   "notPlaying": "No song is currently being played.",
   "notSet": "You have not set any %var%.",

--- a/locales/en_us/info.json
+++ b/locales/en_us/info.json
@@ -59,6 +59,8 @@
   "enableStreamerRole": "%var% set the streamer role to **%var%**",
   "disableSuggestionChannel": "%var% removed the suggestion channel of this server. Users can now post suggestions in any channel.",
   "enableSuggestionChannel": "%var% set this channel as the suggestion channel of this server. When users post a suggestion using the `suggest` command, it will be logged in this channel.",
+  "disableReportChannel": "%var% removed the report channel of this server. User reports won't be received anywhere, anymore.",
+  "enableReportChannel": "%var% set this channel as the report channel of this server. When users report any server member, using the `report` command, it will be posted in this channel.",
 
   "addRole": "%var% added the **%var%** role to **%var%**",
   "ban": "%var% banned **%var%** with the reason **%var%**",

--- a/locales/en_us/info.json
+++ b/locales/en_us/info.json
@@ -72,7 +72,7 @@
   "removeAllRoles": "%var% removed all the roles from **%var%**",
   "removeNickname": "%var% removed the nickname of **%var%**",
   "removeRole": "%var% removed the **%var%** role from **%var%**",
-  "report": "%var% reported %var% to the moderators with the reason **%var%**. Hold tight, they will look into it.",
+  "report": "%var% you've successfully reported %var% to the server staffs with the reason **%var%**. Hold tight, they will look into it.",
   "setNickname": "%var% set the nickname of **%var%** to **%var%**",
   "softBan": "%var% soft-banned **%var%** with the reason **%var%**",
   "softBanDM": "%var% soft-banned you from **%var%** server with the reason **%var%**",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.18",
+  "version": "7.0.0-alpha.19",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",


### PR DESCRIPTION
This PR changes how user reporting works in Bastion.
* Bastion will now have a new Report Channel, where user reports will be received. No need to enable Moderation Logs and set Moderation Channel if a guild just want User Reports.
* Added `reportChannel` command to (un)set Report Channel.
* Rewritten `report` command to work with the above mentioned changes. Its usage has also been changed.

#### Possible drawbacks
None

#### Applicable Issues:
\-

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
