### PR TITLE
Members Only mode

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "June 4, 2018",
+  "date": "June 5, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [],
   "THESE ABILITIES HAVE ENHANCED": [
@@ -18,16 +18,16 @@
     "Tons of under-the-hood improvements & changes."
   ],
   "NEW FEATURES!": [
-    "Set the amount of data shown in the terminal logs by modifying the value of `logLevel` key in config",
+    "Set the amount of data shown in the terminal by modifying the value of `logLevel` key in config",
     "Levels & currencies aren't global anymore. Members have separate currency & level in every server",
     "You can now `give` & `take` any amount of Bastion Currencies to/from any member of your server",
     "Give as much XP as you want to your server members, using the `giveXP` command",
-    "Tired of looking through the moderation logs just to find a specific case? Use the `case` command to fetch any case from the moderation logs",
+    "Tired of looking through the moderation logs to find a specific case? Use the `case` command to fetch any case from the moderation logs",
     "Using the `claim` command daily will count towards your daily streak. If you get a streak of 7 days, you'll can get a bonus of upto 700 BC",
-    "Triggers aren't global anymore. There are now different triggers & responses for different servers",
-    "Triggers aren't owner only anymore! You can now set triggers & responses in the servers you manage",
-    "Triggers can now respond with reactions & embeds along with plain text responses",
-    "Users can now have different music playlists in different servers"
+    "Triggers aren't global & owner only anymore. There are now different triggers & responses for different servers & can be used by you in the servers you manage.",
+    "Trigger responses now support reactions & message embeds too!",
+    "Users can now have different music playlists in different servers",
+    "Members Only mode to allow only users with roles to use the commands."
   ],
   "NEW COMMANDS!": [
     "`blacklist` - Blacklist users globally from using Bastion.",
@@ -40,7 +40,8 @@
     "`toggleBastion` - Toggle Bastion in the server.",
     "`setColor` - Set User Color to use the specified color for yourself in appropriate places like in your Bastion Profile.",
     "`toggleLevelUps` - Toggle gaining XP and leveling up while chatting.",
-    "`reportChannel` - (Un)Set report channel of the server."
+    "`reportChannel` - (Un)Set report channel of the server.",
+    "`membersOnly` - Toggle Members Only mode."
   ],
   "COMMANDS WITH NEW USAGE": [
     "`addTrigger` command's usage syntax has been changed. It won't work the way it used to before, please check the help message for it, using the `help addTrigger` command, to see the new usage details.",

--- a/commands/guild_admin/membersOnly.js
+++ b/commands/guild_admin/membersOnly.js
@@ -1,0 +1,53 @@
+/**
+ * @file membersOnly command
+ * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
+ * @license GPL-3.0
+ */
+
+exports.exec = async (Bastion, message) => {
+  try {
+    let guildModel = await Bastion.database.models.guild.findOne({
+      attributes: [ 'membersOnly' ],
+      where: {
+        guildID: message.guild.id
+      }
+    });
+
+    await Bastion.database.models.guild.update({
+      membersOnly: !guildModel.dataValues.membersOnly
+    },
+    {
+      where: {
+        guildID: message.guild.id
+      },
+      fields: [ 'membersOnly' ]
+    });
+
+    message.channel.send({
+      embed: {
+        color: Bastion.colors[guildModel.dataValues.membersOnly ? 'RED' : 'GREEN'],
+        description: Bastion.i18n.info(message.guild.language, guildModel.dataValues.membersOnly ? 'disableMembersOnly' : 'enableMembersOnly', message.author.tag)
+      }
+    }).catch(e => {
+      Bastion.log.error(e);
+    });
+  }
+  catch (e) {
+    Bastion.log.error(e);
+  }
+};
+
+exports.config = {
+  aliases: [],
+  enabled: true
+};
+
+exports.help = {
+  name: 'membersOnly',
+  description: 'Toggles Members Only mode of Bastion. If Members Only mode is enabled only users with at least one role in the server can use Bastion\'s Commands.',
+  botPermission: '',
+  userTextPermission: 'MANAGE_GUILD',
+  userVoicePermission: '',
+  usage: 'membersOnly',
+  example: []
+};

--- a/data/commands.json
+++ b/data/commands.json
@@ -579,6 +579,10 @@
     "description": "Get the map of the specified location.",
     "module": "Queries"
   },
+  "membersOnly": {
+    "description": "Toggles Members Only mode of Bastion. If Members Only mode is enabled only users with at least one role in the server can use Bastion's Commands.",
+    "module": "Guild Admin"
+  },
   "messageChannel": {
     "description": "Send a specified message to any specified text channel that Bastion has access to.",
     "module": "Owner"

--- a/handlers/commandHandler.js
+++ b/handlers/commandHandler.js
@@ -17,7 +17,7 @@ const activeUsers = {};
 module.exports = async message => {
   try {
     let guildModel = await message.client.database.models.guild.findOne({
-      attributes: [ 'enabled', 'prefix', 'language', 'music', 'musicTextChannel', 'musicVoiceChannel', 'musicMasterRole', 'disabledCommands' ],
+      attributes: [ 'enabled', 'prefix', 'language', 'membersOnly', 'music', 'musicTextChannel', 'musicVoiceChannel', 'musicMasterRole', 'disabledCommands' ],
       where: {
         guildID: message.guild.id
       },
@@ -34,6 +34,10 @@ module.exports = async message => {
     });
 
     if (!guildModel.dataValues.enabled && !message.member.hasPermission('MANAGE_GUILD')) return;
+
+    // Members Only mode. It's < 2 because the everyone has the @everyone role
+    // by default which counts as 1.
+    if (guildModel.dataValues.membersOnly && !message.member.hasPermission('MANAGE_GUILD') && message.member.roles.size < 2) return;
 
     // Add guild's prefix to the discord.js guild object to minimize database reads.
     guildModel.dataValues.prefix.concat(message.client.config.prefix);

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -434,6 +434,9 @@
   "map": {
     "description": "Get the map of the specified location."
   },
+  "membersOnly": {
+    "description": "Toggles Members Only mode of Bastion. If Members Only mode is enabled only users with at least one role in the server can use Bastion's Commands."
+  },
   "messageChannel": {
     "description": "Send a specified message to any specified text channel that Bastion has access to."
   },

--- a/locales/en_us/info.json
+++ b/locales/en_us/info.json
@@ -44,6 +44,8 @@
   "removeLevelUpRoles": "%var% removed all level up roles from level **%var%**.",
   "disableLevelUps": "%var% disabled level ups in this server. Users won't be able to gain experience points and level up while chatting.",
   "enableLevelUps": "%var% enabled level ups in this server. Users will now be able to gain experience points and level up as they chat.",
+  "disableMembersOnly": "%var% disabled Members Only mode in this server. Bastion's Commands can now be used by any member of this server.",
+  "enableMembersOnly": "%var% enabled Members Only mode in this server. Bastion's Commands can now only be used by members with at least one role.",
   "disableServerLog": "%var% disabled logging of server events.",
   "enableServerLog": "%var% enabled logging of server events, in this channel.",
   "disableModerationLog": "%var% disabled logging of moderation actions in this server.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.19",
+  "version": "7.0.0-alpha.20",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",

--- a/utils/models.js
+++ b/utils/models.js
@@ -204,7 +204,7 @@ module.exports = (Sequelize, database) => {
     disabledCommands: {
       type: Sequelize.JSON
     },
-    onlyMembersWithRoles: {
+    membersOnly: {
       type: Sequelize.BOOLEAN,
       allowNull: false,
       defaultValue: false


### PR DESCRIPTION
This PR adds a **Members Only** mode to Bastion.
If members only mode is enabled in a guild, only the members with at least one role (excluding the `@everyone` role) can use Bastion's commands. This will be useful for communities that use roles for trusted membership and only want trusted members to use Bastion.
* Added the `membersOnly` command to toggle the **Members Only** mode in a guild.

#### Possible drawbacks
None

#### Applicable Issues:
\-

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
