### PR TITLE
Reaction Pinning

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -19,15 +19,16 @@
   ],
   "NEW FEATURES!": [
     "Set the amount of data shown in the terminal by modifying the value of `logLevel` key in config",
-    "Levels & currencies aren't global anymore. Members have separate currency & level in every server",
+    "Members have separate currency & level in every server",
     "You can now `give` & `take` any amount of Bastion Currencies to/from any member of your server",
-    "Give as much XP as you want to your server members, using the `giveXP` command",
+    "Give as much XP as you want to your server members using the `giveXP` command",
     "Tired of looking through the moderation logs to find a specific case? Use the `case` command to fetch any case from the moderation logs",
     "Using the `claim` command daily will count towards your daily streak. If you get a streak of 7 days, you'll can get a bonus of upto 700 BC",
-    "Triggers aren't global & owner only anymore. There are now different triggers & responses for different servers & can be used by you in the servers you manage.",
+    "Each servers can have their own triggers & responses",
     "Trigger responses now support reactions & message embeds too!",
     "Users can now have different music playlists in different servers",
-    "Members Only mode to allow only users with roles to use the commands."
+    "Members Only mode to allow only users with roles to use the commands.",
+    "You can now pin a message to the channel just by adding either 📌 or 📍 reaction to a message"
   ],
   "NEW COMMANDS!": [
     "`blacklist` - Blacklist users globally from using Bastion.",
@@ -41,12 +42,14 @@
     "`setColor` - Set User Color to use the specified color for yourself in appropriate places like in your Bastion Profile.",
     "`toggleLevelUps` - Toggle gaining XP and leveling up while chatting.",
     "`reportChannel` - (Un)Set report channel of the server.",
-    "`membersOnly` - Toggle Members Only mode."
+    "`membersOnly` - Toggle Members Only mode.",
+    "`reactionPinning` - Toggle Reaction Pinning."
   ],
   "COMMANDS WITH NEW USAGE": [
     "`addTrigger` command's usage syntax has been changed. It won't work the way it used to before, please check the help message for it, using the `help addTrigger` command, to see the new usage details.",
     "`roleStore` command will only show the roles being sold in the server's Role Store. Use the new `sellRole` command to sell roles instead.",
-    "`report` command will now send user reports in the Report Channel, which can be set using the `reportChannel` command. The usage syntax has also been changed, please check the help message using `help report` to see the new usage details."
+    "`report` command will now send user reports in the Report Channel, which can be set using the `reportChannel` command. The usage syntax has also been changed, please check the help message using `help report` to see the new usage details.",
+    "Trigger commands can now be used by anyone with Manage Server permission."
   ],
   "RENAMED COMMANDS": [
     "Renamed `ignoreChannel` & `ignoreRole` commands to `ignoreChannels` & `ignoreRoles`, respectively.",

--- a/commands/guild_admin/reactionPinning.js
+++ b/commands/guild_admin/reactionPinning.js
@@ -44,7 +44,7 @@ exports.config = {
 
 exports.help = {
   name: 'reactionPinning',
-  description: 'Toggles Members Only mode of Bastion. If Members Only mode is enabled only users with at least one role in the server can use Bastion\'s Commands.',
+  description: 'Toggles Reaction Pinning in the server. If Reaction Pinning is enabled, adding either 📌 or 📍 reaction to a message will pin the message to the channel and removing the reactions will unpin it too.',
   botPermission: '',
   userTextPermission: 'MANAGE_GUILD',
   userVoicePermission: '',

--- a/commands/guild_admin/reactionPinning.js
+++ b/commands/guild_admin/reactionPinning.js
@@ -1,0 +1,53 @@
+/**
+ * @file reactionPinning command
+ * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
+ * @license GPL-3.0
+ */
+
+exports.exec = async (Bastion, message) => {
+  try {
+    let guildModel = await Bastion.database.models.guild.findOne({
+      attributes: [ 'reactionPinning' ],
+      where: {
+        guildID: message.guild.id
+      }
+    });
+
+    await Bastion.database.models.guild.update({
+      reactionPinning: !guildModel.dataValues.reactionPinning
+    },
+    {
+      where: {
+        guildID: message.guild.id
+      },
+      fields: [ 'reactionPinning' ]
+    });
+
+    message.channel.send({
+      embed: {
+        color: Bastion.colors[guildModel.dataValues.reactionPinning ? 'RED' : 'GREEN'],
+        description: Bastion.i18n.info(message.guild.language, guildModel.dataValues.reactionPinning ? 'disableReactionPinning' : 'enableReactionPinning', message.author.tag)
+      }
+    }).catch(e => {
+      Bastion.log.error(e);
+    });
+  }
+  catch (e) {
+    Bastion.log.error(e);
+  }
+};
+
+exports.config = {
+  aliases: [],
+  enabled: true
+};
+
+exports.help = {
+  name: 'reactionPinning',
+  description: 'Toggles Members Only mode of Bastion. If Members Only mode is enabled only users with at least one role in the server can use Bastion\'s Commands.',
+  botPermission: '',
+  userTextPermission: 'MANAGE_GUILD',
+  userVoicePermission: '',
+  usage: 'reactionPinning',
+  example: []
+};

--- a/data/commands.json
+++ b/data/commands.json
@@ -720,7 +720,7 @@
     "module": "Info"
   },
   "reactionPinning": {
-    "description": "Toggles Members Only mode of Bastion. If Members Only mode is enabled only users with at least one role in the server can use Bastion's Commands.",
+    "description": "Toggles Reaction Pinning in the server. If Reaction Pinning is enabled, adding either 📌 or 📍 reaction to a message will pin the message to the channel and removing the reactions will unpin it too.",
     "module": "Guild Admin"
   },
   "reason": {

--- a/data/commands.json
+++ b/data/commands.json
@@ -719,6 +719,10 @@
     "description": "Shows the rank of the specified user's account.",
     "module": "Info"
   },
+  "reactionPinning": {
+    "description": "Toggles Members Only mode of Bastion. If Members Only mode is enabled only users with at least one role in the server can use Bastion's Commands.",
+    "module": "Guild Admin"
+  },
   "reason": {
     "description": "Add/Update the reason for a moderation action, which is logged in the moderation log channel. Only the responsible moderator or anyone with administrator permissions can change the reason.",
     "module": "Moderation"

--- a/events/messageReactionAdd.js
+++ b/events/messageReactionAdd.js
@@ -9,7 +9,6 @@ let starredMessages = [];
 module.exports = async (reaction, user) => {
   try {
     if (!reaction.message.guild) return;
-    if (reaction.message.author.id === user.id) return;
 
     let guildModel = await user.client.database.models.guild.findOne({
       attributes: [ 'starboard' ],
@@ -28,57 +27,61 @@ module.exports = async (reaction, user) => {
       ]
     });
 
-    if (!guildModel || !guildModel.dataValues.starboard) return;
-    if (!reaction.message.content) return;
-    if (starredMessages.includes(reaction.message.id)) return;
+    if (!guildModel) return;
 
-    let stars = [ '🌟', '⭐' ];
-    if (!stars.includes(reaction.emoji.name)) return;
+    if (guildModel.dataValues.starboard) {
+      if (reaction.message.author.id === user.id) return;
+      if (!reaction.message.content) return;
+      if (starredMessages.includes(reaction.message.id)) return;
 
-    let starboardIgnoredChannels = guildModel.textChannels.length && guildModel.textChannels.filter(model => model.dataValues.ignoreStarboard).map(model => model.dataValues.channelID);
-    if (starboardIgnoredChannels && starboardIgnoredChannels.includes(reaction.message.channel.id)) return;
-    let starboardIgnoredRoles = guildModel.roles.length && guildModel.roles.filter(model => model.dataValues.ignoreStarboard).map(model => model.dataValues.roleID);
-    if (starboardIgnoredRoles && reaction.message.member.roles.some(role => starboardIgnoredRoles.includes(role.id))) return;
+      let stars = [ '🌟', '⭐' ];
+      if (!stars.includes(reaction.emoji.name)) return;
 
-    let image;
-    if (reaction.message.attachments.size) {
-      if (reaction.message.attachments.first().height) {
-        image = reaction.message.attachments.first().url;
-      }
-    }
+      let starboardIgnoredChannels = guildModel.textChannels.length && guildModel.textChannels.filter(model => model.dataValues.ignoreStarboard).map(model => model.dataValues.channelID);
+      if (starboardIgnoredChannels && starboardIgnoredChannels.includes(reaction.message.channel.id)) return;
+      let starboardIgnoredRoles = guildModel.roles.length && guildModel.roles.filter(model => model.dataValues.ignoreStarboard).map(model => model.dataValues.roleID);
+      if (starboardIgnoredRoles && reaction.message.member.roles.some(role => starboardIgnoredRoles.includes(role.id))) return;
 
-    if (!image && !reaction.message.content) return;
-
-    let starboardChannel = reaction.message.guild.channels.get(guildModel.dataValues.starboard);
-    if (starboardChannel) {
-      await starboardChannel.send({
-        embed: {
-          color: user.client.colors.GOLD,
-          author: {
-            name: reaction.message.author.tag,
-            icon_url: reaction.message.author.displayAvatarURL
-          },
-          description: reaction.message.content,
-          fields: [
-            {
-              name: 'Channel',
-              value: reaction.message.channel.toString(),
-              inline: true
-            },
-            {
-              name: 'Message ID',
-              value: reaction.message.id,
-              inline: true
-            }
-          ],
-          image: {
-            url: image
-          },
-          timestamp: reaction.message.createdAt
+      let image;
+      if (reaction.message.attachments.size) {
+        if (reaction.message.attachments.first().height) {
+          image = reaction.message.attachments.first().url;
         }
-      });
+      }
+
+      if (!image && !reaction.message.content) return;
+
+      let starboardChannel = reaction.message.guild.channels.get(guildModel.dataValues.starboard);
+      if (starboardChannel) {
+        await starboardChannel.send({
+          embed: {
+            color: user.client.colors.GOLD,
+            author: {
+              name: reaction.message.author.tag,
+              icon_url: reaction.message.author.displayAvatarURL
+            },
+            description: reaction.message.content,
+            fields: [
+              {
+                name: 'Channel',
+                value: reaction.message.channel.toString(),
+                inline: true
+              },
+              {
+                name: 'Message ID',
+                value: reaction.message.id,
+                inline: true
+              }
+            ],
+            image: {
+              url: image
+            },
+            timestamp: reaction.message.createdAt
+          }
+        });
+      }
+      starredMessages.push(reaction.message.id);
     }
-    starredMessages.push(reaction.message.id);
   }
   catch (e) {
     user.client.log.error(e);

--- a/events/messageReactionAdd.js
+++ b/events/messageReactionAdd.js
@@ -11,7 +11,7 @@ module.exports = async (reaction, user) => {
     if (!reaction.message.guild) return;
 
     let guildModel = await user.client.database.models.guild.findOne({
-      attributes: [ 'starboard' ],
+      attributes: [ 'reactionPinning', 'starboard' ],
       where: {
         guildID: reaction.message.guild.id
       },
@@ -28,6 +28,17 @@ module.exports = async (reaction, user) => {
     });
 
     if (!guildModel) return;
+
+    if (guildModel.dataValues.reactionPinning) {
+      let pins = [ '📌', '📍' ];
+      if (!pins.includes(reaction.emoji.name)) return;
+
+      if (!reaction.message.channel.permissionsFor(user).has('MANAGE_MESSAGES')) return;
+
+      if (!reaction.message.pinned) {
+        await reaction.message.pin();
+      }
+    }
 
     if (guildModel.dataValues.starboard) {
       if (reaction.message.author.id === user.id) return;

--- a/events/messageReactionRemove.js
+++ b/events/messageReactionRemove.js
@@ -6,7 +6,27 @@
 
 module.exports = async (reaction, user) => {
   try {
-    // TODO: reaction pinning removal logic
+    if (!reaction.message.guild) return;
+
+    let guildModel = await user.client.database.models.guild.findOne({
+      attributes: [ 'reactionPinning' ],
+      where: {
+        guildID: reaction.message.guild.id
+      }
+    });
+
+    if (!guildModel) return;
+
+    if (guildModel.dataValues.reactionPinning) {
+      let pins = [ '📌', '📍' ];
+      if (!pins.includes(reaction.emoji.name)) return;
+
+      let authorizedUsers = reaction.users.filter(user => reaction.message.channel.permissionsFor(user).has('MANAGE_MESSAGES'));
+
+      if (authorizedUsers.size === 0 && reaction.message.pinned) {
+        await reaction.message.unpin();
+      }
+    }
   }
   catch (e) {
     user.client.log.error(e);

--- a/events/messageReactionRemove.js
+++ b/events/messageReactionRemove.js
@@ -1,0 +1,14 @@
+/**
+ * @file messageReactionRemove event
+ * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
+ * @license GPL-3.0
+ */
+
+module.exports = async (reaction, user) => {
+  try {
+    // TODO: reaction pinning removal logic
+  }
+  catch (e) {
+    user.client.log.error(e);
+  }
+};

--- a/handlers/eventHandler.js
+++ b/handlers/eventHandler.js
@@ -87,7 +87,7 @@ module.exports = Bastion => {
   Bastion.on('message', LOAD_EVENTS('message'));
   /**
    * Emitted whenever a reaction is added to a message.
-   * @listens message
+   * @listens messageReactionAdd
    */
   Bastion.on('messageReactionAdd', LOAD_EVENTS('messageReactionAdd'));
   /**

--- a/handlers/eventHandler.js
+++ b/handlers/eventHandler.js
@@ -91,6 +91,11 @@ module.exports = Bastion => {
    */
   Bastion.on('messageReactionAdd', LOAD_EVENTS('messageReactionAdd'));
   /**
+   * Emitted whenever a reaction is removed from a message.
+   * @listens messageReactionRemove
+   */
+  Bastion.on('messageReactionRemove', LOAD_EVENTS('messageReactionRemove'));
+  /**
    * Emitted whenever a message is updated - e.g. embed or content change.
    * @listens messageUpdate
    */

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -539,6 +539,9 @@
   "rank": {
     "description": "Shows the rank of the specified user's account."
   },
+  "reactionPinning": {
+    "description": "Toggles Members Only mode of Bastion. If Members Only mode is enabled only users with at least one role in the server can use Bastion's Commands."
+  },
   "reason": {
     "description": "Add/Update the reason for a moderation action, which is logged in the moderation log channel. Only the responsible moderator or anyone with administrator permissions can change the reason."
   },

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -540,7 +540,7 @@
     "description": "Shows the rank of the specified user's account."
   },
   "reactionPinning": {
-    "description": "Toggles Members Only mode of Bastion. If Members Only mode is enabled only users with at least one role in the server can use Bastion's Commands."
+    "description": "Toggles Reaction Pinning in the server. If Reaction Pinning is enabled, adding either 📌 or 📍 reaction to a message will pin the message to the channel and removing the reactions will unpin it too."
   },
   "reason": {
     "description": "Add/Update the reason for a moderation action, which is logged in the moderation log channel. Only the responsible moderator or anyone with administrator permissions can change the reason."

--- a/locales/en_us/info.json
+++ b/locales/en_us/info.json
@@ -46,6 +46,8 @@
   "enableLevelUps": "%var% enabled level ups in this server. Users will now be able to gain experience points and level up as they chat.",
   "disableMembersOnly": "%var% disabled Members Only mode in this server. Bastion's Commands can now be used by any member of this server.",
   "enableMembersOnly": "%var% enabled Members Only mode in this server. Bastion's Commands can now only be used by members with at least one role.",
+  "disableReactionPinning": "%var% disabled Reaction Pinning in this server.",
+  "enableReactionPinning": "%var% enabled Reaction Pinning in this server. Adding either 📌 or 📍 reaction to a message will pin the message to the channel and removing the reactions will unpin it too.",
   "disableServerLog": "%var% disabled logging of server events.",
   "enableServerLog": "%var% enabled logging of server events, in this channel.",
   "disableModerationLog": "%var% disabled logging of moderation actions in this server.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.20",
+  "version": "7.0.0-alpha.21",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",

--- a/utils/models.js
+++ b/utils/models.js
@@ -224,7 +224,7 @@ module.exports = (Sequelize, database) => {
       allowNull: false,
       defaultValue: false
     },
-    reactionPinsMessage: {
+    reactionPinning: {
       type: Sequelize.BOOLEAN,
       allowNull: false,
       defaultValue: false


### PR DESCRIPTION
This PR adds **Reaction Pinning** feature to Bastion.

If any user with `MANAGE_MESSAGES` permission adds either 📌 or 📍 reaction to a message, Bastion will pin the message to the channel, provided that Reaction Pinning is enabled in the server.
Also, if all of either the 📌 or 📍 reactions (by guild members with `MANAGE_MESSAGES` permission) are removed from a pinned message, the message will be unpinned from that channel, provided that Reaction Pinning is enabled in the server.

* Added `reactionPinning` command to enable/disable Reaction Pinning in the server.
* Added `messageReactionRemove` Discord event.

#### Possible drawbacks
None

#### Applicable Issues:
\-

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
