### PR TITLE
Warnings Rewrite

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "June 11, 2018",
+  "date": "June 13, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [],
   "THESE ABILITIES HAVE ENHANCED": [
@@ -13,8 +13,9 @@
     "`currencyGiveaway` command isn't bot owner only anymore! You can now use it in your own servers to do Bastion Currency giveaways",
     "Trigger response supports a whole bunch of variables now",
     "`roleInfo` & `serverInfo` commands will now show the role & server description, if you've set it.",
-    "Show if a server is a Bastion premium server in the `serverInfo` command. Premium servers & perks are coming soon™!",
+    "Show if a server is a Bastion premium server in the `serverInfo` command.",
     "Adding music from user playlist to the queue is now faster than ever.",
+    "Warnings are now permanently stored!",
     "Tons of under-the-hood improvements & changes."
   ],
   "NEW FEATURES!": [

--- a/commands/moderation/clearWarn.js
+++ b/commands/moderation/clearWarn.js
@@ -15,33 +15,30 @@ exports.exec = async (Bastion, message, args) => {
     }
     if (!user) {
       /**
-      * The command was ran with invalid parameters.
-      * @fires commandUsage
-      */
+       * The command was ran with invalid parameters.
+       * @fires commandUsage
+       */
       return Bastion.emit('commandUsage', message, this.help);
     }
 
     let member = await message.guild.fetchMember(user.id);
     if (message.author.id !== message.guild.ownerID && message.member.highestRole.comparePositionTo(member.highestRole) <= 0) return Bastion.log.info(Bastion.i18n.error(message.guild.language, 'lowerRole'));
 
+
+    await message.client.database.models.guildMember.update({
+      warnings: null
+    },
+    {
+      where: {
+        userID: member.id,
+        guildID: message.guild.id
+      },
+      fields: [ 'warnings' ]
+    });
+
+
     args.reason = args.reason.join(' ');
 
-    if (!message.guild.warns) {
-      /**
-      * Error condition is encountered.
-      * @fires error
-      */
-      return Bastion.emit('error', '', 'Everyone is decent here, no one has been warned.', message.channel);
-    }
-    if (!message.guild.warns.hasOwnProperty(user.id)) {
-      /**
-      * Error condition is encountered.
-      * @fires error
-      */
-      return Bastion.emit('error', '', `Nah, ${user.tag} is good guy, he hasn't been warned.`, message.channel);
-    }
-
-    delete message.guild.warns[user.id];
     message.channel.send({
       embed: {
         color: Bastion.colors.GREEN,
@@ -52,9 +49,9 @@ exports.exec = async (Bastion, message, args) => {
     });
 
     /**
-    * Logs moderation events if it is enabled
-    * @fires moderationLog
-    */
+     * Logs moderation events if it is enabled
+     * @fires moderationLog
+     */
     Bastion.emit('moderationLog', message, this.help.name, user, args.reason);
   }
   catch (e) {

--- a/commands/moderation/warn.js
+++ b/commands/moderation/warn.js
@@ -15,119 +15,53 @@ exports.exec = async (Bastion, message, args) => {
     }
     if (!user) {
       /**
-      * The command was ran with invalid parameters.
-      * @fires commandUsage
-      */
+       * The command was ran with invalid parameters.
+       * @fires commandUsage
+       */
       return Bastion.emit('commandUsage', message, this.help);
     }
+
 
     let member = await message.guild.fetchMember(user.id);
     if (message.author.id !== message.guild.ownerID && message.member.highestRole.comparePositionTo(member.highestRole) <= 0) return Bastion.log.info(Bastion.i18n.error(message.guild.language, 'lowerRole'));
 
     args.reason = args.reason.join(' ');
 
-    if (!message.guild.warns) {
-      message.guild.warns = {};
-    }
-    if (!message.guild.warns.hasOwnProperty(user.id)) {
-      message.guild.warns[user.id] = 1;
-    }
-    else {
-      if (message.guild.warns[user.id] >= 2) {
-        let guildModel = await message.client.database.models.guild.findOne({
-          attributes: [ 'warnAction' ],
-          where: {
-            guildID: message.guild.id
-          }
-        });
-        if (!guildModel || !guildModel.dataValues.warnAction) return;
 
-        if (guildModel.dataValues.warnAction) {
-          let action;
-          if (guildModel.dataValues.warnAction === 'kick') {
-            if (!member.kickable) {
-              /**
-              * Error condition is encountered.
-              * @fires error
-              */
-              return Bastion.emit('error', '', `I don't have permissions to kick ${user}.`, message.channel);
-            }
-            await member.kick('Warned 3 times!');
-            action = 'Kicked';
-          }
-          if (guildModel.dataValues.warnAction === 'softban') {
-            if (!member.bannable) {
-              /**
-              * Error condition is encountered.
-              * @fires error
-              */
-              return Bastion.emit('error', '', `I don't have permissions to soft-ban ${user}.`, message.channel);
-            }
-            await member.ban('Warned 3 times!');
-            await message.guild.unban(member.id);
-            action = 'Soft-Banned';
-          }
-          if (guildModel.dataValues.warnAction === 'ban') {
-            if (!member.bannable) {
-              /**
-              * Error condition is encountered.
-              * @fires error
-              */
-              return Bastion.emit('error', '', `I don't have permissions to ban ${user}.`, message.channel);
-            }
-            await member.ban('Warned 3 times!');
-            action = 'Banned';
-          }
-
-          delete message.guild.warns[user.id];
-          message.channel.send({
-            embed: {
-              color: Bastion.colors.RED,
-              title: action,
-              fields: [
-                {
-                  name: 'User',
-                  value: user.tag,
-                  inline: true
-                },
-                {
-                  name: 'ID',
-                  value: user.id,
-                  inline: true
-                },
-                {
-                  name: 'Reason',
-                  value: 'Warned 3 times!',
-                  inline: false
-                }
-              ]
-            }
-          }).catch(e => {
-            Bastion.log.error(e);
-          });
-
-          Bastion.emit('moderationLog', message, guildModel.dataValues.warnAction, user, 'Warned 3 times!');
-
-          member.send({
-            embed: {
-              color: Bastion.colors.RED,
-              title: `${action} from ${message.guild.name} Server`,
-              fields: [
-                {
-                  name: 'Reason',
-                  value: 'You have been warned 3 times!'
-                }
-              ]
-            }
-          }).catch(e => {
-            Bastion.log.error(e);
-          });
-        }
+    let guildMemberModel = await message.client.database.models.guildMember.findOne({
+      attributes: [ 'warnings' ],
+      where: {
+        userID: member.id,
+        guildID: message.guild.id
       }
-      else {
-        message.guild.warns[user.id] += 1;
-      }
+    });
+
+
+    if (!guildMemberModel.dataValues.warnings) {
+      guildMemberModel.dataValues.warnings = [];
     }
+
+    guildMemberModel.dataValues.warnings.push({
+      reason: args.reason,
+      executor: message.author.id,
+      time: Date.now()
+    });
+
+
+    await message.client.database.models.guildMember.update({
+      warnings: guildMemberModel.dataValues.warnings
+    },
+    {
+      where: {
+        userID: member.id,
+        guildID: message.guild.id
+      },
+      fields: [ 'warnings' ]
+    });
+
+
+    // TODO: Implement warn action and threshold.
+
 
     message.channel.send({
       embed: {
@@ -149,9 +83,9 @@ exports.exec = async (Bastion, message, args) => {
     });
 
     /**
-    * Logs moderation events if it is enabled
-    * @fires moderationLog
-    */
+     * Logs moderation events if it is enabled
+     * @fires moderationLog
+     */
     Bastion.emit('moderationLog', message, this.help.name, user, args.reason);
   }
   catch (e) {
@@ -170,10 +104,10 @@ exports.config = {
 
 exports.help = {
   name: 'warn',
-  description: 'Warns the specified user. If three warns are given, some action, specified by the `warnAction` command (previously), is taken.',
+  description: 'Warns the specified user.',
   botPermission: 'KICK_MEMBERS',
   userTextPermission: 'KICK_MEMBERS',
   userVoicePermission: '',
-  usage: 'warn <@USER_MENTION | USER_ID> -r [Reason]',
-  example: [ 'warn @user#001 -r NSFW in non NSFW channels', 'warn 167147569575323761 -r Advertisements' ]
+  usage: 'warn < @USER-MENTION | USER_ID > -r [Reason]',
+  example: [ 'warn @user#001 -r Sharing NSFW contents', 'warn 167147569575323761 -r Advertisements' ]
 };

--- a/data/commands.json
+++ b/data/commands.json
@@ -1136,7 +1136,7 @@
     "module": "Guild Admin"
   },
   "warn": {
-    "description": "Warns the specified user.",
+    "description": "Warns the specified user. If warning threshold reaches for a user some action, specified by the `warnAction` command, is taken.",
     "module": "Moderation"
   },
   "warnAction": {

--- a/data/commands.json
+++ b/data/commands.json
@@ -1136,7 +1136,7 @@
     "module": "Guild Admin"
   },
   "warn": {
-    "description": "Warns the specified user. If three warns are given, some action, specified by the `warnAction` command (previously), is taken.",
+    "description": "Warns the specified user.",
     "module": "Moderation"
   },
   "warnAction": {

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -852,7 +852,7 @@
     "description": "Adds/removes the channel as a voting channel. Any messages posted in this channel, by a user, will be available for voting."
   },
   "warn": {
-    "description": "Warns the specified user."
+    "description": "Warns the specified user. If warning threshold reaches for a user some action, specified by the `warnAction` command, is taken."
   },
   "warnAction": {
     "description": "Sets the warn action for the server."

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -852,7 +852,7 @@
     "description": "Adds/removes the channel as a voting channel. Any messages posted in this channel, by a user, will be available for voting."
   },
   "warn": {
-    "description": "Warns the specified user. If three warns are given, some action, specified by the `warnAction` command (previously), is taken."
+    "description": "Warns the specified user."
   },
   "warnAction": {
     "description": "Sets the warn action for the server."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.22",
+  "version": "7.0.0-alpha.23",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",

--- a/utils/models.js
+++ b/utils/models.js
@@ -298,6 +298,9 @@ module.exports = (Sequelize, database) => {
     claimStreak: {
       type: Sequelize.TINYINT(3),
       defaultValue: 0
+    },
+    warnings: {
+      type: Sequelize.JSON
     }
   },
   {


### PR DESCRIPTION
#### Changes made in this PR
* Warnings are now permanent. Warnings will now be stored in the database and remains even if user leaves the server.
* Default warning threshold is now set to 5 (from 3).
* Rewritten `warn`, `listWarns` & `clearWarn` command to implement these changes.

#### Possible drawbacks
None

#### Applicable Issues:
\-

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
