### PR TITLE
Reaction Roles

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "June 15, 2018",
+  "date": "June 22, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [],
   "THESE ABILITIES HAVE ENHANCED": [
@@ -30,7 +30,8 @@
     "Users can now have different music playlists in different servers",
     "Members Only mode to allow only users with roles to use the commands.",
     "You can now pin a message to the channel just by adding either 📌 or 📍 reaction to a message",
-    "You can now run multiple giveaways"
+    "You can now run multiple giveaways",
+    "Reaction Roles. Similar to self assignable roles, but instead of using commands, you just need to add/remove reactions to get roles"
   ],
   "NEW COMMANDS!": [
     "`blacklist` - Blacklist users globally from using Bastion.",
@@ -45,7 +46,9 @@
     "`toggleLevelUps` - Toggle gaining XP and leveling up while chatting.",
     "`reportChannel` - (Un)Set report channel of the server.",
     "`membersOnly` - Toggle Members Only mode.",
-    "`reactionPinning` - Toggle Reaction Pinning."
+    "`reactionPinning` - Toggle Reaction Pinning.",
+    "`roleEmoji` - Assign an emoji to a role.",
+    "`reactionRolesGroup` - Creates a group of Reaction Roles and sends a message to which users can react to self assign roles to themselves and vice versa."
   ],
   "COMMANDS WITH NEW USAGE": [
     "`addTrigger` command's usage syntax has been changed. It won't work the way it used to before, please check the help message for it, using the `help addTrigger` command, to see the new usage details.",

--- a/commands/guild_admin/reactionRolesGroup.js
+++ b/commands/guild_admin/reactionRolesGroup.js
@@ -1,0 +1,108 @@
+/**
+ * @file reactionRolesGroup command
+ * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
+ * @license GPL-3.0
+ */
+
+exports.exec = async (Bastion, message, args) => {
+  try {
+    if (!args.roles) {
+      /**
+       * The command was ran with invalid parameters.
+       * @fires commandUsage
+       */
+      return Bastion.emit('commandUsage', message, this.help);
+    }
+
+
+    let roleModels = await Bastion.database.models.role.findAll({
+      attributes: [ 'roleID', 'emoji' ],
+      where: {
+        guildID: message.guild.id,
+        emoji: {
+          [Bastion.database.Op.not]: null
+        }
+      }
+    });
+
+
+    let reactionRolesIDs = roleModels.map(model => model.dataValues.roleID);
+
+    args.roles = args.roles.filter(role => message.guild.roles.has(role));
+    if (!args.roles.length) {
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'roleNotFound'), message.channel);
+    }
+
+    let unassignedRoleEmojis = args.roles.some(role => !reactionRolesIDs.includes(role));
+    if (unassignedRoleEmojis) {
+      return Bastion.emit('error', '', 'Some roles doesn\'t have any assigned emojis. Please assign emojis to roles before you use them for reaction roles.', message.channel);
+    }
+
+
+    let body;
+    if (args.body && args.body.length) {
+      body = args.body.join(' ');
+    }
+    else {
+      let reactionRoles = roleModels.filter(model => args.roles.includes(model.dataValues.roleID));
+      reactionRoles = reactionRoles.map(model => `${decodeURIComponent(model.dataValues.emoji)} - **${message.guild.roles.get(model.dataValues.roleID).name}** / ${model.dataValues.roleID}`);
+      body = reactionRoles.join('\n');
+    }
+
+
+    let reactionRolesMessage = await message.channel.send({
+      embed: {
+        color: Bastion.colors.BLUE,
+        title: args.title && args.title.length ? args.title.join(' ') : 'Reaction Roles',
+        description: body
+      }
+    });
+
+
+    await Bastion.database.models.reactionRolesGroup.upsert({
+      messageID: reactionRolesMessage.id,
+      channelID: reactionRolesMessage.channel.id,
+      guildID: reactionRolesMessage.guild.id,
+      reactionRoles: args.roles,
+      mutuallyExclusive: args.exclusive
+    },
+    {
+      where: {
+        messageID: reactionRolesMessage.id,
+        channelID: reactionRolesMessage.channel.id,
+        guildID: reactionRolesMessage.guild.id
+      },
+      fields: [ 'messageID', 'channelID', 'guildID', 'reactionRoles', 'mutuallyExclusive' ]
+    });
+
+
+    let reactionRolesEmojis = roleModels.map(model => model.dataValues.emoji);
+    for (let emoji of reactionRolesEmojis) {
+      await reactionRolesMessage.react(emoji);
+    }
+  }
+  catch (e) {
+    Bastion.log.error(e);
+  }
+};
+
+exports.config = {
+  aliases: [ 'reactionRoles' ],
+  enabled: true,
+  argsDefinitions: [
+    { name: 'roles', type: String, multiple: true, defaultOption: true },
+    { name: 'title', type: String, alias: 't', muiltiple: true },
+    { name: 'body', type: String, alias: 'b', multiple: true },
+    { name: 'exclusive', type: Boolean, alias: 'e', defaultValue: false }
+  ]
+};
+
+exports.help = {
+  name: 'reactionRolesGroup',
+  description: 'Creates a group of Reaction Roles and sends a message to which users can react to self assign roles to themselves and vice versa.',
+  botPermission: '',
+  userTextPermission: 'MANAGE_GUILD',
+  userVoicePermission: '',
+  usage: 'reactionRolesGroup < ROLE_ID_1, ROLE_ID_2, ... > [ -t Message Title ] [ -b Message Body ] [ --exclusive ]',
+  example: [ 'reactionRolesGroup 219101083619902983', 'reactionRolesGroup 219101083619902983 2494130541574845651 -t Self Assign -b React to Get Role', 'reactionRolesGroup 219101083619902983 2494130541574845651 --exclusive' ]
+};

--- a/commands/guild_admin/reactionRolesGroup.js
+++ b/commands/guild_admin/reactionRolesGroup.js
@@ -76,7 +76,7 @@ exports.exec = async (Bastion, message, args) => {
     });
 
 
-    let reactionRolesEmojis = roleModels.map(model => model.dataValues.emoji);
+    let reactionRolesEmojis = roleModels.filter(model => args.roles.includes(model.dataValues.roleID)).map(model => model.dataValues.emoji);
     for (let emoji of reactionRolesEmojis) {
       await reactionRolesMessage.react(emoji);
     }

--- a/commands/guild_admin/reactionRolesGroup.js
+++ b/commands/guild_admin/reactionRolesGroup.js
@@ -87,6 +87,7 @@ exports.exec = async (Bastion, message, args) => {
         }
       }
     });
+    await reactionRolesMessage.pin().catch(() => {});
 
 
     await Bastion.database.models.reactionRolesGroup.upsert({

--- a/commands/guild_admin/reactionRolesGroup.js
+++ b/commands/guild_admin/reactionRolesGroup.js
@@ -54,7 +54,10 @@ exports.exec = async (Bastion, message, args) => {
       embed: {
         color: Bastion.colors.BLUE,
         title: args.title && args.title.length ? args.title.join(' ') : 'Reaction Roles',
-        description: body
+        description: body,
+        footer: {
+          text: `${args.exclusive ? 'Mutually Exclusive' : ''} Reaction Roles • React with the emoji to get the corresponding role.`
+        }
       }
     });
 

--- a/commands/guild_admin/reactionRolesGroup.js
+++ b/commands/guild_admin/reactionRolesGroup.js
@@ -17,6 +17,29 @@ exports.exec = async (Bastion, message, args) => {
     if (!args.roles) {
       let reactionRolesGroups = reactionRolesGroupModels.map(model => model.dataValues.messageID);
 
+
+      if (args.remove) {
+        if (reactionRolesGroups.includes(args.remove)) {
+          await Bastion.database.models.reactionRolesGroup.destroy({
+            where: {
+              messageID: args.remove,
+              guildID: message.guild.id
+            }
+          });
+
+          return message.channel.send({
+            embed: {
+              color: Bastion.colors.RED,
+              title: 'Reaction Roles Group Removed',
+              description: `The Reaction Roles Group associated with the message ${args.remove} has been successfully removed.`
+            }
+          }).catch(e => {
+            Bastion.log.error(e);
+          });
+        }
+      }
+
+
       if (!reactionRolesGroups.length) {
         /**
          * The command was ran with invalid parameters.
@@ -124,7 +147,8 @@ exports.config = {
     { name: 'roles', type: String, multiple: true, defaultOption: true },
     { name: 'title', type: String, alias: 't', muiltiple: true },
     { name: 'body', type: String, alias: 'b', multiple: true },
-    { name: 'exclusive', type: Boolean, alias: 'e', defaultValue: false }
+    { name: 'exclusive', type: Boolean, alias: 'e', defaultValue: false },
+    { name: 'remove', type: String, alias: 'r' }
   ]
 };
 
@@ -134,6 +158,6 @@ exports.help = {
   botPermission: '',
   userTextPermission: 'MANAGE_GUILD',
   userVoicePermission: '',
-  usage: 'reactionRolesGroup [ ROLE_ID_1, ROLE_ID_2, ... ] [ -t Message Title ] [ -b Message Body ] [ --exclusive ]',
+  usage: 'reactionRolesGroup [ ROLE_ID_1, ROLE_ID_2, ... ] [ -t Message Title ] [ -b Message Body ] [ --exclusive ] [ --remove MESSAGE_ID ]',
   example: [ 'reactionRolesGroup', 'reactionRolesGroup 219101083619902983 2494130541574845651 -t Self Assign -b React to Get Role', 'reactionRolesGroup 219101083619902983 2494130541574845651 --exclusive' ]
 };

--- a/commands/guild_admin/reactionRolesGroup.js
+++ b/commands/guild_admin/reactionRolesGroup.js
@@ -6,23 +6,38 @@
 
 exports.exec = async (Bastion, message, args) => {
   try {
-    if (!args.roles) {
-      /**
-       * The command was ran with invalid parameters.
-       * @fires commandUsage
-       */
-      return Bastion.emit('commandUsage', message, this.help);
-    }
-
-
-    let reactionRolesGroup = await Bastion.database.models.reactionRolesGroup.findAll({
+    let reactionRolesGroupModels = await Bastion.database.models.reactionRolesGroup.findAll({
       fields: [ 'messageID' ],
       where: {
         guildID: message.guild.id
       }
     });
 
-    if (reactionRolesGroup && reactionRolesGroup.length === 2) {
+
+    if (!args.roles) {
+      let reactionRolesGroups = reactionRolesGroupModels.map(model => model.dataValues.messageID);
+
+      if (!reactionRolesGroups.length) {
+        /**
+         * The command was ran with invalid parameters.
+         * @fires commandUsage
+         */
+        return Bastion.emit('commandUsage', message, this.help);
+      }
+
+      return message.channel.send({
+        embed: {
+          color: Bastion.colors.BLUE,
+          title: 'Reaction Roles Groups',
+          description: reactionRolesGroups.map((group, index) => `${index + 1}. ${group}`).join('\n')
+        }
+      }).catch(e => {
+        Bastion.log.error(e);
+      });
+    }
+
+
+    if (reactionRolesGroupModels && reactionRolesGroupModels.length === 2) {
       return Bastion.emit('error', '', 'You can\'t have more than 2 Reaction Roles Group, for now. Delete any previous Group of Reaction Roles to add new ones.', message.channel);
     }
 
@@ -118,6 +133,6 @@ exports.help = {
   botPermission: '',
   userTextPermission: 'MANAGE_GUILD',
   userVoicePermission: '',
-  usage: 'reactionRolesGroup < ROLE_ID_1, ROLE_ID_2, ... > [ -t Message Title ] [ -b Message Body ] [ --exclusive ]',
-  example: [ 'reactionRolesGroup 219101083619902983', 'reactionRolesGroup 219101083619902983 2494130541574845651 -t Self Assign -b React to Get Role', 'reactionRolesGroup 219101083619902983 2494130541574845651 --exclusive' ]
+  usage: 'reactionRolesGroup [ ROLE_ID_1, ROLE_ID_2, ... ] [ -t Message Title ] [ -b Message Body ] [ --exclusive ]',
+  example: [ 'reactionRolesGroup', 'reactionRolesGroup 219101083619902983 2494130541574845651 -t Self Assign -b React to Get Role', 'reactionRolesGroup 219101083619902983 2494130541574845651 --exclusive' ]
 };

--- a/commands/guild_admin/reactionRolesGroup.js
+++ b/commands/guild_admin/reactionRolesGroup.js
@@ -15,6 +15,18 @@ exports.exec = async (Bastion, message, args) => {
     }
 
 
+    let reactionRolesGroup = await Bastion.database.models.reactionRolesGroup.findAll({
+      fields: [ 'messageID' ],
+      where: {
+        guildID: message.guild.id
+      }
+    });
+
+    if (reactionRolesGroup && reactionRolesGroup.length === 2) {
+      return Bastion.emit('error', '', 'You can\'t have more than 2 Reaction Roles Group, for now. Delete any previous Group of Reaction Roles to add new ones.', message.channel);
+    }
+
+
     let roleModels = await Bastion.database.models.role.findAll({
       attributes: [ 'roleID', 'emoji' ],
       where: {

--- a/commands/guild_admin/roleEmoji.js
+++ b/commands/guild_admin/roleEmoji.js
@@ -17,6 +17,7 @@ exports.exec = async (Bastion, message, args) => {
     }
 
 
+    args.role = args.role.join(' ');
     let role;
     if (message.guild.roles.has(args.role)) {
       role = message.guild.roles.get(args.role);

--- a/commands/guild_admin/roleEmoji.js
+++ b/commands/guild_admin/roleEmoji.js
@@ -81,7 +81,7 @@ exports.config = {
 
 exports.help = {
   name: 'roleEmoji',
-  description: 'Assign an emoji to a specified role.',
+  description: 'Assign an emoji to a specified role. The assigned emojis are used with Reaction Roles.',
   botPermission: '',
   userTextPermission: 'MANAGE_GUILD',
   userVoicePermission: '',

--- a/commands/guild_admin/roleEmoji.js
+++ b/commands/guild_admin/roleEmoji.js
@@ -1,0 +1,89 @@
+/**
+ * @file roleEmoji command
+ * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
+ * @license GPL-3.0
+ */
+
+const emojis = xrequire('./assets/emojis.json');
+
+exports.exec = async (Bastion, message, args) => {
+  try {
+    if (!args.role || !(args.emoji || args.remove)) {
+      /**
+       * The command was ran with invalid parameters.
+       * @fires commandUsage
+       */
+      return Bastion.emit('commandUsage', message, this.help);
+    }
+
+
+    let role;
+    if (message.guild.roles.has(args.role)) {
+      role = message.guild.roles.get(args.role);
+    }
+    else if (message.mentions.roles.size) {
+      role = message.mentions.roles.first();
+    }
+    else {
+      role = message.guild.roles.find(args.role);
+    }
+    if (!role) {
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'roleNotFound'), message.channel);
+    }
+
+    let emoji = null;
+    if (args.emoji) {
+      emoji = encodeURIComponent(args.emoji);
+      if (!emojis.includes(emoji)) {
+        return Bastion.emit('error', 'invalidInput', 'The emoji you entered is invalid. Note that custom emojis aren\'t supported currently.', message.channel);
+      }
+    }
+
+
+    await Bastion.database.models.role.upsert({
+      roleID: role.id,
+      guildID: message.guild.id,
+      emoji: args.remove ? null : emoji
+    },
+    {
+      where: {
+        roleID: role.id,
+        guildID: message.guild.id
+      },
+      fields: [ 'roleID', 'guildID', 'emoji' ]
+    });
+
+
+    message.channel.send({
+      embed: {
+        color: args.remove ? Bastion.colors.RED : Bastion.colors.GREEN,
+        description: Bastion.i18n.info(message.guild.language, args.remove ? 'unsetRoleEmoji' : 'setRoleEmoji', message.author.tag, role.name, decodeURIComponent(emoji))
+      }
+    }).catch(e => {
+      Bastion.log.error(e);
+    });
+  }
+  catch (e) {
+    Bastion.log.error(e);
+  }
+};
+
+exports.config = {
+  aliases: [],
+  enabled: true,
+  argsDefinitions: [
+    { name: 'role', type: String, multiple: true, defaultOption: true },
+    { name: 'emoji', type: String, alias: 'e' },
+    { name: 'remove', type: Boolean }
+  ]
+};
+
+exports.help = {
+  name: 'roleEmoji',
+  description: 'Assign an emoji to a specified role.',
+  botPermission: '',
+  userTextPermission: 'MANAGE_GUILD',
+  userVoicePermission: '',
+  usage: 'roleEmoji < ROLE_ID | @Role Mention | Role Name > < --emoji :emoji_name: | --remove >',
+  example: []
+};

--- a/data/commands.json
+++ b/data/commands.json
@@ -832,7 +832,7 @@
     "module": "Info"
   },
   "roleEmoji": {
-    "description": "Assign an emoji to a specified role.",
+    "description": "Assign an emoji to a specified role. The assigned emojis are used with Reaction Roles.",
     "module": "Guild Admin"
   },
   "roleID": {

--- a/data/commands.json
+++ b/data/commands.json
@@ -827,6 +827,10 @@
     "description": "Set a description for a role, which will be shown in the `roleInfo` command.",
     "module": "Info"
   },
+  "roleEmoji": {
+    "description": "Assign an emoji to a specified role.",
+    "module": "Guild Admin"
+  },
   "roleID": {
     "description": "Shows the ID of a specified role of your Discord server.",
     "module": "Info"

--- a/data/commands.json
+++ b/data/commands.json
@@ -723,6 +723,10 @@
     "description": "Toggles Reaction Pinning in the server. If Reaction Pinning is enabled, adding either 📌 or 📍 reaction to a message will pin the message to the channel and removing the reactions will unpin it too.",
     "module": "Guild Admin"
   },
+  "reactionRolesGroup": {
+    "description": "Creates a group of Reaction Roles and sends a message to which users can react to self assign roles to themselves and vice versa.",
+    "module": "Guild Admin"
+  },
   "reason": {
     "description": "Add/Update the reason for a moderation action, which is logged in the moderation log channel. Only the responsible moderator or anyone with administrator permissions can change the reason.",
     "module": "Moderation"

--- a/events/ready.js
+++ b/events/ready.js
@@ -98,6 +98,7 @@ module.exports = async Bastion => {
 
     xrequire('./handlers/scheduledCommandHandler')(Bastion);
     xrequire('./handlers/streamNotifier')(Bastion);
+    xrequire('./handlers/reactionRolesGroupsHandler')(Bastion);
 
     if (Bastion.shard) {
       Bastion.log.console(`${COLOR.cyan(`[${Bastion.user.username}]:`)} Shard ${Bastion.shard.id} is ready with ${Bastion.guilds.size} servers.`);

--- a/handlers/reactionRolesGroupsHandler.js
+++ b/handlers/reactionRolesGroupsHandler.js
@@ -1,0 +1,26 @@
+/**
+ * @file Reaction Roles Groups Handler
+ * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
+ * @license GPL-3.0
+ */
+
+module.exports = async Bastion => {
+  try {
+    let reactionRolesGroupModels = await Bastion.database.models.reactionRolesGroup.findAll({
+      attributes: [ 'messageID', 'channelID', 'guildID' ]
+    });
+
+    let reactionRolesGroups = reactionRolesGroupModels.map(model => model.dataValues);
+
+    for (let group of reactionRolesGroups) {
+      if (!Bastion.channels.has(group.channelID)) return;
+      let channel = Bastion.channels.get(group.channelID);
+      if (!channel.messages.has(group.messageID)) {
+        await channel.fetchMessage(group.messageID);
+      }
+    }
+  }
+  catch (e) {
+    Bastion.error.log(e);
+  }
+};

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -542,6 +542,9 @@
   "reactionPinning": {
     "description": "Toggles Reaction Pinning in the server. If Reaction Pinning is enabled, adding either 📌 or 📍 reaction to a message will pin the message to the channel and removing the reactions will unpin it too."
   },
+  "reactionRolesGroup": {
+    "description": "Creates a group of Reaction Roles and sends a message to which users can react to self assign roles to themselves and vice versa."
+  },
   "reason": {
     "description": "Add/Update the reason for a moderation action, which is logged in the moderation log channel. Only the responsible moderator or anyone with administrator permissions can change the reason."
   },

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -624,7 +624,7 @@
     "description": "Set a description for a role, which will be shown in the `roleInfo` command."
   },
   "roleEmoji": {
-    "description": "Assign an emoji to a specified role."
+    "description": "Assign an emoji to a specified role. The assigned emojis are used with Reaction Roles."
   },
   "roleID": {
     "description": "Shows the ID of a specified role of your Discord server."

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -620,6 +620,9 @@
   "roleDescription": {
     "description": "Set a description for a role, which will be shown in the `roleInfo` command."
   },
+  "roleEmoji": {
+    "description": "Assign an emoji to a specified role."
+  },
   "roleID": {
     "description": "Shows the ID of a specified role of your Discord server."
   },

--- a/locales/en_us/info.json
+++ b/locales/en_us/info.json
@@ -53,6 +53,8 @@
   "disableModerationLog": "%var% disabled logging of moderation actions in this server.",
   "enableModerationLog": "%var% enabled logging of moderation actions, in this channel.",
   "resetModerationLogCases": "%var% reset the moderation log case numbers in this server.",
+  "setRoleEmoji": "%var% set the **%var%** role's emoji to %var%.",
+  "unsetRoleEmoji": "%var% removed the emoji for the **%var%** role.",
   "setPrefix": "%var% changed the prefix for the server to `%var%`",
   "disableSlowMode": "%var% disabled slow mode in this server. Everyone, get spicy!",
   "enableSlowMode": "%var% enabled slow mode in this server. Beware spammers!",

--- a/utils/models.js
+++ b/utils/models.js
@@ -654,6 +654,24 @@ module.exports = (Sequelize, database) => {
     }
   });
 
+  const ReactionRolesGroup = database.define('reactionRolesGroup', {
+    messageID: {
+      type: Sequelize.STRING,
+      allowNull: false
+    },
+    channelID: {
+      type: Sequelize.STRING,
+      allowNull: false
+    },
+    guildID: {
+      type: Sequelize.STRING,
+      allowNull: false
+    },
+    reactionRoles: {
+      type: Sequelize.JSON
+    }
+  });
+
   // Associations
   Guild.Items = Guild.hasMany(Items, {
     foreignKey: 'guildID',
@@ -701,6 +719,11 @@ module.exports = (Sequelize, database) => {
     onUpdate: 'CASCADE'
   });
   Guild.Playlist = Guild.hasMany(Playlist, {
+    foreignKey: 'guildID',
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE'
+  });
+  Guild.ReactionRolesGroup = Guild.hasMany(ReactionRolesGroup, {
     foreignKey: 'guildID',
     onDelete: 'CASCADE',
     onUpdate: 'CASCADE'

--- a/utils/models.js
+++ b/utils/models.js
@@ -669,6 +669,11 @@ module.exports = (Sequelize, database) => {
     },
     reactionRoles: {
       type: Sequelize.JSON
+    },
+    mutuallyExclusive: {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
     }
   });
 

--- a/utils/models.js
+++ b/utils/models.js
@@ -487,7 +487,7 @@ module.exports = (Sequelize, database) => {
     price: {
       type: Sequelize.TEXT
     },
-    reaction: {
+    emoji: {
       type: Sequelize.STRING
     },
     blacklisted: {

--- a/utils/models.js
+++ b/utils/models.js
@@ -487,6 +487,9 @@ module.exports = (Sequelize, database) => {
     price: {
       type: Sequelize.TEXT
     },
+    reaction: {
+      type: Sequelize.STRING
+    },
     blacklisted: {
       type: Sequelize.BOOLEAN,
       allowNull: false,


### PR DESCRIPTION
#### Changes introduced by this PR
* Adds **Reaction Roles** feature. Similar to Self Assignable Roles, but instead of using commands, users just need to add/remove reactions to self assign/ unassign roles.
* Adds `roleEmoji` command to assign an Emoji to a Role.
* Adds `reactionRolesGroup` command to create a group of Reaction Roles and sends a message to which users can react to self assign roles to themselves and vice versa.

#### Possible drawbacks
None

#### Applicable Issues
Closes #229 

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
