### PR TITLE
AFK Mode

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "June 22, 2018",
+  "date": "June 28, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [],
   "THESE ABILITIES HAVE ENHANCED": [
@@ -31,7 +31,8 @@
     "Members Only mode to allow only users with roles to use the commands.",
     "You can now pin a message to the channel just by adding either 📌 or 📍 reaction to a message",
     "You can now run multiple giveaways",
-    "Reaction Roles. Similar to self assignable roles, but instead of using commands, you just need to add/remove reactions to get roles"
+    "Reaction Roles. Similar to self assignable roles, but instead of using commands, you just need to add/remove reactions to get roles",
+    "AFK Mode. Users can now set themselves as AFK and anyone mentioning them, in a server they manage, will be responded by Bastion that the user is AFK."
   ],
   "NEW COMMANDS!": [
     "`blacklist` - Blacklist users globally from using Bastion.",
@@ -48,7 +49,8 @@
     "`membersOnly` - Toggle Members Only mode.",
     "`reactionPinning` - Toggle Reaction Pinning.",
     "`roleEmoji` - Assign an emoji to a role.",
-    "`reactionRolesGroup` - Creates a group of Reaction Roles and sends a message to which users can react to self assign roles to themselves and vice versa."
+    "`reactionRolesGroup` - Creates a group of Reaction Roles and sends a message to which users can react to self assign roles to themselves and vice versa.",
+    "`afk` - Sets AFK mode for the user."
   ],
   "COMMANDS WITH NEW USAGE": [
     "`addTrigger` command's usage syntax has been changed. It won't work the way it used to before, please check the help message for it, using the `help addTrigger` command, to see the new usage details.",

--- a/commands/info/afk.js
+++ b/commands/info/afk.js
@@ -1,0 +1,45 @@
+/**
+ * @file afk command
+ * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
+ * @license GPL-3.0
+ */
+
+exports.exec = (Bastion, message) => {
+  try {
+    if (!message.guild.usersAFK) {
+      message.guild.usersAFK = [];
+    }
+    message.guild.usersAFK.push(message.author.id);
+
+
+    message.channel.send({
+      embed: {
+        color: Bastion.colors.GREEN,
+        description: `${message.author} I've set you as AFK. If anyone mentions you while you're away, I'll let them know. AFK mode will be disabled once you're back and send a message anywhere.`
+      }
+    }).catch(e => {
+      Bastion.log.error(e);
+    });
+  }
+  catch (e) {
+    Bastion.log.error(e);
+  }
+};
+
+exports.config = {
+  aliases: [],
+  enabled: true,
+  argsDefinitions: [
+    { name: 'message', type: String, alias: 'm', defaultOption: true }
+  ]
+};
+
+exports.help = {
+  name: 'afk',
+  description: 'Sets you as Away From Keyboard (AFK). So when someone mentions you, Bastion will let them know that you\'re AFK. It\'ll be automatically disabled once you are back.',
+  botPermission: '',
+  userTextPermission: '',
+  userVoicePermission: '',
+  usage: 'afk',
+  example: []
+};

--- a/commands/info/afk.js
+++ b/commands/info/afk.js
@@ -6,20 +6,19 @@
 
 exports.exec = (Bastion, message) => {
   try {
-    if (!message.guild.usersAFK) {
-      message.guild.usersAFK = [];
+    if (!message.guild.usersAFK) message.guild.usersAFK = [];
+    if (!message.guild.usersAFK.includes(message.author.id)) {
+      message.guild.usersAFK.push(message.author.id);
+
+      message.channel.send({
+        embed: {
+          color: Bastion.colors.GREEN,
+          description: `${message.author} I've set you as AFK. If anyone mentions you while you're away, I'll let them know. AFK mode will be disabled once you're back and send a message anywhere.`
+        }
+      }).catch(e => {
+        Bastion.log.error(e);
+      });
     }
-    message.guild.usersAFK.push(message.author.id);
-
-
-    message.channel.send({
-      embed: {
-        color: Bastion.colors.GREEN,
-        description: `${message.author} I've set you as AFK. If anyone mentions you while you're away, I'll let them know. AFK mode will be disabled once you're back and send a message anywhere.`
-      }
-    }).catch(e => {
-      Bastion.log.error(e);
-    });
   }
   catch (e) {
     Bastion.log.error(e);

--- a/data/commands.json
+++ b/data/commands.json
@@ -27,6 +27,10 @@
     "description": "Adds a domain to the whitelist for link filter.",
     "module": "Guild Admin"
   },
+  "afk": {
+    "description": "Sets you as Away From Keyboard (AFK). So when someone mentions you, Bastion will let them know that you're AFK. It'll be automatically disabled once you are back.",
+    "module": "Info"
+  },
   "airhorn": {
     "description": "Plays an airhorn in a voice channel.",
     "module": "Fun"

--- a/events/message.js
+++ b/events/message.js
@@ -193,11 +193,11 @@ module.exports = async message => {
           guildID: message.guild.id
         }
       });
-      if (!textChannelModel || !textChannelModel.dataValues.votingChannel) return;
-
-      // Add reactions for voting
-      await message.react('👍');
-      await message.react('👎');
+      if (textChannelModel && textChannelModel.dataValues.votingChannel) {
+        // Add reactions for voting
+        await message.react('👍');
+        await message.react('👎');
+      }
     }
     else {
       /**

--- a/events/message.js
+++ b/events/message.js
@@ -198,6 +198,25 @@ module.exports = async message => {
         await message.react('👍');
         await message.react('👎');
       }
+
+
+      /**
+       * AFK Mode
+       */
+      if (message.guild.usersAFK) {
+        // Delete message author from usersAFK if he's back.
+        if (message.guild.usersAFK.includes(message.author.id)) {
+          message.guild.usersAFK.splice(message.guild.usersAFK.indexOf(message.author.id), 1);
+        }
+
+        let usersAFK = message.mentions.users.filter(user => message.guild.usersAFK.includes(user.id) && message.channel.permissionsFor(user).has('MANAGE_GUILD'));
+        for (let user of usersAFK) {
+          user = user[1];
+          if ([ 'idle', 'offline' ].includes(user.presence.status)) {
+            message.channel.send(`**${user.tag}** is currently away from keyboard. He'll get back to you once he's back.`).catch(() => {});
+          }
+        }
+      }
     }
     else {
       /**

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -20,6 +20,9 @@
   "addWhitelistDomains": {
     "description": "Adds a domain to the whitelist for link filter."
   },
+  "afk": {
+    "description": "Sets you as Away From Keyboard (AFK). So when someone mentions you, Bastion will let them know that you're AFK. It'll be automatically disabled once you are back."
+  },
   "airhorn": {
     "description": "Plays an airhorn in a voice channel."
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.25",
+  "version": "7.0.0-alpha.26",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",

--- a/utils/models.js
+++ b/utils/models.js
@@ -249,6 +249,11 @@ module.exports = (Sequelize, database) => {
     color: {
       type: Sequelize.STRING
     },
+    AFK: {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
+    },
     AFKMessage: {
       type: Sequelize.BLOB
     },

--- a/utils/models.js
+++ b/utils/models.js
@@ -249,6 +249,9 @@ module.exports = (Sequelize, database) => {
     color: {
       type: Sequelize.STRING
     },
+    AFKMessage: {
+      type: Sequelize.BLOB
+    },
     blacklisted: {
       type: Sequelize.BOOLEAN,
       allowNull: false,


### PR DESCRIPTION
#### Changes introduced by this PR
* When **AFK mode** is enabled for a user and someone mentions them in a guild where they have the **Manage Server** perms, Bastion'll will let them know that the user is currently AFK.
* AFK mode will be disabled automatically once the user is back and sends a message somewhere (provided that Bastion has access to that channel).
* AFK mode will only work for a user when the user is either `idle` or `offline`.
* Added `afk` command to set AFK mode for the message author.
* Added `AFK` and `AFKMessage` fields in the `User` model (currently unused).

#### Possible drawbacks
* Currently AFK mode isn't persistent after restart. But will be made persistent in the future.

#### Applicable Issues
Closes #237 

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
