### PR TITLE
Level-up Messages

### DIFF
--- a/assets/levelUpMessages.json
+++ b/assets/levelUpMessages.json
@@ -1,0 +1,22 @@
+[
+  "You realize that all your life you have been coasting along as if you were in a dream. Suddenly, facing the trials of the last few days, you have come alive.",
+  "You realize that you are catching on to the secret of success. It's just a matter of concentration.",
+  "You've done things the hard way. But without taking risks, taking responsibility for failure... how could you have understood?",
+  "Everything you do is just a bit easier, more instinctive, more satisfying. It is as though you had suddenly developed keen senses and instincts.",
+  "You've learned a lot about Cyrodiil... and about yourself. It's hard to believe how ignorant you were, but now you have so much more to learn.",
+  "You resolve to continue pushing yourself. Perhaps there's more to you than you thought.",
+  "The secret does seem to be hard work, yes, but it's also a kind of blind passion, an inspiration.",
+  "So that's how it works. You plod along, putting one foot before the other, look up, and suddenly, there you are. Right where you wanted to be all along.",
+  "You woke today with a new sense of purpose. You're no longer afraid of failure. Failure is just an opportunity to learn something new.",
+  "Being smart doesn't hurt. And a little luck now and then is nice. But the key is patience and hard work.",
+  "You can't believe how easy it is. You just have to go... a little crazy. And then, suddenly, it all makes sense, and everything you do turns to gold.",
+  "It's the most amazing thing. Yesterday it was hard, and today it is easy. Just a good night's sleep, and yesterday's mysteries are today's masteries.",
+  "Today you wake up, full of energy and ideas, and you know, somehow, that overnight everything has changed. What a difference a day makes.",
+  "Now you just stay at your peak as long as you can. There's no one stronger in Tamriel, but there's always someone younger... a new challenger.",
+  "You've been trying too hard, thinking too much. Relax. Trust your instincts. Just be yourself. Do the little things, and the big things take care of themselves.",
+  "Life isn't over. You can still get smarter, or cleverer, or more experienced, or meaner... but your body and soul just aren't going to get any younger.",
+  "With the life you've been living, the punishment your body has taken... there are limits, and maybe you've reached them. Is this what it's like to grow old?",
+  "You're really good. Maybe the best. And that's why it's so hard to get better. But you just keep trying, because that's the way you are.",
+  "By superhuman effort, you can avoid slipping backwards for a while. But one day, you'll lose a step, or drop a beat, or miss a detail... and you'll be gone forever.",
+  "The results of hard work and dedication always look like luck. But you know you've earned every ounce of your success."
+]

--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "June 28, 2018",
+  "date": "July 4, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [],
   "THESE ABILITIES HAVE ENHANCED": [
@@ -32,7 +32,8 @@
     "You can now pin a message to the channel just by adding either 📌 or 📍 reaction to a message",
     "You can now run multiple giveaways",
     "Reaction Roles. Similar to self assignable roles, but instead of using commands, you just need to add/remove reactions to get roles",
-    "AFK Mode. Users can now set themselves as AFK and anyone mentioning them, in a server they manage, will be responded by Bastion that the user is AFK."
+    "AFK Mode. Users can now set themselves as AFK and anyone mentioning them, in a server they manage, will be responded by Bastion that the user is AFK.",
+    "Level up messages will now show some inspirational texts."
   ],
   "NEW COMMANDS!": [
     "`blacklist` - Blacklist users globally from using Bastion.",

--- a/handlers/levelHandler.js
+++ b/handlers/levelHandler.js
@@ -4,6 +4,8 @@
  * @license GPL-3.0
  */
 
+const levelUpMessages = xrequire('./assets/levelUpMessages.json');
+
 /**
  * Handles user's experience points and levels
  * @param {Message} message Discord.js message object
@@ -71,14 +73,25 @@ module.exports = async message => {
         });
 
         if (guildModel.dataValues.levelUpMessages) {
+          let levelUpMessage = levelUpMessages[Math.floor(Math.random() * levelUpMessages.length)];
+
           message.channel.send({
             embed: {
               color: message.client.colors.BLUE,
-              title: 'Leveled up',
-              description: `:up: **${message.author.username}**#${message.author.discriminator} leveled up to **Level ${currentLevel}**`
+              title: 'LEVELED UP!',
+              description: levelUpMessage,
+              thumbnail: {
+                url: `https://dummyimage.com/250/40C4FB/&text=${currentLevel}`
+              },
+              fields: [
+                {
+                  name: `${message.author.tag} leveled up to Level ${currentLevel}`,
+                  value: '\u200B'
+                }
+              ]
             }
           }).then(msg => {
-            msg.delete(5000).catch(() => {});
+            msg.delete(90000).catch(() => {});
           }).catch(e => {
             message.client.log.error(e);
           });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.26",
+  "version": "7.0.0-alpha.27",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",


### PR DESCRIPTION
#### Changes introduced by this PR
* Shows inspirational level up messages rather than the old generic *Leveled Up!* text.
* Level up messages will now last for 90 seconds so users can read the message before it gets deleted.
* Minor UI changes to the level up message.

#### Possible drawbacks
None

#### Applicable Issues
\-

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
