### PR TITLE
More message events

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "July 10, 2018",
+  "date": "July 11, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [],
   "THESE ABILITIES HAVE ENHANCED": [
@@ -16,6 +16,7 @@
     "Show if a server is a Bastion premium server in the `serverInfo` command.",
     "Adding music from user playlist to the queue is now faster than ever.",
     "Warnings are now permanently stored!",
+    "Server logging will now also log message update and message delete events.",
     "Tons of under-the-hood improvements & changes."
   ],
   "NEW FEATURES!": [

--- a/events/messageDelete.js
+++ b/events/messageDelete.js
@@ -1,0 +1,66 @@
+/**
+ * @file messageDelete event
+ * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
+ * @license GPL-3.0
+ */
+
+module.exports = async message => {
+  try {
+    let guildModel = await message.client.database.models.guild.findOne({
+      attributes: [ 'serverLog' ],
+      where: {
+        guildID: message.guild.id
+      }
+    });
+
+    if (!guildModel || !guildModel.dataValues.serverLog) return;
+
+    let logChannel = message.guild.channels.get(guildModel.dataValues.serverLog);
+    if (!logChannel) return;
+
+    logChannel.send({
+      embed: {
+        color: message.client.colors.RED,
+        title: message.client.i18n.event(message.guild.language, 'messageDelete'),
+        fields: [
+          {
+            name: 'Message Channel',
+            value: message.channel.toString(),
+            inline: true
+          },
+          {
+            name: 'Message Channel ID',
+            value: message.channel.id,
+            inline: true
+          },
+          {
+            name: 'Message ID',
+            value: message.id,
+            inline: true
+          },
+          {
+            name: 'Message Author',
+            value: message.author.tag,
+            inline: true
+          },
+          {
+            name: 'Message Author ID',
+            value: message.author.id,
+            inline: true
+          },
+          {
+            name: 'Message Content',
+            value: '~~Deleted~~',
+            inline: true
+          }
+        ],
+        timestamp: new Date()
+      }
+    }).catch(e => {
+      message.client.log.error(e);
+    });
+  }
+  catch (e) {
+    message.client.log.error(e);
+  }
+};

--- a/events/messageUpdate.js
+++ b/events/messageUpdate.js
@@ -14,30 +14,22 @@ module.exports = async  (oldMessage, newMessage) => {
     // If message content hasn't been changed, do nothing
     if (oldMessage.content === newMessage.content) return;
 
-    /**
-     * Filter Bastion's credentials from the message
-     */
+    // Filter Bastion's credentials from the message
     credentialsFilter(newMessage);
 
     if (!oldMessage.guild) return;
     if (newMessage.author.bot) return;
 
-    /**
-     * Filter specific words from the message
-     */
+    // Filter specific words from the message
     wordFilter(newMessage);
 
-    /**
-     * Filter links from the message
-     */
+    // Filter links from the message
     linkFilter(newMessage);
 
-    /**
-     * Filter Discord server invites from the message
-     */
+    // Filter Discord server invites from the message
     inviteFilter(newMessage);
 
-
+    // Server Logging
     let guildModel = await newMessage.client.database.models.guild.findOne({
       attributes: [ 'serverLog' ],
       where: {

--- a/events/messageUpdate.js
+++ b/events/messageUpdate.js
@@ -9,30 +9,90 @@ const wordFilter = xrequire('./utils/wordFilter');
 const linkFilter = xrequire('./utils/linkFilter');
 const inviteFilter = xrequire('./utils/inviteFilter');
 
-module.exports = (oldMessage, newMessage) => {
-  // If message content hasn't been changed, do nothing
-  if (oldMessage.content === newMessage.content) return;
+module.exports = async  (oldMessage, newMessage) => {
+  try {
+    // If message content hasn't been changed, do nothing
+    if (oldMessage.content === newMessage.content) return;
 
-  /**
-   * Filter Bastion's credentials from the message
-   */
-  credentialsFilter(newMessage);
+    /**
+     * Filter Bastion's credentials from the message
+     */
+    credentialsFilter(newMessage);
 
-  if (!oldMessage.guild) return;
-  if (newMessage.author.bot) return;
+    if (!oldMessage.guild) return;
+    if (newMessage.author.bot) return;
 
-  /**
-   * Filter specific words from the message
-   */
-  wordFilter(newMessage);
+    /**
+     * Filter specific words from the message
+     */
+    wordFilter(newMessage);
 
-  /**
-   * Filter links from the message
-   */
-  linkFilter(newMessage);
+    /**
+     * Filter links from the message
+     */
+    linkFilter(newMessage);
 
-  /**
-   * Filter Discord server invites from the message
-   */
-  inviteFilter(newMessage);
+    /**
+     * Filter Discord server invites from the message
+     */
+    inviteFilter(newMessage);
+
+
+    let guildModel = await newMessage.client.database.models.guild.findOne({
+      attributes: [ 'serverLog' ],
+      where: {
+        guildID: newMessage.guild.id
+      }
+    });
+
+    if (!guildModel || !guildModel.dataValues.serverLog) return;
+
+    let logChannel = newMessage.guild.channels.get(guildModel.dataValues.serverLog);
+    if (!logChannel) return;
+
+    logChannel.send({
+      embed: {
+        color: newMessage.client.colors.ORANGE,
+        title: newMessage.client.i18n.event(newMessage.guild.language, 'messageUpdate'),
+        fields: [
+          {
+            name: 'Message Channel',
+            value: newMessage.channel.toString(),
+            inline: true
+          },
+          {
+            name: 'Message Channel ID',
+            value: newMessage.channel.id,
+            inline: true
+          },
+          {
+            name: 'Message ID',
+            value: newMessage.id,
+            inline: true
+          },
+          {
+            name: 'Message Author',
+            value: newMessage.author.tag,
+            inline: true
+          },
+          {
+            name: 'Message Author ID',
+            value: newMessage.author.id,
+            inline: true
+          },
+          {
+            name: 'Old Message Content',
+            value: '~~Deleted~~',
+            inline: true
+          }
+        ],
+        timestamp: new Date()
+      }
+    }).catch(e => {
+      newMessage.client.log.error(e);
+    });
+  }
+  catch (e) {
+    newMessage.client.log.error(e);
+  }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.28",
+  "version": "7.0.0-alpha.29",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",


### PR DESCRIPTION
#### Changes introduced by this PR
* Add `messageDelete` event.
* Add server logging for `messageUpdate` and `messageDelete` event.

#### Possible drawbacks
If logging for `messageUpdate` event gets too noisy, I will probably remove it before release.

#### Applicable Issues
Closes #269 

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
