### PR TITLE
Guilds Listing

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -54,7 +54,8 @@
     "`roleEmoji` - Assign an emoji to a role.",
     "`reactionRolesGroup` - Creates a group of Reaction Roles and sends a message to which users can react to self assign roles to themselves and vice versa.",
     "`afk` - Sets AFK mode for the user.",
-    "`moveMembers` - Moves all the members in a voice channel to another specified voice channel."
+    "`moveMembers` - Moves all the members in a voice channel to another specified voice channel.",
+    "`listServers` - Lists all Discord servers that Bastion is connected to, in the current shard."
   ],
   "COMMANDS WITH NEW USAGE": [
     "`addTrigger` command's usage syntax has been changed. It won't work the way it used to before, please check the help message for it, using the `help addTrigger` command, to see the new usage details.",

--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "July 11, 2018",
+  "date": "July 13, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [],
   "THESE ABILITIES HAVE ENHANCED": [
@@ -68,7 +68,8 @@
   "RENAMED COMMANDS": [
     "Renamed `ignoreChannel` & `ignoreRole` commands to `ignoreChannels` & `ignoreRoles`, respectively.",
     "Renamed `votingChannel` command to `votingChannels`.",
-    "Renamed `resetModLogs` command to `resetModerationLogs`."
+    "Renamed `resetModLogs` command to `resetModerationLogs`.",
+    "Renamed `searchServer` command to `searchServers`. Also removed its `servers` alias and added `searchGuilds` alias."
   ],
   "NOT AVAILABLE ANYMORE": [
     "Removed `todo`, `listTodo` & `deleteTodo` commands.",

--- a/commands/owner/listServers.js
+++ b/commands/owner/listServers.js
@@ -1,0 +1,58 @@
+/**
+ * @file listServers command
+ * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
+ * @license GPL-3.0
+ */
+
+exports.exec = (Bastion, message, args) => {
+  let guilds = Array.from(Bastion.guilds.values());
+
+  let totalGuilds = guilds.length;
+  let noOfPages = totalGuilds / 2;
+  let p = (args.page > 0 && args.page < noOfPages + 1) ? args.page : 1;
+  p = p - 1;
+
+  guilds = guilds.slice(p * 2, (p * 2) + 2);
+
+  let fields = [];
+  for (let i = 0; i < guilds.length; i++) {
+    fields.push({
+      name: guilds[i].name,
+      value: guilds[i].id
+    });
+  }
+
+
+  message.channel.send({
+    embed: {
+      color: Bastion.colors.BLUE,
+      title: 'Server List',
+      description: `Bastion is connected to **${totalGuilds}** servers${Bastion.shard ? `, in Shard ${Bastion.shard.id}` : ''}.`,
+      fields: fields,
+      footer: {
+        text: `Page: ${p + 1} of ${noOfPages > parseInt(noOfPages) ? parseInt(noOfPages) + 1 : parseInt(noOfPages)}`
+      }
+    }
+  }).catch(e => {
+    Bastion.log.error(e);
+  });
+};
+
+exports.config = {
+  aliases: [ 'servers' ],
+  enabled: true,
+  ownerOnly: true,
+  argsDefinitions: [
+    { name: 'page', type: Number, alias: 'p', defaultOption: true, defaultValue: 1 }
+  ]
+};
+
+exports.help = {
+  name: 'listServers',
+  description: 'Lists all Discord servers that Bastion is connected to, in the current shard.',
+  botPermission: '',
+  userTextPermission: '',
+  userVoicePermission: '',
+  usage: 'listServers [PAGE_NO]',
+  example: [ 'listServers 2' ]
+};

--- a/commands/owner/searchServers.js
+++ b/commands/owner/searchServers.js
@@ -1,5 +1,5 @@
 /**
- * @file searchServer command
+ * @file searchServers command
  * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
  * @license GPL-3.0
  */
@@ -35,17 +35,17 @@ exports.exec = (Bastion, message, args) => {
 };
 
 exports.config = {
-  aliases: [ 'servers' ],
+  aliases: [ 'searchGuilds' ],
   enabled: true,
   ownerOnly: true
 };
 
 exports.help = {
-  name: 'searchServer',
+  name: 'searchServers',
   description: 'Searches for Discord servers, containing the specified text in their name, that Bastion is connected to.',
   botPermission: '',
   userTextPermission: '',
   userVoicePermission: '',
-  usage: 'searchServer <name>',
-  example: [ 'searchServer Bastion' ]
+  usage: 'searchServers <name>',
+  example: [ 'searchServers Bastion' ]
 };

--- a/data/commands.json
+++ b/data/commands.json
@@ -539,6 +539,10 @@
     "description": "Lists all self-assignable roles.",
     "module": "Guild Admin"
   },
+  "listServers": {
+    "description": "Lists all Discord servers that Bastion is connected to, in the current shard.",
+    "module": "Owner"
+  },
   "listTriggers": {
     "description": "Lists all the message triggers.",
     "module": "Guild Admin"

--- a/data/commands.json
+++ b/data/commands.json
@@ -875,7 +875,7 @@
     "description": "Schedule a command as cron jobs to run at the specified schedule.\n`cron` expression format:```Second         0-59 or * or range\nMinute         0-59 or * or range\nHour           0-23 or * or range\nDay of month   1-31 or * or range\nMonth          1-12 or * or range\nDay of week    0-7 (0 or 7 is SUN) or * or range```",
     "module": "Owner"
   },
-  "searchServer": {
+  "searchServers": {
     "description": "Searches for Discord servers, containing the specified text in their name, that Bastion is connected to.",
     "module": "Owner"
   },

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -656,7 +656,7 @@
   "scheduleCommand": {
     "description": "Schedule a command as cron jobs to run at the specified schedule.\n`cron` expression format:```Second         0-59 or * or range\nMinute         0-59 or * or range\nHour           0-23 or * or range\nDay of month   1-31 or * or range\nMonth          1-12 or * or range\nDay of week    0-7 (0 or 7 is SUN) or * or range```"
   },
-  "searchServer": {
+  "searchServers": {
     "description": "Searches for Discord servers, containing the specified text in their name, that Bastion is connected to."
   },
   "selfDestruct": {

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -404,6 +404,9 @@
   "listSelfAssignableRoles": {
     "description": "Lists all self-assignable roles."
   },
+  "listServers": {
+    "description": "Lists all Discord servers that Bastion is connected to, in the current shard."
+  },
   "listTriggers": {
     "description": "Lists all the message triggers."
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.29",
+  "version": "7.0.0-alpha.30",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",


### PR DESCRIPTION
#### Changes introduced by this PR
* Added `listServers` command. As the name suggests, it'll list all the guilds Bastion is connected to (well, all the guilds in the current shard).
* Renamed `searchServer` command to `searchServers`.
* Removed the `servers` alias from `searchServers` command (`servers` is now an alias of `listServers` command).
* Added `searchGuilds` alias to `searchServers` command.

#### Possible drawbacks
None

#### Applicable Issues
Closes #275 

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
