### PR TITLE
Making --server mute able to use a timer

### DIFF
--- a/commands/moderation/textMute.js
+++ b/commands/moderation/textMute.js
@@ -15,9 +15,9 @@ exports.exec = async (Bastion, message, args) => {
     }
     if (!user) {
       /**
-      * The command was ran with invalid parameters.
-      * @fires commandUsage
-      */
+       * The command was ran with invalid parameters.
+       * @fires commandUsage
+       */
       return Bastion.emit('commandUsage', message, this.help);
     }
 
@@ -43,6 +43,7 @@ exports.exec = async (Bastion, message, args) => {
           });
         }
       }
+
       if (args.timeout) {
         args.timeout = Math.abs(args.timeout);
 
@@ -93,9 +94,9 @@ exports.exec = async (Bastion, message, args) => {
     });
 
     /**
-    * Logs moderation events if it is enabled
-    * @fires moderationLog
-    */
+     * Logs moderation events if it is enabled
+     * @fires moderationLog
+     */
     Bastion.emit('moderationLog', message, this.help.name, user, args.reason, {
       channel: message.channel
     });

--- a/commands/moderation/textMute.js
+++ b/commands/moderation/textMute.js
@@ -43,6 +43,20 @@ exports.exec = async (Bastion, message, args) => {
           });
         }
       }
+      if (args.timeout) {
+        args.timeout = Math.abs(args.timeout);
+
+        if (!args.timeout || args.timeout > 1440) args.timeout = 1440;
+
+        Bastion.setTimeout(async () => {
+          try {
+            await member.removeRole(mutedRole);
+          }
+          catch (e) {
+            Bastion.log.error(e);
+          }
+        }, args.timeout * 60 * 1000);
+      }
     }
     else {
       await message.channel.overwritePermissions(user, {

--- a/commands/moderation/textMute.js
+++ b/commands/moderation/textMute.js
@@ -51,7 +51,7 @@ exports.exec = async (Bastion, message, args) => {
 
         Bastion.setTimeout(async () => {
           try {
-            await member.removeRole(mutedRole);
+            await member.removeRole(mutedRole, 'User auto unmuted after timeout.');
           }
           catch (e) {
             Bastion.log.error(e);


### PR DESCRIPTION
#### Changes introduced by this PR
When you use the 'textMute @user --server' then you can't add a timer with -t but with this change it would be posible to give people server mute for a day and then the bot removes the mute after

Closes https://github.com/TheBastionBot/Bastion/issues/296


#### Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] Test scripts passes
- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
