### PR TITLE
Adding --module to enableCommand

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "August 7, 2018",
+  "date": "August 8, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [],
   "THESE ABILITIES HAVE ENHANCED": [
@@ -17,6 +17,7 @@
     "Adding music from user playlist to the queue is now faster than ever.",
     "Warnings are now permanently stored!",
     "Server logging will now also log message update and message delete events.",
+    "You can now enable disabled modules using the `--module` option in the `enableCommand` command.",
     "Tons of under-the-hood improvements & changes."
   ],
   "NEW FEATURES!": [

--- a/commands/guild_admin/enableCommand.js
+++ b/commands/guild_admin/enableCommand.js
@@ -66,7 +66,6 @@ exports.exec = async (Bastion, message, args) => {
       }
     });
     if (guildModel.dataValues.disabledCommands) {
-      // disabledCommands = disabledCommands.concat(guildModel.dataValues.disabledCommands);
       disabledCommands = guildModel.dataValues.disabledCommands.filter(value => !disabledCommands.includes(value));
     }
 

--- a/commands/guild_admin/enableCommand.js
+++ b/commands/guild_admin/enableCommand.js
@@ -53,9 +53,6 @@ exports.exec = async (Bastion, message, args) => {
   }
   else if (args.module) {
     args.module = args.module.join('_').toLowerCase();
-    if ([ 'owner', 'guild_admin' ].includes(args.module)) {
-      return Bastion.emit('error', '', 'You can\'t disable commands in this module.', message.channel);
-    }
 
     disabledCommands = Bastion.commands.filter(c => c.config.module === args.module).map(c => c.help.name.toLowerCase());
 

--- a/commands/guild_admin/enableCommand.js
+++ b/commands/guild_admin/enableCommand.js
@@ -19,9 +19,9 @@ exports.exec = async (Bastion, message, args) => {
     }
     else {
       /**
-      * Error condition is encountered.
-      * @fires error
-      */
+       * Error condition is encountered.
+       * @fires error
+       */
       return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notFound', 'command'), message.channel);
     }
 
@@ -63,7 +63,7 @@ exports.exec = async (Bastion, message, args) => {
       }
     });
     if (guildModel.dataValues.disabledCommands) {
-      disabledCommands = guildModel.dataValues.disabledCommands.filter(value => !disabledCommands.includes(value));
+      disabledCommands = guildModel.dataValues.disabledCommands.filter(command => !disabledCommands.includes(command));
     }
 
     description = Bastion.i18n.info(message.guild.language, 'enableModule', message.author.tag, args.module);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.37",
+  "version": "7.0.0-alpha.38",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",


### PR DESCRIPTION
#### Changes introduced by this PR
Adding the --module argument to the enableCommand so you can enable a whole module again after disabling a module, or just enable all the commands that you have disabled in one of your modules without having to do them separately.

#### Possible drawbacks
None

#### Applicable Issues
<!--
    Link any applicable Issues/PRs here. With a brief description explaining
    why.
-->

#### Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] Test scripts passes
- [x] Documentation is changed or added (if applicable)
- [ ] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)

