### PR TITLE
Fixing error in getting bio info

### DIFF
--- a/commands/info/profile.js
+++ b/commands/info/profile.js
@@ -49,7 +49,7 @@ exports.exec = async (Bastion, message, args) => {
 
     let bio;
     if (userModel && userModel.dataValues.bio) {
-      bio = await Bastion.methods.decodeString(guildMemberModel.dataValues.bio);
+      bio = await Bastion.methods.decodeString(userModel.dataValues.bio);
     }
     else {
       bio = `No bio has been set. ${user.id === message.author.id ? 'Set your bio using `setBio` command.' : ''}`;


### PR DESCRIPTION


#### Changes introduced by this PR
profile: Fixing calling the wrong table on getting bio

You are calling (guildMemberModel.dataValues.bio) when bio is saved under (userModel.dataValues.bio) so bot just error's out

#### Possible drawbacks

None

#### Applicable Issues

None

#### Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] Test scripts passes
- [ ] Documentation is changed or added (if applicable)
- [ ] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
