### PR TITLE
Fixing error in reactionRolesGroup.js

### DIFF
--- a/commands/guild_admin/reactionRolesGroup.js
+++ b/commands/guild_admin/reactionRolesGroup.js
@@ -145,7 +145,7 @@ exports.config = {
   enabled: true,
   argsDefinitions: [
     { name: 'roles', type: String, multiple: true, defaultOption: true },
-    { name: 'title', type: String, alias: 't', muiltiple: true },
+    { name: 'title', type: String, alias: 't', multiple: true },
     { name: 'body', type: String, alias: 'b', multiple: true },
     { name: 'exclusive', type: Boolean, alias: 'e', defaultValue: false },
     { name: 'remove', type: String, alias: 'r' }


### PR DESCRIPTION


#### Changes introduced by this PR
Fixing type error

args title didn't accept multiple args and made it error out because multiple: true was misspelled

#### Possible drawbacks

None

#### Applicable Issues

None

#### Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] Test scripts passes
- [ ] Documentation is changed or added (if applicable)
- [ ] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
