### PR TITLE
Remove requirement for Cleverbot API key

### DIFF
--- a/commands/guild_admin/chat.js
+++ b/commands/guild_admin/chat.js
@@ -6,14 +6,6 @@
 
 exports.exec = async (Bastion, message) => {
   try {
-    if (!Bastion.credentials.cleverbotAPIkey) {
-      /**
-      * Error condition is encountered.
-      * @fires error
-      */
-      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'noCredentials', 'Cleverbot API'), message.channel);
-    }
-
     let guildModel = await Bastion.database.models.guild.findOne({
       attributes: [ 'chat' ],
       where: {

--- a/handlers/conversationHandler.js
+++ b/handlers/conversationHandler.js
@@ -4,11 +4,7 @@
  * @license GPL-3.0
  */
 
-const CLEVERBOT = xrequire('cleverbot.js');
-const CREDENTIALS = xrequire('./settings/credentials.json');
-const BOT = new CLEVERBOT({
-  APIKey: CREDENTIALS.cleverbotAPIkey
-});
+const request = require('request-promise-native');
 
 /**
  * Handles conversations with Bastion
@@ -27,18 +23,24 @@ module.exports = async message => {
     });
     if (!guildModel.dataValues.chat) return;
 
-    let response = await BOT.write(message.content);
-    if (response.output) {
-      message.channel.startTyping();
-      setTimeout(async () => {
-        try {
-          message.channel.stopTyping(true);
-          await message.channel.send(response.output);
-        }
-        catch (e) {
-          message.client.log.error(e);
-        }
-      }, response.output.length * 100);
+    message.channel.startTyping();
+
+    let options = {
+      url: 'https://bastion-cleverbot.glitch.me/api',
+      qs: {
+        message: message.content.replace(/<@!?[0-9]{1,20}> ?/i, '')
+      },
+      json: true
+    };
+    let response = await request(options);
+
+    if (response.status === 'success') {
+      message.channel.stopTyping(true);
+      await message.channel.send(response.response);
+    }
+    else {
+      message.channel.stopTyping(true);
+      await message.channel.send('Beep. Beep. Boop. Boop.');
     }
   }
   catch (e) {

--- a/handlers/conversationHandler.js
+++ b/handlers/conversationHandler.js
@@ -13,7 +13,9 @@ const request = require('request-promise-native');
  */
 module.exports = async message => {
   try {
-    if (message.content.length <= `${message.client.user}  `.length) return;
+    message.content = message.content.replace(/^<@!?[0-9]{1,20}> ?/i, '');
+
+    if (message.content.length < 2) return;
 
     let guildModel = await message.client.database.models.guild.findOne({
       attributes: [ 'chat' ],
@@ -28,18 +30,18 @@ module.exports = async message => {
     let options = {
       url: 'https://bastion-cleverbot.glitch.me/api',
       qs: {
-        message: message.content.replace(/<@!?[0-9]{1,20}> ?/i, '')
+        message: message.content
       },
       json: true
     };
     let response = await request(options);
 
+    message.channel.stopTyping(true);
+
     if (response.status === 'success') {
-      message.channel.stopTyping(true);
       await message.channel.send(response.response);
     }
     else {
-      message.channel.stopTyping(true);
       await message.channel.send('Beep. Beep. Boop. Boop.');
     }
   }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@k3rn31p4nic/google-translate-api": "~1.0.4",
     "chalk": "~2.4.1",
     "cheerio": "~1.0.0-rc.2",
-    "cleverbot.js": "~1.0.0",
     "color-convert": "~1.9.2",
     "command-line-args": "github:k3rn31p4nic/command-line-args",
     "cron": "~1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.42",
+  "version": "7.0.0-alpha.43",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",

--- a/settings/credentials_example.json
+++ b/settings/credentials_example.json
@@ -24,7 +24,6 @@
   "theMovieDBApiKey": "",
   "IGDBUserKey": "",
   "musixmatchAPIKey": "",
-  "cleverbotAPIkey": "",
   "github": {
     "accessToken": ""
   },


### PR DESCRIPTION
#### Changes introduced by this PR
This PR implements [Bastion Cleverbot API](https://github.com/TheBastionBot/cleverbot.bastionbot.org) into Bastion, which removes the requirement for Cleverbot API key.

#### Possible drawbacks
None

#### Applicable Issues
Closes #343 

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
