### PR TITLE
Custom avatars for Bastion profile

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "September 9, 2018",
+  "date": "September 10, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [],
   "THESE ABILITIES HAVE ENHANCED": [
@@ -59,7 +59,8 @@
     "`mentionRole` - Mentions any unmentionable role.",
     "`roblox` - Get info of any Roblox player.",
     "`apod` - Get the Astronomy Picture of the Day from NASA.",
-    "`ark` - Get stats of any ARK: Survival Evolved game server."
+    "`ark` - Get stats of any ARK: Survival Evolved game server.",
+    "`setProfilePicture` - Sets your profile picture that shows up in the Bastion user profile."
   ],
   "COMMANDS WITH NEW USAGE": [
     "`addTrigger` command's usage syntax has been changed. It won't work the way it used to before, please check the help message for it, using the `help addTrigger` command, to see the new usage details.",

--- a/commands/info/profile.js
+++ b/commands/info/profile.js
@@ -33,7 +33,7 @@ exports.exec = async (Bastion, message, args) => {
     });
 
     let userModel = await Bastion.database.models.user.findOne({
-      attributes: [ 'bio', 'birthDate', 'color', 'location' ],
+      attributes: [ 'avatar', 'bio', 'birthDate', 'color', 'location' ],
       where: {
         userID: user.id
       }
@@ -103,7 +103,7 @@ exports.exec = async (Bastion, message, args) => {
         description: bio,
         fields: profileData,
         thumbnail: {
-          url: user.displayAvatarURL
+          url: userModel && userModel.dataValues.avatar ? userModel.dataValues.avatar : user.displayAvatarURL
         },
         footer: {
           text: `${guildMemberModel.dataValues.reputations} Reputation${parseInt(guildMemberModel.dataValues.reputations) === 1 ? '' : 's'}`

--- a/commands/info/setProfilePicture.js
+++ b/commands/info/setProfilePicture.js
@@ -1,0 +1,70 @@
+/**
+ * @file setProfilePicture command
+ * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
+ * @license GPL-3.0
+ */
+
+exports.exec = async (Bastion, message, args) => {
+  try {
+    args = args.join(' ');
+    if (!/^(https?:\/\/)((([-a-z0-9]{1,})?(-?)+[-a-z0-9]{1,})(\.))+([a-z]{1,63})\/((([a-z0-9._\-~#%])+\/)+)?([a-z0-9._\-~#%]+)\.(jpg|jpeg|gif|png|bmp)$/i.test(args)) {
+      /**
+       * The command was ran with invalid parameters.
+       * @fires commandUsage
+       */
+      return Bastion.emit('commandUsage', message, this.help);
+    }
+
+    let userModel = await Bastion.database.models.user.findOne({
+      attributes: [ 'avatar' ],
+      where: {
+        userID: message.author.id
+      }
+    });
+
+    if (!userModel) return;
+
+    await Bastion.database.models.user.update({
+      avatar: args
+    },
+    {
+      where: {
+        userID: message.author.id
+      },
+      fields: [ 'avatar' ]
+    });
+
+    message.channel.send({
+      embed: {
+        color: Bastion.colors.GREEN,
+        title: 'Profile Picture Set',
+        image: {
+          url: args
+        },
+        footer: {
+          text: message.author.tag
+        }
+      }
+    }).catch(e => {
+      Bastion.log.error(e);
+    });
+  }
+  catch (e) {
+    Bastion.log.error(e);
+  }
+};
+
+exports.config = {
+  aliases: [],
+  enabled: true
+};
+
+exports.help = {
+  name: 'setProfilePicture',
+  description: 'Sets your profile picture that shows up in the Bastion user profile.',
+  botPermission: '',
+  userTextPermission: '',
+  userVoicePermission: '',
+  usage: 'setProfilePicture <IMAGE_URL>',
+  example: [ 'setProfilePicture https://bastionbot.org/avatar.gif' ]
+};

--- a/data/commands.json
+++ b/data/commands.json
@@ -987,6 +987,10 @@
     "description": "Sets %bastion%'s prefix for the server.",
     "module": "Guild Admin"
   },
+  "setProfilePicture": {
+    "description": "Sets your profile picture that shows up in the Bastion user profile.",
+    "module": "Info"
+  },
   "setStatus": {
     "description": "Sets the status of %bastion%.",
     "module": "Owner"

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -740,6 +740,9 @@
   "setPrefix": {
     "description": "Sets %bastion%'s prefix for the server."
   },
+  "setProfilePicture": {
+    "description": "Sets your profile picture that shows up in the Bastion user profile."
+  },
   "setStatus": {
     "description": "Sets the status of %bastion%."
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.43",
+  "version": "7.0.0-alpha.44",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",

--- a/utils/models.js
+++ b/utils/models.js
@@ -237,6 +237,9 @@ module.exports = (Sequelize, database) => {
       allowNull: false,
       primaryKey: true
     },
+    avatar: {
+      type: Sequelize.STRING(2048)
+    },
     bio: {
       type: Sequelize.BLOB
     },


### PR DESCRIPTION
#### Changes introduced by this PR
* Added `avatar` field to the `User` model.
* Added `setProfilePicture` command to allow users to set their custom avatar.
* Updated `profile` command to show custom avatar (if available) instead of Discord avatar.

#### Possible drawbacks
None

#### Applicable Issues
\-

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
