### PR TITLE
Bastion profile bio should be called profile info

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "September 16, 2018",
+  "date": "September 19, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [],
   "THESE ABILITIES HAVE ENHANCED": [
@@ -74,7 +74,8 @@
     "Renamed `ignoreChannel` & `ignoreRole` commands to `ignoreChannels` & `ignoreRoles`, respectively.",
     "Renamed `votingChannel` command to `votingChannels`.",
     "Renamed `resetModLogs` command to `resetModerationLogs`.",
-    "Renamed `searchServer` command to `searchServers`. Also removed its `servers` alias and added `searchGuilds` alias."
+    "Renamed `searchServer` command to `searchServers`. Also removed its `servers` alias and added `searchGuilds` alias.",
+    "Renamed `setBio` command to `setInfo`."
   ],
   "NOT AVAILABLE ANYMORE": [
     "Removed `todo`, `listTodo` & `deleteTodo` commands.",

--- a/commands/info/profile.js
+++ b/commands/info/profile.js
@@ -52,7 +52,7 @@ exports.exec = async (Bastion, message, args) => {
       info = await Bastion.methods.decodeString(userModel.dataValues.info);
     }
     else {
-      info = `No info has been set. ${user.id === message.author.id ? 'Set your info using `setBio` command.' : ''}`;
+      info = `No info has been set. ${user.id === message.author.id ? 'Set your info using `setInfo` command.' : ''}`;
     }
 
     let profileData = [

--- a/commands/info/profile.js
+++ b/commands/info/profile.js
@@ -33,7 +33,7 @@ exports.exec = async (Bastion, message, args) => {
     });
 
     let userModel = await Bastion.database.models.user.findOne({
-      attributes: [ 'avatar', 'bio', 'birthDate', 'color', 'location' ],
+      attributes: [ 'avatar', 'info', 'birthDate', 'color', 'location' ],
       where: {
         userID: user.id
       }
@@ -48,8 +48,8 @@ exports.exec = async (Bastion, message, args) => {
     }
 
     let bio;
-    if (userModel && userModel.dataValues.bio) {
-      bio = await Bastion.methods.decodeString(userModel.dataValues.bio);
+    if (userModel && userModel.dataValues.info) {
+      bio = await Bastion.methods.decodeString(userModel.dataValues.info);
     }
     else {
       bio = `No bio has been set. ${user.id === message.author.id ? 'Set your bio using `setBio` command.' : ''}`;

--- a/commands/info/profile.js
+++ b/commands/info/profile.js
@@ -47,12 +47,12 @@ exports.exec = async (Bastion, message, args) => {
       return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'profileNotCreated', `<@${user.id}>`), message.channel);
     }
 
-    let bio;
+    let info;
     if (userModel && userModel.dataValues.info) {
-      bio = await Bastion.methods.decodeString(userModel.dataValues.info);
+      info = await Bastion.methods.decodeString(userModel.dataValues.info);
     }
     else {
-      bio = `No bio has been set. ${user.id === message.author.id ? 'Set your bio using `setBio` command.' : ''}`;
+      info = `No bio has been set. ${user.id === message.author.id ? 'Set your bio using `setBio` command.' : ''}`;
     }
 
     let profileData = [
@@ -100,7 +100,7 @@ exports.exec = async (Bastion, message, args) => {
           name: user.tag,
           icon_url: await getUserIcon(user)
         },
-        description: bio,
+        description: info,
         fields: profileData,
         thumbnail: {
           url: userModel && userModel.dataValues.avatar ? userModel.dataValues.avatar : user.displayAvatarURL

--- a/commands/info/profile.js
+++ b/commands/info/profile.js
@@ -52,7 +52,7 @@ exports.exec = async (Bastion, message, args) => {
       info = await Bastion.methods.decodeString(userModel.dataValues.info);
     }
     else {
-      info = `No bio has been set. ${user.id === message.author.id ? 'Set your bio using `setBio` command.' : ''}`;
+      info = `No info has been set. ${user.id === message.author.id ? 'Set your info using `setBio` command.' : ''}`;
     }
 
     let profileData = [

--- a/commands/info/setBio.js
+++ b/commands/info/setBio.js
@@ -1,5 +1,5 @@
 /**
- * @file setBio command
+ * @file setInfo command
  * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
  * @license GPL-3.0
  */
@@ -77,11 +77,11 @@ exports.config = {
 };
 
 exports.help = {
-  name: 'setBio',
+  name: 'setInfo',
   description: 'Sets your info that shows up in the Bastion user profile.',
   botPermission: '',
   userTextPermission: '',
   userVoicePermission: '',
-  usage: 'setBio <text>',
-  example: [ 'setBio I\'m awesome. :sunglasses:' ]
+  usage: 'setInfo <text>',
+  example: [ 'setInfo I\'m awesome. :sunglasses:' ]
 };

--- a/commands/info/setBio.js
+++ b/commands/info/setBio.js
@@ -16,9 +16,9 @@ exports.exec = async (Bastion, message, args) => {
     args = args.join(' ');
 
     let charLimit = 160;
-    let bio = await Bastion.methods.encodeString(args);
+    let info = await Bastion.methods.encodeString(args);
 
-    if (bio.length > charLimit) {
+    if (info.length > charLimit) {
       /**
       * Error condition is encountered.
       * @fires error
@@ -44,7 +44,7 @@ exports.exec = async (Bastion, message, args) => {
     }
 
     await Bastion.database.models.user.update({
-      info: bio
+      info: info
     },
     {
       where: {

--- a/commands/info/setBio.js
+++ b/commands/info/setBio.js
@@ -36,7 +36,7 @@ exports.exec = async (Bastion, message, args) => {
     if (!userModel) {
       return message.channel.send({
         embed: {
-          description: `<@${args.id}> you didn't had a profile yet. I've now created your profile. Now you can use the command again to set your bio.`
+          description: `<@${args.id}> you didn't had a profile yet. I've now created your profile. Now you can use the command again to set your info.`
         }
       }).catch(e => {
         Bastion.log.error(e);
@@ -56,7 +56,7 @@ exports.exec = async (Bastion, message, args) => {
     message.channel.send({
       embed: {
         color: Bastion.colors.GREEN,
-        title: 'Bio Set',
+        title: 'Info Set',
         description: args,
         footer: {
           text: args.tag
@@ -78,7 +78,7 @@ exports.config = {
 
 exports.help = {
   name: 'setBio',
-  description: 'Sets your bio that shows up in the Bastion user profile.',
+  description: 'Sets your info that shows up in the Bastion user profile.',
   botPermission: '',
   userTextPermission: '',
   userVoicePermission: '',

--- a/commands/info/setBio.js
+++ b/commands/info/setBio.js
@@ -27,7 +27,7 @@ exports.exec = async (Bastion, message, args) => {
     }
 
     let userModel = await Bastion.database.models.user.findOne({
-      attributes: [ 'bio' ],
+      attributes: [ 'info' ],
       where: {
         userID: message.author.id
       }
@@ -44,13 +44,13 @@ exports.exec = async (Bastion, message, args) => {
     }
 
     await Bastion.database.models.user.update({
-      bio: bio
+      info: bio
     },
     {
       where: {
         userID: message.author.id
       },
-      fields: [ 'bio' ]
+      fields: [ 'info' ]
     });
 
     message.channel.send({

--- a/commands/info/setBio.js
+++ b/commands/info/setBio.js
@@ -23,7 +23,7 @@ exports.exec = async (Bastion, message, args) => {
       * Error condition is encountered.
       * @fires error
       */
-      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'bioRange', charLimit), message.channel);
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'infoRange', charLimit), message.channel);
     }
 
     let userModel = await Bastion.database.models.user.findOne({

--- a/data/commands.json
+++ b/data/commands.json
@@ -959,16 +959,16 @@
     "description": "Sets the avatar of %bastion%.",
     "module": "Owner"
   },
-  "setBio": {
-    "description": "Sets your bio that shows up in the Bastion user profile.",
-    "module": "Info"
-  },
   "setBirthDate": {
     "description": "Sets your birth date that shows up in the Bastion user profile. Don't worry Bastion will never show your age/year to public.",
     "module": "Info"
   },
   "setColor": {
     "description": "Sets your user color that is used in the Bastion user profile.",
+    "module": "Info"
+  },
+  "setInfo": {
+    "description": "Sets your info that shows up in the Bastion user profile.",
     "module": "Info"
   },
   "setLanguage": {

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -719,14 +719,14 @@
   "setAvatar": {
     "description": "Sets the avatar of %bastion%."
   },
-  "setBio": {
-    "description": "Sets your bio that shows up in the Bastion user profile."
-  },
   "setBirthDate": {
     "description": "Sets your birth date that shows up in the Bastion user profile. Don't worry Bastion will never show your age/year to public."
   },
   "setColor": {
     "description": "Sets your user color that is used in the Bastion user profile."
+  },
+  "setInfo": {
+    "description": "Sets your info that shows up in the Bastion user profile."
   },
   "setLanguage": {
     "description": "Sets %bastion%'s language for the server."

--- a/locales/en_us/error.json
+++ b/locales/en_us/error.json
@@ -2,7 +2,7 @@
   "ageAbove100": "Are you kidding me? You're more than 100 years old (and using Discord)! Try again with a valid age.",
   "ageBelow13": "Sorry kid, you're not even allowed to use Discord until you turn 13.",
   "bastionMissingPermissions": "I need %var% permission to run this command.",
-  "bioRange": "Bio should be fewer than %var% characters.",
+  "infoRange": "Info should be fewer than %var% characters.",
   "channelNameLength": "Channel name should be between %var% and %var% characters.",
   "channelNotFound": "The specified channel was not found.",
   "claimCooldown": "%var% you have recently claimed your daily reward, please try again tomorrow. You can claim daily rewards only once every day.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.46",
+  "version": "7.0.0-alpha.47",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",

--- a/utils/models.js
+++ b/utils/models.js
@@ -240,7 +240,7 @@ module.exports = (Sequelize, database) => {
     avatar: {
       type: Sequelize.STRING(2048)
     },
-    bio: {
+    info: {
       type: Sequelize.BLOB
     },
     birthDate: {


### PR DESCRIPTION
#### Changes introduced by this PR
This PR renames Bastion profile bio to profile info.
* Rename `bio` field in the `User` DB model to `info`.
* Rename the `setBio` command to `setInfo`.

#### Possible drawbacks
None

#### Applicable Issues
\-

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
