### PR TITLE
data: remove data/.meta file

### DIFF
--- a/data/.meta
+++ b/data/.meta
@@ -1,3 +1,0 @@
-All the files that are dynamically generated when Bastion is in a running
-state are stored in this directory.
-Those files include database, playlist, etc.


### PR DESCRIPTION
#### Changes introduced by this PR
This PR removes the `.meta` file inside the `data` directory as that isn't required for anything anymore.

#### Possible drawbacks
None

#### Applicable Issues
\-

#### Checklist
- [X] Test scripts passes
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
