### PR TITLE
fix cat command

### DIFF
--- a/commands/fun/cat.js
+++ b/commands/fun/cat.js
@@ -13,10 +13,11 @@ exports.exec = async (Bastion, message) => {
       url: 'https://thecatapi.com/api/images/get',
       followAllRedirects: true
     };
-    let response = await request(options);
+    let pic;
+    await request(options, function (error, response) { pic = response.request.uri.href; });
 
     await message.channel.send({
-      files: [ response.original_image ]
+      files: [ pic ]
     });
   }
   catch (e) {

--- a/commands/fun/cat.js
+++ b/commands/fun/cat.js
@@ -11,13 +11,13 @@ exports.exec = async (Bastion, message) => {
     let options = {
       method: 'HEAD',
       url: 'https://thecatapi.com/api/images/get',
-      followAllRedirects: true
+      followAllRedirects: true,
+      resolveWithFullResponse: true
     };
-    let pic;
-    await request(options, function (error, response) { pic = response.request.uri.href; });
+    let response = await request(options);
 
     await message.channel.send({
-      files: [ pic ]
+      files: [ response.request.uri.href ]
     });
   }
   catch (e) {


### PR DESCRIPTION
fix cat command

The edits done gets the redirection url from the request , puts it in a variable and sends the variable to the channel.

#### Changes introduced by this PR
The url of the picture is now obtained from the redirection in the header, other than the body.

#### Possible drawbacks
<!--
    Are there any possible side-effects or negative impacts of the code change?
    If yes, please, state them.
-->

#### Applicable Issues
Fixes : https://github.com/TheBastionBot/Bastion/issues/356

#### Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] Test scripts passes
- [ ] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
