### PR TITLE
Update & externalize endorsement messages

### DIFF
--- a/commands/fun/echo.js
+++ b/commands/fun/echo.js
@@ -18,7 +18,7 @@ exports.exec = (Bastion, message, args) => {
       color: Bastion.colors.DEFAULT,
       description: args.join(' '),
       footer: {
-        text: `${Bastion.credentials.ownerId.includes(message.author.id) ? '' : Bastion.i18n.error(message.guild.language, 'endorsementMessage')}`
+        text: `${!Bastion.credentials.ownerId.includes(message.author.id) ? '' : Bastion.i18n.info(message.guild.language, 'endorsementMessage')}`
       }
     }
   }).catch(e => {

--- a/commands/fun/echo.js
+++ b/commands/fun/echo.js
@@ -18,7 +18,7 @@ exports.exec = (Bastion, message, args) => {
       color: Bastion.colors.DEFAULT,
       description: args.join(' '),
       footer: {
-        text: `${Bastion.credentials.ownerId.includes(message.author.id) ? '' : 'This content is neither created nor endorsed by Bastion.'}`
+        text: `${Bastion.credentials.ownerId.includes(message.author.id) ? '' : Bastion.i18n.error(message.guild.language, 'endorsementMessage')}`
       }
     }
   }).catch(e => {

--- a/commands/fun/echo.js
+++ b/commands/fun/echo.js
@@ -18,7 +18,7 @@ exports.exec = (Bastion, message, args) => {
       color: Bastion.colors.DEFAULT,
       description: args.join(' '),
       footer: {
-        text: `${Bastion.credentials.ownerId.includes(message.author.id) ? '' : 'This is not an official message from Bastion or from its creators.'}`
+        text: `${Bastion.credentials.ownerId.includes(message.author.id) ? '' : 'This content is neither created nor endorsed by Bastion.'}`
       }
     }
   }).catch(e => {

--- a/commands/fun/selfDestruct.js
+++ b/commands/fun/selfDestruct.js
@@ -34,7 +34,7 @@ exports.exec = async (Bastion, message, args) => {
         color: Bastion.colors.DEFAULT,
         description: args.content.join(' '),
         footer: {
-          text: `${Bastion.credentials.ownerId.includes(message.author.id) ? '' : 'This content is neither created nor endorsed by Bastion.'}`
+          text: `${Bastion.credentials.ownerId.includes(message.author.id) ? '' : Bastion.i18n.error(message.guild.language, 'endorsementMessage')}`
         }
       }
     });

--- a/commands/fun/selfDestruct.js
+++ b/commands/fun/selfDestruct.js
@@ -34,7 +34,7 @@ exports.exec = async (Bastion, message, args) => {
         color: Bastion.colors.DEFAULT,
         description: args.content.join(' '),
         footer: {
-          text: `${Bastion.credentials.ownerId.includes(message.author.id) ? '' : Bastion.i18n.error(message.guild.language, 'endorsementMessage')}`
+          text: `${Bastion.credentials.ownerId.includes(message.author.id) ? '' : Bastion.i18n.info(message.guild.language, 'endorsementMessage')}`
         }
       }
     });

--- a/commands/fun/selfDestruct.js
+++ b/commands/fun/selfDestruct.js
@@ -34,7 +34,7 @@ exports.exec = async (Bastion, message, args) => {
         color: Bastion.colors.DEFAULT,
         description: args.content.join(' '),
         footer: {
-          text: `${Bastion.credentials.ownerId.includes(message.author.id) ? '' : 'This is not an official message from Bastion or from its creators.'}`
+          text: `${Bastion.credentials.ownerId.includes(message.author.id) ? '' : 'This content is neither created nor endorsed by Bastion.'}`
         }
       }
     });

--- a/commands/fun/sendEmbed.js
+++ b/commands/fun/sendEmbed.js
@@ -16,7 +16,7 @@ exports.exec = (Bastion, message, args) => {
 
     args = JSON.parse(args.join(' '));
     args.footer = {
-      text: `${Bastion.credentials.ownerId.includes(message.author.id) ? '' : 'This is not an official message from Bastion or from its creators.'}`
+      text: `${Bastion.credentials.ownerId.includes(message.author.id) ? '' : 'This content is neither created nor endorsed by Bastion.'}`
     };
 
     message.channel.send({

--- a/commands/fun/sendEmbed.js
+++ b/commands/fun/sendEmbed.js
@@ -16,7 +16,7 @@ exports.exec = (Bastion, message, args) => {
 
     args = JSON.parse(args.join(' '));
     args.footer = {
-      text: `${Bastion.credentials.ownerId.includes(message.author.id) ? '' : 'This content is neither created nor endorsed by Bastion.'}`
+      text: `${Bastion.credentials.ownerId.includes(message.author.id) ? '' : Bastion.i18n.error(message.guild.language, 'endorsementMessage')}`
     };
 
     message.channel.send({

--- a/commands/fun/sendEmbed.js
+++ b/commands/fun/sendEmbed.js
@@ -16,7 +16,7 @@ exports.exec = (Bastion, message, args) => {
 
     args = JSON.parse(args.join(' '));
     args.footer = {
-      text: `${Bastion.credentials.ownerId.includes(message.author.id) ? '' : Bastion.i18n.error(message.guild.language, 'endorsementMessage')}`
+      text: `${Bastion.credentials.ownerId.includes(message.author.id) ? '' : Bastion.i18n.info(message.guild.language, 'endorsementMessage')}`
     };
 
     message.channel.send({

--- a/locales/en_us/info.json
+++ b/locales/en_us/info.json
@@ -103,5 +103,7 @@
   "lastSeen": "%var% was last seen %var% ago.",
   "notSeen": "I have not seen %var% in a while.",
   "deleteReminder": "%var% your reminders have been deleted.",
-  "addReminder": "%var% I will remind you to **%var%** after **%var%**."
+  "addReminder": "%var% I will remind you to **%var%** after **%var%**.",
+
+  "endorsementMessage": "This content is neither created nor endorsed by Bastion."
 }


### PR DESCRIPTION
#### Changes introduced by this PR
This PR updates the endorsement messages that's shown in messages by Bastion which are not created by Bastion or the bot owner. This also externalizes the endorsement message to info locale string.

#### Possible drawbacks
None

#### Applicable Issues
\-

#### Checklist
- [X] Test scripts passes
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
