### PR TITLE
Use yarn package manager

### DIFF
--- a/.github/DEVELOPMENT_ENVIRONMENT.md
+++ b/.github/DEVELOPMENT_ENVIRONMENT.md
@@ -23,5 +23,6 @@ The next step is to install the dev dependencies of Bastion so that you get all
 the things needed to properly develop Bastion.
 
 ```bash
-npm install --only=development
+npm install --global yarn
+yarn install
 ```

--- a/.github/TESTING.md
+++ b/.github/TESTING.md
@@ -7,7 +7,7 @@ your code is consistent with Bastion's [style guide] and doesn't break anything.
 After you've coded your heart out, run all the specified test scripts, by
 running this in your terminal:
 ```bash
-npm test
+yarn test
 ```
 This will verify the consistency of the coding style and if Bastion boots
 successfully.

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,14 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then npm install -g ffmpeg-binaries; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ffmpeg; fi
+  - npm install --global yarn
 install:
-  - npm install
+  - yarn install
 before_script:
   - cp settings/credentials_example.json settings/credentials.json
   - cp settings/config_example.json settings/config.json
 script:
-  - npm test
+  - yarn test
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then shellcheck -x *.sh; fi
 after_success:
   - wget https://raw.githubusercontent.com/k3rn31p4nic/travis-ci-discord-webhook/master/send.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,8 @@ image:
 clone_depth: 1
 install:
   - choco install nodejs-lts
-  - npm install
+  - npm install --global yarn
+  - yarn install
 platform: x64
 build: off
 before_test:
@@ -18,8 +19,8 @@ before_test:
   - cp settings\config_example.json settings\config.json
 test_script:
   - node --version
-  - npm --version
-  - npm test
+  - yarn --version
+  - yarn test
 on_success:
   - ps: Invoke-RestMethod https://raw.githubusercontent.com/k3rn31p4nic/appveyor-discord-webhook/master/send.ps1 -o send.ps1
   - ps: ./send.ps1 success $env:WEBHOOK_URL

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "main": "index.js",
   "scripts": {
     "build:commandStrings": "node -r ./utils/globals.js utils/generateCommandStrings.js",
-    "build": "npm run build:commandStrings",
+    "build": "yarn run build:commandStrings",
     "test:lint": "./node_modules/.bin/eslint .",
     "test:modules": "node -r ./utils/globals.js tests/modules.js",
     "test:boot": "node -r ./utils/globals.js tests/boot.js",
-    "test": "npm run test:lint && npm run test:modules && npm run test:boot",
+    "test": "yarn run test:lint && yarn run test:modules && yarn run test:boot",
     "start": "node -r ./utils/globals.js index.js",
     "start:noshard": "node -r ./utils/globals.js bastion.js"
   },

--- a/scripts/bash/methods.sh
+++ b/scripts/bash/methods.sh
@@ -24,7 +24,7 @@ function method::debug () {
 function method::fix-dependencies () {
   print::message "Fixing dependencies..."
   rm -rf node_modules package-lock.json
-  npm i --only=production --no-package-lock
+  yarn install --production --no-lockfile
 }
 
 function method::fix-locales () {
@@ -162,7 +162,7 @@ function method::update () {
     echo "Updating dependencies..."
 
     rm -fr node_modules package-lock.json screenlog.0
-    npm i --only=production --no-package-lock
+    yarn install --production --no-lockfile
     if ! [[ "$?" -eq 0 ]]
     then
       print::error "Failed to install dependencies."

--- a/scripts/powershell/Update.ps1
+++ b/scripts/powershell/Update.ps1
@@ -65,10 +65,10 @@ Write-Host "[Bastion]: Updating dependencies..."
 Write-Host
 
 Remove-Item -Path ".\node_modules", ".\package-lock.json" -Force -Recurse -ErrorAction SilentlyContinue
-npm install --only=production --no-package-lock
+yarn install --production --no-lockfile
 If (-Not ($?)) {
   Write-Host "[Bastion]: Unable to update Bastion, error while updating dependencies."
-  Write-Host "[Bastion]: Try updating it manually: npm i --only=production --no-package-lock"
+  Write-Host "[Bastion]: Try updating it manually: yarn install --production --no-lockfile"
   Write-Host "[Bastion]: Contact Bastion Support for further help."
 
   Exit-Bastion-Updater


### PR DESCRIPTION
#### Changes introduced by this PR
This PR updates Bastion to use `yarn` instead of `npm`. 

#### Possible drawbacks
None

#### Applicable Issues
\-

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
