### PR TITLE
Issue 374 show proper message when no one's streaming

### DIFF
--- a/commands/queries/live.js
+++ b/commands/queries/live.js
@@ -6,11 +6,12 @@
 
 exports.exec = (Bastion, message) => {
   let streamers = Array.from(message.guild.presences.filter(p => p.game && p.game.streaming === true).keys());
+
   message.channel.send({
     embed: {
       color: Bastion.colors.DARK_PURPLE,
       title: 'Users Streaming',
-      description: !streamers.length ? 'No users currently streaming' : streamers.length > 10 ? `<@${streamers.splice(0, 10).join('>\n<@')}>\nand ${streamers.length - 10} others are now live.` : `<@${streamers.join('>\n<@')}>`
+      description: !streamers.length ? 'No one is currently streaming in this server.' : streamers.length > 10 ? `<@${streamers.splice(0, 10).join('>\n<@')}>\nand ${streamers.length - 10} others are now live.` : `<@${streamers.join('>\n<@')}>`
     }
   }).catch(e => {
     Bastion.log.error(e);

--- a/commands/queries/live.js
+++ b/commands/queries/live.js
@@ -10,7 +10,7 @@ exports.exec = (Bastion, message) => {
     embed: {
       color: Bastion.colors.DARK_PURPLE,
       title: 'Users Streaming',
-      description: streamers.length > 10 ? `<@${streamers.splice(0, 10).join('>\n<@')}>\nand ${streamers.length - 10} others are now live.` : `<@${streamers.join('>\n<@')}>`
+      description: !streamers.length ? 'No users currently streaming' : streamers.length > 10 ? `<@${streamers.splice(0, 10).join('>\n<@')}>\nand ${streamers.length - 10} others are now live.` : `<@${streamers.join('>\n<@')}>`
     }
   }).catch(e => {
     Bastion.log.error(e);


### PR DESCRIPTION
#### Changes introduced by this PR

live.js: If `streamers` array is empty print string saying `No users currently streaming`. 


#### Possible drawbacks

No

#### Applicable Issues
Fixes: https://github.com/TheBastionBot/Bastion/issues/374

#### Checklist

- [x] Test scripts passes
- [x] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
