### PR TITLE
commands: add world of warcraft command

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -62,7 +62,8 @@
     "`apod` - Get the Astronomy Picture of the Day from NASA.",
     "`setProfilePicture` - Sets your profile picture that shows up in the Bastion user profile.",
     "`book` - Shows details about the specified book.",
-    "`ignoreXP` - Set channels and/or roles to be ignored for experience."
+    "`ignoreXP` - Set channels and/or roles to be ignored for experience.",
+    "`wow` - Get stats of any World of Warcraft character from the Armory."
   ],
   "COMMANDS WITH NEW USAGE": [
     "`addTrigger` command's usage syntax has been changed. It won't work the way it used to before, please check the help message for it, using the `help addTrigger` command, to see the new usage details.",

--- a/commands/game_stats/wow.js
+++ b/commands/game_stats/wow.js
@@ -84,31 +84,35 @@ exports.exec = async (Bastion, message, args) => {
     args.region = args.region.toLowerCase();
     let locale = args.region === 'us' ? 'en-us' : 'en-gb';
 
-    let requestUrl = `https://${args.region}.api.battle.net/wow/character/${args.realm}/${args.character}?fields=guild,items&locale=${locale}&apikey=${Bastion.credentials.battleNetApiKey}`;
-
     let options = {
-      url: requestUrl,
+      url: `https://${args.region}.api.battle.net/wow/character/${args.realm}/${args.character}`,
+      qs: {
+        fields: 'guild,items',
+        locale: locale,
+        apikey: Bastion.credentials.battleNetApiKey
+      },
       json: true
     };
 
     let response = await request(options);
 
     let factionIcon = `https://worldofwarcraft.akamaized.net/static/components/Logo/Logo-${response.faction === 0 ? 'alliance' : 'horde'}.png`;
-
     let avatar = `https://render-${args.region}.worldofwarcraft.com/character/${response.thumbnail}`;
 
     let stats = [
       {
         name: 'Character',
-        value: `${response.level} ${wowConstants.race[response.race]} ${wowConstants.class[response.class]}`
+        value: `${response.level} - ${wowConstants.race[response.race]} - ${wowConstants.class[response.class]}`
       },
       {
         name: 'Achievement Points',
-        value: response.achievementPoints
+        value: response.achievementPoints,
+        inline: true
       },
       {
         name: 'Item Level',
-        value: response.items.averageItemLevel
+        value: response.items.averageItemLevel,
+        inline: true
       }
     ];
 
@@ -116,13 +120,15 @@ exports.exec = async (Bastion, message, args) => {
       stats.push(
         {
           name: 'Guild',
-          value: response.guild.name
+          value: response.guild.name,
+          inline: true
         }
       );
     }
 
     message.channel.send({
       embed: {
+        color: Bastion.colors.BLUE,
         author: {
           name: response.name,
           url: `https://worldofwarcraft.com/${locale}/character/${args.realm}/${args.character}`,
@@ -131,6 +137,9 @@ exports.exec = async (Bastion, message, args) => {
         fields: stats,
         thumbnail: {
           url: avatar
+        },
+        footer: {
+          text: 'Powered by Blizzard Battle.net'
         }
       }
     }).catch(e => {
@@ -167,6 +176,6 @@ exports.help = {
   userVoicePermission: '',
   usage: 'wow <CHARACTER> <--realm REALM> [-region <REGION>]',
   example: [
-    'wow Fallken --realm Burning-Blade --region us'
+    'wow Fallken --realm Burning-Blade --region EU'
   ]
 };

--- a/commands/game_stats/wow.js
+++ b/commands/game_stats/wow.js
@@ -81,32 +81,35 @@ exports.exec = async (Bastion, message, args) => {
       return Bastion.emit('commandUsage', message, this.help);
     }
 
-    let locale = args.region == 'us' ? 'en-us' : 'en-gb';
+    let locale = args.region === 'us' ? 'en-us' : 'en-gb';
 
     let requestUrl = `https://${args.region}.api.battle.net/wow/character/${args.realm}/${args.character}?fields=guild,items&locale=${locale}&apikey=${Bastion.credentials.battleNetApiKey}`;
 
-    options = {
+    let options = {
       url: requestUrl,
       json: true
     };
-    response = await request(options);
 
-    let factionIcon = `https://worldofwarcraft.akamaized.net/static/components/Logo/Logo-${response.faction == 0 ? 'alliance' : 'horde'}.png` + "";
+    let response = await request(options);
 
-    let avatar = `https://render-${args.region}.worldofwarcraft.com/character/${response.thumbnail}` + "";
+    let factionIcon = `https://worldofwarcraft.akamaized.net/static/components/Logo/Logo-${response.faction === 0 ? 'alliance' : 'horde'}.png`;
 
-    let stats = [{
-      name: 'Character',
-      value: `${response.level} ${wowConstants.race[response.race]} ${wowConstants.class[response.class]}`
-    },
-    {
-      name: 'Achievement Points',
-      value: response.achievementPoints
-    },
-    {
-      name: 'Item Level',
-      value: response.items.averageItemLevel
-    }];
+    let avatar = `https://render-${args.region}.worldofwarcraft.com/character/${response.thumbnail}`;
+
+    let stats = [
+      {
+        name: 'Character',
+        value: `${response.level} ${wowConstants.race[response.race]} ${wowConstants.class[response.class]}`
+      },
+      {
+        name: 'Achievement Points',
+        value: response.achievementPoints
+      },
+      {
+        name: 'Item Level',
+        value: response.items.averageItemLevel
+      }
+    ];
 
     if (response.guild) {
       stats.push(
@@ -114,7 +117,7 @@ exports.exec = async (Bastion, message, args) => {
           name: 'Guild',
           value: response.guild.name
         }
-      )
+      );
     }
 
     message.channel.send({
@@ -136,7 +139,7 @@ exports.exec = async (Bastion, message, args) => {
   }
   catch (e) {
     if (e.name === 'StatusCodeError') {
-      if (e.statusCode == '404') {
+      if (e.statusCode === '404') {
         return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notFound', 'player'), message.channel);
       }
       return Bastion.emit('error', e.statusCode, e.error.message, message.channel);
@@ -151,7 +154,7 @@ exports.config = {
   argsDefinitions: [
     { name: 'character', type: String, defaultOption: true },
     { name: 'realm', type: String, alias: 'r' },
-    { name: 'region', type: String, alias: 'e', defaultValue: 'us' },
+    { name: 'region', type: String, alias: 'e', defaultValue: 'us' }
   ]
 };
 
@@ -162,5 +165,7 @@ exports.help = {
   userTextPermission: '',
   userVoicePermission: '',
   usage: 'wow <character> <realm> [-r <region>]',
-  example: ['wow Fallken -r Burning-Blade -e eu ']
+  example: [
+    'wow Fallken -r Burning-Blade -e eu '
+  ]
 };

--- a/commands/game_stats/wow.js
+++ b/commands/game_stats/wow.js
@@ -1,0 +1,166 @@
+/**
+ * @file wow command
+ * @author James Naylor (a.k.a euronay)
+ * @license GPL-3.0
+ */
+
+const request = xrequire('request-promise-native');
+
+const wowConstants = {
+  faction: [
+    'Alliance',
+    'Horde'
+  ],
+  gender: [
+    'None',
+    'Male',
+    'Female'
+  ],
+  race: [
+    'None',
+    'Human',
+    'Orc',
+    'Dwarf',
+    'Night Elf',
+    'Undead',
+    'Tauren',
+    'Gnome',
+    'Troll',
+    'Goblin',
+    'Blood Elf',
+    'Draenei',
+    'Fel Orc',
+    'Naga',
+    'Broken',
+    'Skeleton',
+    'Vrykul',
+    'Tuskarr',
+    'Forest Troll',
+    'Taunka',
+    'Northrend Skeleton',
+    'Ice Troll',
+    'Worgen',
+    'Gilnean',
+    'Pandaren',
+    'Pandaren',
+    'Pandaren',
+    'Nightborn',
+    'Highmountain Tauren',
+    'Void Elf',
+    'Lightforged Draenei',
+    'Zandalari Troll',
+    'Kul Tiran',
+    'Human',
+    'Dark Iron Dwarf',
+    'Vulpera',
+    'Mag\'har Orc'
+  ],
+  class: [
+    'None',
+    'Warrior',
+    'Paladin',
+    'Hunter',
+    'Rogue',
+    'Priest',
+    'Death Knight',
+    'Shaman',
+    'Mage',
+    'Warlock',
+    'Druid',
+    'Demon Hunter'
+  ]
+};
+
+exports.exec = async (Bastion, message, args) => {
+  try {
+    if (!args.character || !args.realm) {
+      /**
+       * The command was ran with invalid parameters.
+       * @fires commandUsage
+       */
+      return Bastion.emit('commandUsage', message, this.help);
+    }
+
+    let locale = args.region == 'us' ? 'en-us' : 'en-gb';
+
+    let requestUrl = `https://${args.region}.api.battle.net/wow/character/${args.realm}/${args.character}?fields=guild,items&locale=${locale}&apikey=${Bastion.credentials.battleNetApiKey}`;
+
+    options = {
+      url: requestUrl,
+      json: true
+    };
+    response = await request(options);
+
+    let factionIcon = `https://worldofwarcraft.akamaized.net/static/components/Logo/Logo-${response.faction == 0 ? 'alliance' : 'horde'}.png` + "";
+
+    let avatar = `https://render-${args.region}.worldofwarcraft.com/character/${response.thumbnail}` + "";
+
+    let stats = [{
+      name: 'Character',
+      value: `${response.level} ${wowConstants.race[response.race]} ${wowConstants.class[response.class]}`
+    },
+    {
+      name: 'Achievement Points',
+      value: response.achievementPoints
+    },
+    {
+      name: 'Item Level',
+      value: response.items.averageItemLevel
+    }];
+
+    if (response.guild) {
+      stats.push(
+        {
+          name: 'Guild',
+          value: response.guild.name
+        }
+      )
+    }
+
+    message.channel.send({
+      embed: {
+        author: {
+          name: response.name,
+          url: `https://worldofwarcraft.com/${locale}/character/${args.realm}/${args.character}`,
+          icon_url: factionIcon
+        },
+        fields: stats,
+        thumbnail: {
+          url: avatar
+        }
+      }
+    }).catch(e => {
+      Bastion.log.error(e);
+    });
+
+  }
+  catch (e) {
+    if (e.name === 'StatusCodeError') {
+      if (e.statusCode == '404') {
+        return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notFound', 'player'), message.channel);
+      }
+      return Bastion.emit('error', e.statusCode, e.error.message, message.channel);
+    }
+    Bastion.log.error(e);
+  }
+};
+
+exports.config = {
+  aliases: [],
+  enabled: true,
+  argsDefinitions: [
+    { name: 'character', type: String, defaultOption: true },
+    { name: 'realm', type: String, alias: 'r' },
+    { name: 'region', type: String, alias: 'e', defaultValue: 'us' },
+  ]
+};
+
+exports.help = {
+  name: 'wow',
+  description: 'Get stats of any World of Warcraft character from the Armory.',
+  botPermission: '',
+  userTextPermission: '',
+  userVoicePermission: '',
+  usage: 'wow <character> <realm> [-r <region>]',
+  example: ['wow Fallken -r Burning-Blade -e eu ']
+};

--- a/commands/game_stats/wow.js
+++ b/commands/game_stats/wow.js
@@ -81,6 +81,7 @@ exports.exec = async (Bastion, message, args) => {
       return Bastion.emit('commandUsage', message, this.help);
     }
 
+    args.region = args.region.toLowerCase();
     let locale = args.region === 'us' ? 'en-us' : 'en-gb';
 
     let requestUrl = `https://${args.region}.api.battle.net/wow/character/${args.realm}/${args.character}?fields=guild,items&locale=${locale}&apikey=${Bastion.credentials.battleNetApiKey}`;

--- a/commands/game_stats/wow.js
+++ b/commands/game_stats/wow.js
@@ -154,7 +154,7 @@ exports.config = {
   argsDefinitions: [
     { name: 'character', type: String, defaultOption: true },
     { name: 'realm', type: String, alias: 'r' },
-    { name: 'region', type: String, alias: 'e', defaultValue: 'us' }
+    { name: 'region', type: String, defaultValue: 'us' }
   ]
 };
 
@@ -164,8 +164,8 @@ exports.help = {
   botPermission: '',
   userTextPermission: '',
   userVoicePermission: '',
-  usage: 'wow <character> <realm> [-r <region>]',
+  usage: 'wow <CHARACTER> <--realm REALM> [-region <REGION>]',
   example: [
-    'wow Fallken -r Burning-Blade -e eu '
+    'wow Fallken --realm Burning-Blade --region us'
   ]
 };

--- a/data/commands.json
+++ b/data/commands.json
@@ -1231,6 +1231,10 @@
     "description": "Shows a would you rather situation. See how you and your friends answer that!",
     "module": "Games"
   },
+  "wow": {
+    "description": "Get stats of any World of Warcraft character from the Armory.",
+    "module": "Game Stats"
+  },
   "xkcd": {
     "description": "Shows a xkcd comic.",
     "module": "Fun"

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -923,6 +923,9 @@
   "wouldYouRather": {
     "description": "Shows a would you rather situation. See how you and your friends answer that!"
   },
+  "wow": {
+    "description": "Get stats of any World of Warcraft character from the Armory."
+  },
   "xkcd": {
     "description": "Shows a xkcd comic."
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.51",
+  "version": "7.0.0-alpha.52",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",

--- a/settings/credentials_example.json
+++ b/settings/credentials_example.json
@@ -33,5 +33,6 @@
     "creatorAccessToken": "",
     "creatorRefreshToken": ""
   },
-  "NASAAPIKey": ""
+  "NASAAPIKey": "",
+  "battleNetApiKey": ""
 }


### PR DESCRIPTION
#### Changes introduced by this PR
Added a command to retrieve a World of Warcraft character from the Armory. Usage example is:
```
wow Fallken -r burning-blade --region EU
```

I'm only getting the basics at the moment - name, level, race, class, guild etc. There is tons of stuff in the API (items, acheivments, pets etc) that I could add, but wanted to get some feedback first.

Apologies if I've messed up any of the PR, let me know any issues - I'll do my best to update with any feedback (I don't get much time at all to develop)

#### Possible drawbacks
Need to add battle.net api key to config (guess this will need a documentation issue? - I'm happy to do this)


#### Applicable Issues
Fixes: https://github.com/TheBastionBot/Bastion/issues/323

#### Checklist
<!-- For completed items, change [ ] to [x]. -->

- [x] Test scripts passes
- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
