### PR TITLE
Add support for ignoring level ups

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "October 2, 2018",
+  "date": "October 4, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [],
   "THESE ABILITIES HAVE ENHANCED": [
@@ -61,7 +61,8 @@
     "`roblox` - Get info of any Roblox player.",
     "`apod` - Get the Astronomy Picture of the Day from NASA.",
     "`setProfilePicture` - Sets your profile picture that shows up in the Bastion user profile.",
-    "`book` - Shows details about the specified book."
+    "`book` - Shows details about the specified book.",
+    "`ignoreXP` - Set channels and/or roles to be ignored for experience."
   ],
   "COMMANDS WITH NEW USAGE": [
     "`addTrigger` command's usage syntax has been changed. It won't work the way it used to before, please check the help message for it, using the `help addTrigger` command, to see the new usage details.",

--- a/commands/guild_admin/ignoreXP.js
+++ b/commands/guild_admin/ignoreXP.js
@@ -1,0 +1,154 @@
+/**
+ * @file ignoreXP command
+ * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
+ * @license GPL-3.0
+ */
+
+exports.exec = async (Bastion, message, args) => {
+  try {
+    if (args.channel) {
+      args.channel = message.mentions.channels.size
+        ? message.mentions.channels.first()
+        : message.guild.channels.get(args.channel);
+
+      if (!args.channel) {
+        return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'channelNotFound'), message.channel);
+      }
+
+      await Bastion.database.models.textChannel.upsert({
+        channelID: args.channel.id,
+        guildID: message.guild.id,
+        ignoreXP: !args.remove
+      },
+      {
+        where: {
+          channelID: args.channel.id,
+          guildID: message.guild.id
+        },
+        fields: [ 'ignoreXP' ]
+      });
+
+      let description;
+      if (args.remove) {
+        description = `Removed the ${args.channel} text channel from the experience ignore list.`;
+      }
+      else {
+        description = `Added the ${args.channel} text channel to the experience ignore list.`;
+      }
+      message.channel.send({
+        embed: {
+          color: Bastion.colors.BLUE,
+          description: description
+        }
+      }).catch(e => {
+        Bastion.log.error(e);
+      });
+    }
+    else if (args.role) {
+      args.role = message.guild.roles.get(args.role);
+
+      if (!args.role) {
+        return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'roleNotFound'), message.channel);
+      }
+
+      await Bastion.database.models.role.upsert({
+        roleID: args.role.id,
+        guildID: message.guild.id,
+        ignoreXP: !args.remove
+      },
+      {
+        where: {
+          roleID: args.role.id,
+          guildID: message.guild.id
+        },
+        fields: [ 'ignoreXP' ]
+      });
+
+      let description;
+      if (args.remove) {
+        description = `Removed the ${args.role} role from the experience ignore list.`;
+      }
+      else {
+        description = `Added the ${args.role} role to the experience ignore list.`;
+      }
+      message.channel.send({
+        embed: {
+          color: Bastion.colors.BLUE,
+          description: description
+        }
+      }).catch(e => {
+        Bastion.log.error(e);
+      });
+    }
+    else {
+      let fields = [];
+
+      let textChannelModel = await Bastion.database.models.textChannel.findAll({
+        attributes: [ 'channelID' ],
+        where: {
+          guildID: message.guild.id,
+          ignoreXP: true
+        }
+      });
+
+      let ignoredChannels = 'No channels are being ignored for experience.';
+      if (textChannelModel.length) {
+        ignoredChannels = `<#${textChannelModel.map(model => model.dataValues.channelID).join('>\n<#')}>`;
+      }
+      fields.push({
+        name: 'Ignored Channels',
+        value: ignoredChannels
+      });
+
+      let roleModel = await Bastion.database.models.role.findAll({
+        attributes: [ 'roleID' ],
+        where: {
+          guildID: message.guild.id,
+          ignoreXP: true
+        }
+      });
+
+      let ignoredRoles = 'No roles are being ignored for experience.';
+      if (roleModel.length) {
+        ignoredRoles = `<@&${roleModel.map(model => model.dataValues.roleID).join('>\n<@&')}>`;
+      }
+      fields.push({
+        name: 'Ignored Roles',
+        value: ignoredRoles
+      });
+
+      message.channel.send({
+        embed: {
+          color: Bastion.colors.BLUE,
+          title: 'Experience Ignored List',
+          fields: fields
+        }
+      }).catch(e => {
+        Bastion.log.error(e);
+      });
+    }
+  }
+  catch (e) {
+    Bastion.log.error(e);
+  }
+};
+
+exports.config = {
+  aliases: [],
+  enabled: true,
+  argsDefinitions: [
+    { name: 'channel', type: String, defaultOption: true },
+    { name: 'role', type: String },
+    { name: 'remove', type: Boolean, alias: 'r' }
+  ]
+};
+
+exports.help = {
+  name: 'ignoreXP',
+  description: 'Add/remove channels/roles to/from the experience ignored list. Users will not gain experience in these channels or if they have these roles.',
+  botPermission: '',
+  userTextPermission: 'MANAGE_GUILD',
+  userVoicePermission: '',
+  usage: 'ignoreXP [--channel #CHANNEL_MENTION | CHANNEL_ID] [--role ROLE_ID] [--remove]',
+  example: []
+};

--- a/data/commands.json
+++ b/data/commands.json
@@ -499,6 +499,10 @@
     "description": "Add/remove channels/roles to/from the word filter ignored list. Bastion will not filter words posted in these channels or by these roles.",
     "module": "Guild Admin"
   },
+  "ignoreXP": {
+    "description": "Add/remove channels/roles to/from the experience ignored list. Users will not gain experience in these channels or if they have these roles.",
+    "module": "Guild Admin"
+  },
   "inRole": {
     "description": "Shows members that have a specified role in your Discord server.",
     "module": "Info"

--- a/handlers/levelHandler.js
+++ b/handlers/levelHandler.js
@@ -42,11 +42,26 @@ module.exports = async message => {
       },
       include: [
         {
+          model: message.client.database.models.textChannel,
+          attributes: [ 'channelID', 'ignoreXP' ]
+        },
+        {
           model: message.client.database.models.role,
-          attributes: [ 'roleID', 'level' ]
+          attributes: [ 'roleID', 'level', 'ignoreXP' ]
         }
       ]
     });
+
+
+    let experienceIgnoredChannels = guildModel.textChannels.length && guildModel.textChannels.filter(model => model.dataValues.ignoreXP).map(model => model.dataValues.channelID);
+    let isIgnoredChannel = experienceIgnoredChannels && experienceIgnoredChannels.includes(message.channel.id);
+
+    if (isIgnoredChannel) return;
+
+    let experienceIgnoredRoles = guildModel.roles.length && guildModel.roles.filter(model => model.dataValues.ignoreXP).map(model => model.dataValues.roleID);
+    let hasIgnoredRole = experienceIgnoredRoles && message.member.roles.some(role => experienceIgnoredRoles.includes(role.id));
+
+    if (hasIgnoredRole) return;
 
 
     guildMemberModel.dataValues.experiencePoints = parseInt(guildMemberModel.dataValues.experiencePoints);

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -374,6 +374,9 @@
   "ignoreWordFilter": {
     "description": "Add/remove channels/roles to/from the word filter ignored list. Bastion will not filter words posted in these channels or by these roles."
   },
+  "ignoreXP": {
+    "description": "Add/remove channels/roles to/from the experience ignored list. Users will not gain experience in these channels or if they have these roles."
+  },
   "inRole": {
     "description": "Shows members that have a specified role in your Discord server."
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.50",
+  "version": "7.0.0-alpha.51",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",


### PR DESCRIPTION
#### Changes introduced by this PR
This PR introduces ignoring level ups feature that allows guild admins to set channels/roles to be ignored from the count towards level up. Messages sent in channels, set to ignore experience gains, will not increase the message author's experience. And users in the roles, set to ignore experience gains, will not gain experience until they have that role.

* Added `ignoreXP` command to set channels/roles to ignored exp. list.
* Implemented ignoring exp. gains in level handler.

#### Possible drawbacks
None

#### Applicable Issues
\-

#### Checklist
- [X] Test scripts passes
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
