### PR TITLE
APOD command improvements

### DIFF
--- a/commands/fun/apod.js
+++ b/commands/fun/apod.js
@@ -9,12 +9,7 @@ const request = xrequire('request-promise-native');
 exports.exec = async (Bastion, message) => {
   try {
     let options = {
-      method: 'GET',
-      url: 'https://api.nasa.gov/planetary/apod',
-      qs: {
-        api_key: Bastion.credentials.NASAAPIKey || 'DEMO_KEY'
-      },
-      followAllRedirects: true,
+      url: 'https://api.bastionbot.org/nasa/apod',
       json: true
     };
     let response = await request(options);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.57",
+  "version": "7.0.0-alpha.58",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",

--- a/settings/credentials.example.yaml
+++ b/settings/credentials.example.yaml
@@ -34,5 +34,4 @@ patreon:
   creatorAccessToken:
   creatorRefreshToken:
 
-NASAAPIKey:
 BattleNetApiKey:


### PR DESCRIPTION
#### Changes introduced by this PR
The NASA API Key won't be required for the `apod` command anymore. It will now use the [Bastion Web API](https://api.bastionbot.org).

#### Possible drawbacks
None

#### Applicable Issues
\-

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
