### PR TITLE
Use Bastion web API

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "October 31, 2018",
+  "date": "November 3, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [],
   "THESE ABILITIES HAVE ENHANCED": [
@@ -18,6 +18,7 @@
     "Warnings are now permanently stored!",
     "Server logging will now also log message update and message delete events.",
     "You can now enable disabled modules using the `--module` option in the `enableCommand` command.",
+    "`contributors` command will now show contributors across all repositories of The Bastion Bot Project.",
     "Tons of under-the-hood improvements & changes."
   ],
   "NEW FEATURES!": [

--- a/commands/game_stats/rocketLeague.js
+++ b/commands/game_stats/rocketLeague.js
@@ -30,7 +30,7 @@ exports.exec = async (Bastion, message, args) => {
 
     if (args.platform === 'steam') {
       let options = {
-        url: `https://peaceful-celsius.glitch.me/api/${args.player}`,
+        url: `https://api.bastionbot.org/steam/profile/${args.player}`,
         json: true
       };
 

--- a/commands/info/contributors.js
+++ b/commands/info/contributors.js
@@ -7,7 +7,7 @@
 exports.exec = async (Bastion, message, args) => {
   try {
     let contributors = await Bastion.methods.getContributors();
-    contributors = contributors.map(contributor => `${contributor.username} - ${contributor.contributions} contributions`);
+    contributors = contributors.map(contributor => `**${contributor.username}** - ${contributor.contributions} contributions`);
 
     let noOfPages = contributors.length / 25;
     let i = (args.page > 0 && args.page < noOfPages + 1) ? args.page : 1;
@@ -16,7 +16,9 @@ exports.exec = async (Bastion, message, args) => {
     message.channel.send({
       embed: {
         color: 10181046,
-        description: 'These are the people who contribute to the development of the Bastion Bot on [GitHub](https://github.com/TheBastionBot/Bastion).',
+        title: 'The Bastion Bot Project',
+        url: 'https://github.com/TheBastionBot',
+        description: 'These are the people who contribute to the development of The Bastion Bot Project on [GitHub](https://github.com/TheBastionBot).',
         fields: [
           {
             name: 'Contributors',
@@ -24,7 +26,7 @@ exports.exec = async (Bastion, message, args) => {
           }
         ],
         footer: {
-          text: `Page: ${i + 1} of ${noOfPages > parseInt(noOfPages) ? parseInt(noOfPages) + 1 : parseInt(noOfPages)} • https://github.com/TheBastionBot/Bastion`
+          text: `Page: ${i + 1} of ${noOfPages > parseInt(noOfPages) ? parseInt(noOfPages) + 1 : parseInt(noOfPages)} • https://github.com/TheBastionBot`
         }
       }
     }).catch(e => {
@@ -46,7 +48,7 @@ exports.config = {
 
 exports.help = {
   name: 'contributors',
-  description: 'Shows the list of people who contribute to the development of the Bastion Bot on [GitHub](%github.org%/Bastion).',
+  description: 'Shows the list of people who contribute to the development of The Bastion Bot Project on [GitHub](%github.org%).',
   botPermission: '',
   userTextPermission: '',
   userVoicePermission: '',

--- a/handlers/conversationHandler.js
+++ b/handlers/conversationHandler.js
@@ -28,7 +28,7 @@ module.exports = async message => {
     message.channel.startTyping();
 
     let options = {
-      url: 'https://bastion-cleverbot.glitch.me/api',
+      url: 'https://api.bastionbot.org/chat',
       qs: {
         message: message.content
       },

--- a/methods/getContributors.js
+++ b/methods/getContributors.js
@@ -5,36 +5,31 @@
  */
 
 const request = xrequire('request-promise-native');
-const fs = require('fs');
-const YAML = require('yaml');
-
-// eslint-disable-next-line no-sync
-const credentialsFile = fs.readFileSync('./settings/credentials.yaml', 'utf8');
-const { github } = YAML.parse(credentialsFile);
 
 module.exports = () => {
   return new Promise(async (resolve, reject) => {
     try {
       let options = {
         headers: {
-          'User-Agent': 'Bastion Discord Bot (https://bastionbot.org)',
-          'Authorization': github ? `token ${github.accessToken}` : undefined
+          'User-Agent': 'Bastion Discord Bot (https://bastionbot.org)'
         },
-        uri: 'https://api.github.com/repos/TheBastionBot/Bastion/contributors',
+        uri: 'https://api.bastionbot.org/github/contributors',
         json: true
       };
 
       let response = await request(options);
 
-      let contributors = response.map(contributor => {
-        return {
-          id: contributor.id,
-          username: contributor.login,
-          url: contributor.html_url,
-          contributions: contributor.contributions,
-          avatar_url: contributor.avatar_url
-        };
-      });
+      let contributors = [];
+      for (let contributor of Object.keys(response)) {
+        if (response[contributor].type === 'User') {
+          contributors.push({
+            username: response[contributor].login,
+            url: response[contributor].url,
+            avatar: response[contributor].avatar,
+            contributions: response[contributor].contributions
+          });
+        }
+      }
 
       resolve(contributors);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.58",
+  "version": "7.0.0-alpha.59",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",

--- a/settings/credentials.example.yaml
+++ b/settings/credentials.example.yaml
@@ -25,8 +25,6 @@ rocketLeagueUserToken:
 theMovieDBApiKey:
 IGDBUserKey:
 musixmatchAPIKey:
-github:
-  accessToken:
 
 patreon:
   clientID:


### PR DESCRIPTION
#### Changes introduced by this PR
This PR implements the usage of [Bastion Web API](https://api.bastionbot.org).
- In the chat module
- To fetch Steam profiles
- To fetch GitHub contributors

And the side effect of these changes?
- `contributors` command will now show the contributors across all our repositories in GitHub.
- Users won't need to set GitHub API anymore.

#### Possible drawbacks
None

#### Applicable Issues
\-

#### Checklist
- [X] Test scripts passes
- [ ] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
