### PR TITLE
Tesseract 0.0.6

### DIFF
--- a/commands/administration/iAm.js
+++ b/commands/administration/iAm.js
@@ -35,7 +35,7 @@ exports.exec = async (Bastion, message, args) => {
 
     let member = message.member;
     if (!member) {
-      member = await message.guild.fetchMember(message.author.id);
+      member = await Bastion.utils.fetchMember(message.guild, message.author.id);
     }
 
     await member.addRole(role);

--- a/commands/administration/iAmNot.js
+++ b/commands/administration/iAmNot.js
@@ -35,7 +35,7 @@ exports.exec = async (Bastion, message, args) => {
 
     let member = message.member;
     if (!member) {
-      member = await message.guild.fetchMember(message.author.id);
+      member = await Bastion.utils.fetchMember(message.guild, message.author.id);
     }
 
     await member.removeRole(role);

--- a/commands/info/avatar.js
+++ b/commands/info/avatar.js
@@ -11,7 +11,7 @@ exports.exec = async (Bastion, message, args) => {
       user = message.mentions.users.first();
     }
     else if (args.id) {
-      user = await message.guild.fetchMember(args.id);
+      user = await Bastion.utils.fetchMember(message.guild, args.id);
       if (user) {
         user = user.user;
       }

--- a/commands/info/profile.js
+++ b/commands/info/profile.js
@@ -13,7 +13,7 @@ exports.exec = async (Bastion, message, args) => {
       user = message.mentions.users.first();
     }
     else if (args.id) {
-      user = await message.guild.fetchMember(args.id);
+      user = await Bastion.utils.fetchMember(message.guild, args.id);
       if (user) {
         user = user.user;
       }
@@ -147,7 +147,7 @@ async function getUserIcon(user) {
     const bastionGuildID = specialIDs.bastionGuild;
     const bastionGuild = user.client.guilds.get(bastionGuildID);
     if (!bastionGuild) return;
-    const bastionGuildMember = await bastionGuild.fetchMember(user.id);
+    const bastionGuildMember = await user.client.utils.fetchMember(bastionGuild, user.id);
     if (!bastionGuildMember) return;
 
     const devRoleID = specialIDs.developerRole;

--- a/commands/info/userInfo.js
+++ b/commands/info/userInfo.js
@@ -11,7 +11,7 @@ exports.exec = async (Bastion, message, args) => {
       user = message.mentions.users.first();
     }
     else if (args.id) {
-      member = await message.guild.fetchMember(args.id);
+      member = await Bastion.utils.fetchMember(message.guild, args.id);
       if (member) {
         user = member.user;
       }
@@ -20,7 +20,7 @@ exports.exec = async (Bastion, message, args) => {
       user = message.author;
     }
     if (!member) {
-      member = await message.guild.fetchMember(user.id);
+      member = await Bastion.utils.fetchMember(message.guild, args.id);
     }
     let nick = member.nickname;
     if (!nick) {

--- a/commands/moderation/addRole.js
+++ b/commands/moderation/addRole.js
@@ -33,7 +33,7 @@ exports.exec = async (Bastion, message, args) => {
       return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'roleNotFound'), message.channel);
     }
 
-    let member = await message.guild.fetchMember(user.id);
+    let member = await Bastion.utils.fetchMember(message.guild, user.id);
     member.addRole(role);
 
     message.channel.send({

--- a/commands/moderation/ban.js
+++ b/commands/moderation/ban.js
@@ -22,7 +22,7 @@ exports.exec = async (Bastion, message, args) => {
     }
 
     if (message.guild.members.has(user.id)) {
-      let member = await message.guild.fetchMember(user.id);
+      let member = await message.guild.members.get(user.id);
       if (message.author.id !== message.guild.ownerID && message.member.highestRole.comparePositionTo(member.highestRole) <= 0) return Bastion.log.info(Bastion.i18n.error(message.guild.language, 'lowerRole'));
 
       if (!member.bannable) {

--- a/commands/moderation/clearWarn.js
+++ b/commands/moderation/clearWarn.js
@@ -21,7 +21,7 @@ exports.exec = async (Bastion, message, args) => {
       return Bastion.emit('commandUsage', message, this.help);
     }
 
-    let member = await message.guild.fetchMember(user.id);
+    let member = await Bastion.utils.fetchMember(message.guild, user.id);
     if (message.author.id !== message.guild.ownerID && message.member.highestRole.comparePositionTo(member.highestRole) <= 0) return Bastion.log.info(Bastion.i18n.error(message.guild.language, 'lowerRole'));
 
 

--- a/commands/moderation/deafen.js
+++ b/commands/moderation/deafen.js
@@ -21,7 +21,7 @@ exports.exec = async (Bastion, message, args) => {
       return Bastion.emit('commandUsage', message, this.help);
     }
 
-    let member = await message.guild.fetchMember(user.id);
+    let member = await Bastion.utils.fetchMember(message.guild, user.id);
     if (message.author.id !== message.guild.ownerID && message.member.highestRole.comparePositionTo(member.highestRole) <= 0) return Bastion.log.info(Bastion.i18n.error(message.guild.language, 'lowerRole'));
 
     await member.setDeaf(true);

--- a/commands/moderation/kick.js
+++ b/commands/moderation/kick.js
@@ -21,7 +21,7 @@ exports.exec = async (Bastion, message, args) => {
       return Bastion.emit('commandUsage', message, this.help);
     }
 
-    let member = await message.guild.fetchMember(user.id);
+    let member = await Bastion.utils.fetchMember(message.guild, user.id);
     if (message.author.id !== message.guild.ownerID && message.member.highestRole.comparePositionTo(member.highestRole) <= 0) return Bastion.log.info(Bastion.i18n.error(message.guild.language, 'lowerRole'));
 
     if (!member.kickable) {

--- a/commands/moderation/mute.js
+++ b/commands/moderation/mute.js
@@ -21,7 +21,7 @@ exports.exec = async (Bastion, message, args) => {
       return Bastion.emit('commandUsage', message, this.help);
     }
 
-    let member = await message.guild.fetchMember(user.id);
+    let member = await Bastion.utils.fetchMember(message.guild, user.id);
     if (message.author.id !== message.guild.ownerID && message.member.highestRole.comparePositionTo(member.highestRole) <= 0) return Bastion.log.info(Bastion.i18n.error(message.guild.language, 'lowerRole'));
 
     await member.setMute(true);

--- a/commands/moderation/nickname.js
+++ b/commands/moderation/nickname.js
@@ -21,7 +21,7 @@ exports.exec = async (Bastion, message, args) => {
       return Bastion.emit('commandUsage', message, this.help);
     }
 
-    let member = await message.guild.fetchMember(user.id);
+    let member = await Bastion.utils.fetchMember(message.guild, user.id);
     if (message.author.id !== message.guild.ownerID && message.member.highestRole.comparePositionTo(member.highestRole) <= 0) return Bastion.log.info(Bastion.i18n.error(message.guild.language, 'lowerRole'));
 
     let color;

--- a/commands/moderation/removeAllRoles.js
+++ b/commands/moderation/removeAllRoles.js
@@ -19,7 +19,7 @@ exports.exec = async (Bastion, message, args) => {
       user = message.mentions.users.first();
     }
     else if (args.id) {
-      user = await message.guild.fetchMember(args.id);
+      user = await Bastion.utils.fetchMember(message.guild, args.id);
       if (user) {
         user = user.user;
       }
@@ -28,7 +28,7 @@ exports.exec = async (Bastion, message, args) => {
       user = message.author;
     }
 
-    let member = await message.guild.fetchMember(user.id);
+    let member = await Bastion.utils.fetchMember(message.guild, user.id);
     if (message.author.id !== message.guild.ownerID && message.member.highestRole.comparePositionTo(member.highestRole) <= 0) return Bastion.log.info(Bastion.i18n.error(message.guild.language, 'lowerRole'));
 
     await member.removeRoles(member.roles);

--- a/commands/moderation/removeRole.js
+++ b/commands/moderation/removeRole.js
@@ -33,7 +33,7 @@ exports.exec = async (Bastion, message, args) => {
       return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'roleNotFound'), message.channel);
     }
 
-    let member = await message.guild.fetchMember(user.id);
+    let member = await Bastion.utils.fetchMember(message.guild, user.id);
     await member.removeRole(role);
 
     message.channel.send({

--- a/commands/moderation/softBan.js
+++ b/commands/moderation/softBan.js
@@ -21,7 +21,7 @@ exports.exec = async (Bastion, message, args) => {
       return Bastion.emit('commandUsage', message, this.help);
     }
 
-    let member = await message.guild.fetchMember(user.id);
+    let member = await Bastion.utils.fetchMember(message.guild, user.id);
     if (message.author.id !== message.guild.ownerID && message.member.highestRole.comparePositionTo(member.highestRole) <= 0) return Bastion.log.info(Bastion.i18n.error(message.guild.language, 'lowerRole'));
 
     if (!member.bannable) {

--- a/commands/moderation/textMute.js
+++ b/commands/moderation/textMute.js
@@ -21,7 +21,7 @@ exports.exec = async (Bastion, message, args) => {
       return Bastion.emit('commandUsage', message, this.help);
     }
 
-    let member = await message.guild.fetchMember(user.id);
+    let member = await Bastion.utils.fetchMember(message.guild, user.id);
     if (message.author.id !== message.guild.ownerID && message.member.highestRole.comparePositionTo(member.highestRole) <= 0) return Bastion.log.info(Bastion.i18n.error(message.guild.language, 'lowerRole'));
 
     args.reason = args.reason.join(' ');

--- a/commands/moderation/textUnMute.js
+++ b/commands/moderation/textUnMute.js
@@ -21,7 +21,7 @@ exports.exec = async (Bastion, message, args) => {
       return Bastion.emit('commandUsage', message, this.help);
     }
 
-    let member = await message.guild.fetchMember(user.id);
+    let member = await Bastion.utils.fetchMember(message.guild, user.id);
     if (message.author.id !== message.guild.ownerID && message.member.highestRole.comparePositionTo(member.highestRole) <= 0) return Bastion.log.info(Bastion.i18n.error(message.guild.language, 'lowerRole'));
 
     if (args.server) {

--- a/commands/moderation/unDeafen.js
+++ b/commands/moderation/unDeafen.js
@@ -21,7 +21,7 @@ exports.exec = async (Bastion, message, args) => {
       return Bastion.emit('commandUsage', message, this.help);
     }
 
-    let member = await message.guild.fetchMember(user.id);
+    let member = await Bastion.utils.fetchMember(message.guild, user.id);
     if (message.author.id !== message.guild.ownerID && message.member.highestRole.comparePositionTo(member.highestRole) <= 0) return Bastion.log.info(Bastion.i18n.error(message.guild.language, 'lowerRole'));
 
     args.reason = args.reason.join(' ');

--- a/commands/moderation/unMute.js
+++ b/commands/moderation/unMute.js
@@ -21,7 +21,7 @@ exports.exec = async (Bastion, message, args) => {
       return Bastion.emit('commandUsage', message, this.help);
     }
 
-    let member = await message.guild.fetchMember(user.id);
+    let member = await Bastion.utils.fetchMember(message.guild, user.id);
     if (message.author.id !== message.guild.ownerID && message.member.highestRole.comparePositionTo(member.highestRole) <= 0) return Bastion.log.info(Bastion.i18n.error(message.guild.language, 'lowerRole'));
 
     args.reason = args.reason.join(' ');

--- a/commands/moderation/warn.js
+++ b/commands/moderation/warn.js
@@ -22,7 +22,7 @@ exports.exec = async (Bastion, message, args) => {
     }
 
 
-    let member = await message.guild.fetchMember(user.id);
+    let member = await Bastion.utils.fetchMember(message.guild, user.id);
     if (message.author.id !== message.guild.ownerID && message.member.highestRole.comparePositionTo(member.highestRole) <= 0) return Bastion.log.info(Bastion.i18n.error(message.guild.language, 'lowerRole'));
 
     args.reason = args.reason.join(' ');

--- a/commands/money/give.js
+++ b/commands/money/give.js
@@ -19,7 +19,7 @@ exports.exec = async (Bastion, message, args) => {
       user = message.mentions.users.first();
     }
     else if (args.id) {
-      user = await message.guild.fetchMember(args.id);
+      user = await Bastion.utils.fetchMember(message.guild, args.id);
       if (user) {
         user = user.user;
       }

--- a/commands/money/leaderboard.js
+++ b/commands/money/leaderboard.js
@@ -29,7 +29,7 @@ exports.exec = async (Bastion, message, args) => {
     for (let i = 0; i < profiles.length; i++) {
       let user;
       if (message.guild.members.has(profiles[i].userID)) {
-        let member = await message.guild.fetchMember(profiles[i].userID);
+        let member = await message.guild.members.get(profiles[i].userID);
         user = `${member.user.tag} - ${member.id}`;
       }
       else {

--- a/commands/queries/lastSeen.js
+++ b/commands/queries/lastSeen.js
@@ -11,7 +11,7 @@ exports.exec = async (Bastion, message, args) => {
       user = message.mentions.users.first();
     }
     else if (args.id) {
-      user = await message.guild.fetchMember(args.id);
+      user = await Bastion.utils.fetchMember(message.guild, args.id);
       if (user) {
         user = user.user;
       }

--- a/events/discord/messageReactionAdd.js
+++ b/events/discord/messageReactionAdd.js
@@ -121,7 +121,7 @@ module.exports = async (reaction, user) => {
             let reactionRoles = reactionRoleModelsForReaction.map(model => model.dataValues.roleID);
 
             if (reactionRoles.length) {
-              let member = await reaction.message.guild.fetchMember(user);
+              let member = await user.client.utils.fetchMember(reaction.message.guild, user.id);
 
               await member.addRoles(reactionRoles, 'Self-Assigned via reaction roles.').catch(() => {});
 

--- a/events/discord/messageReactionRemove.js
+++ b/events/discord/messageReactionRemove.js
@@ -51,7 +51,7 @@ module.exports = async (reaction, user) => {
             let reactionRoles = reactionRoleModelsForReaction.map(model => model.dataValues.roleID);
 
             if (reactionRoles.length) {
-              let member = await reaction.message.guild.fetchMember(user);
+              let member = await user.client.utils.fetchMember(reaction.message.guild, user.id);
 
               await member.removeRoles(reactionRoles, 'Self-Unassigned via reaction roles.').catch(() => {});
             }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "snekfetch": "~4.0.4",
     "sqlite": "~3.0.0",
     "sqlite3": "~4.0.2",
-    "tesseract": "github:TheBastionBot/Tesseract#v0.0.5",
+    "tesseract": "github:TheBastionBot/Tesseract#v0.0.6",
     "weather-js": "~2.0.0",
     "webshot": "~0.18.0",
     "word-definition": "~2.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.63",
+  "version": "7.0.0-alpha.64",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",


### PR DESCRIPTION
#### Changes introduced by this PR
* This PR updates Tesseract to `v0.0.6`
* Bastion now uses Tesseract's `fetchMember` method instead the discord.js one. So, now it does a `fetchUser` before `fetchMember`.

#### Possible drawbacks
None

#### Applicable Issues
\-

#### Checklist
- [X] Test scripts passes
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
