### PR TITLE
Stop typing in case request doesn't resolve

### DIFF
--- a/handlers/conversationHandler.js
+++ b/handlers/conversationHandler.js
@@ -49,6 +49,8 @@ module.exports = async message => {
     }
   }
   catch (e) {
+    message.channel.stopTyping(true);
+
     message.client.log.error(e);
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.69",
+  "version": "7.0.0-alpha.70",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",


### PR DESCRIPTION
#### Changes introduced by this PR
This PR fixes the issue that prevented Bastion from stopping the typing event when request to Bastion Web API didn't resolve.

#### Possible drawbacks
None

#### Applicable Issues
\-

#### Checklist
<!-- For completed items, change [ ] to [x]. -->

- [X] Test scripts passes
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
