### PR TITLE
Reaction announcements are here!

### DIFF
--- a/commands/guild_admin/reactionAnnouncements.js
+++ b/commands/guild_admin/reactionAnnouncements.js
@@ -1,0 +1,53 @@
+/**
+ * @file reactionAnnouncements command
+ * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
+ * @license GPL-3.0
+ */
+
+exports.exec = async (Bastion, message) => {
+  try {
+    let guildModel = await Bastion.database.models.guild.findOne({
+      attributes: [ 'reactionAnnouncements' ],
+      where: {
+        guildID: message.guild.id
+      }
+    });
+
+    await Bastion.database.models.guild.update({
+      reactionAnnouncements: !guildModel.dataValues.reactionAnnouncements
+    },
+    {
+      where: {
+        guildID: message.guild.id
+      },
+      fields: [ 'reactionAnnouncements' ]
+    });
+
+    message.channel.send({
+      embed: {
+        color: Bastion.colors[guildModel.dataValues.reactionAnnouncements ? 'RED' : 'GREEN'],
+        description: Bastion.i18n.info(message.guild.language, guildModel.dataValues.reactionAnnouncements ? 'disableReactionAnnouncements' : 'enableReactionAnnouncements', message.author.tag)
+      }
+    }).catch(e => {
+      Bastion.log.error(e);
+    });
+  }
+  catch (e) {
+    Bastion.log.error(e);
+  }
+};
+
+exports.config = {
+  aliases: [],
+  enabled: true
+};
+
+exports.help = {
+  name: 'reactionAnnouncements',
+  description: 'Toggles Reaction Announcements in the server. Adding either 📣 or 📢 reaction to a message will send the message to the announcement channel, provided an announcement channel has been set.',
+  botPermission: '',
+  userTextPermission: 'MANAGE_GUILD',
+  userVoicePermission: '',
+  usage: 'reactionAnnouncements',
+  example: []
+};

--- a/data/commands.json
+++ b/data/commands.json
@@ -775,6 +775,10 @@
     "description": "Shows the rank of the specified user's account.",
     "module": "Info"
   },
+  "reactionAnnouncements": {
+    "description": "Toggles Reaction Announcements in the server. Adding either 📣 or 📢 reaction to a message will send the message to the announcement channel, provided an announcement channel has been set.",
+    "module": "Guild Admin"
+  },
   "reactionPinning": {
     "description": "Toggles Reaction Pinning in the server. If Reaction Pinning is enabled, adding either 📌 or 📍 reaction to a message will pin the message to the channel and removing the reactions will unpin it too.",
     "module": "Guild Admin"

--- a/events/discord/messageReactionAdd.js
+++ b/events/discord/messageReactionAdd.js
@@ -12,7 +12,12 @@ module.exports = async (reaction, user) => {
 
 
     let guildModel = await user.client.database.models.guild.findOne({
-      attributes: [ 'reactionPinning', 'starboard' ],
+      attributes: [
+        'announcementChannel',
+        'reactionAnnouncements',
+        'reactionPinning',
+        'starboard'
+      ],
       where: {
         guildID: reaction.message.guild.id
       },
@@ -34,6 +39,26 @@ module.exports = async (reaction, user) => {
 
 
     if (guildModel) {
+      if (guildModel.dataValues.announcementChannel && guildModel.dataValues.reactionAnnouncements) {
+        if ([ '📣', '📢' ].includes(reaction.emoji.name)) {
+          if (reaction.message.channel.permissionsFor(user).has('MANAGE_GUILD')) {
+            await reaction.message.channel.send({
+              embed: {
+                color: user.client.colors.BLUE,
+                author: {
+                  name: reaction.message.author.tag
+                },
+                description: reaction.message.content,
+                footer: {
+                  text: `📣 Announcement made by ${user.tag}`
+                }
+              }
+            });
+          }
+        }
+      }
+
+
       if (guildModel.dataValues.reactionPinning) {
         if ([ '📌', '📍' ].includes(reaction.emoji.name)) {
           if (reaction.message.channel.permissionsFor(user).has('MANAGE_MESSAGES')) {

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -581,6 +581,9 @@
   "rank": {
     "description": "Shows the rank of the specified user's account."
   },
+  "reactionAnnouncements": {
+    "description": "Toggles Reaction Announcements in the server. Adding either 📣 or 📢 reaction to a message will send the message to the announcement channel, provided an announcement channel has been set."
+  },
   "reactionPinning": {
     "description": "Toggles Reaction Pinning in the server. If Reaction Pinning is enabled, adding either 📌 or 📍 reaction to a message will pin the message to the channel and removing the reactions will unpin it too."
   },
@@ -774,7 +777,7 @@
     "description": "Shows detailed stats and info of the shard the command was used in."
   },
   "ship": {
-    "description": "Combines two or more mentioned users' names."
+    "description": "Combines two or more mentioned user's names."
   },
   "shop": {
     "description": "Lists/Adds/Removes items from your server's shop. Listed items in the shop can be bought by anyone, with %currency.name_plural%, in your server using the `buy` command. When users buy item, the server owner gets 90% of the profit."

--- a/locales/en_us/info.json
+++ b/locales/en_us/info.json
@@ -46,6 +46,8 @@
   "enableLevelUps": "%var% enabled level ups in this server. Users will now be able to gain experience points and level up as they chat.",
   "disableMembersOnly": "%var% disabled Members Only mode in this server. Bastion's Commands can now be used by any member of this server.",
   "enableMembersOnly": "%var% enabled Members Only mode in this server. Bastion's Commands can now only be used by members with at least one role.",
+  "disableReactionAnnouncements": "%var% disabled Reaction Announcements in this server.",
+  "enableReactionAnnouncements": "%var% enabled Reaction Announcements in this server. Adding either 📣 or 📢 reaction to a message will send the message to the announcement channel, provided an announcement channel has been set.",
   "disableReactionPinning": "%var% disabled Reaction Pinning in this server.",
   "enableReactionPinning": "%var% enabled Reaction Pinning in this server. Adding either 📌 or 📍 reaction to a message will pin the message to the channel and removing the reactions will unpin it too.",
   "disableServerLog": "%var% disabled logging of server events.",

--- a/utils/models.js
+++ b/utils/models.js
@@ -229,6 +229,11 @@ module.exports = (Sequelize, database) => {
       allowNull: false,
       defaultValue: false
     },
+    reactionAnnouncements: {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
+    },
     reactionPinning: {
       type: Sequelize.BOOLEAN,
       allowNull: false,


### PR DESCRIPTION
#### Changes introduced by this PR
This PR adds "reaction announcements". If reaction announcements are enabled, adding the 📢 or 📣 reaction to a message, will relay the message to the announcement channel, given that an announcement channel has been set.

#### Possible drawbacks
None

#### Applicable Issues
Closes: https://github.com/TheBastionBot/Bastion/issues/418

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
