### PR TITLE
Fix typo in wow command usage

### DIFF
--- a/commands/game_stats/wow.js
+++ b/commands/game_stats/wow.js
@@ -174,7 +174,7 @@ exports.help = {
   botPermission: '',
   userTextPermission: '',
   userVoicePermission: '',
-  usage: 'wow <CHARACTER> <--realm REALM> [-region <REGION>]',
+  usage: 'wow <CHARACTER> <--realm REALM> [--region <REGION>]',
   example: [
     'wow Fallken --realm Burning-Blade --region EU'
   ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.75",
+  "version": "7.0.0-alpha.76",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",


### PR DESCRIPTION
#### Changes introduced by this PR
Fix a typo in `wow` command's usage syntax.

#### Possible drawbacks
None

#### Applicable Issues
Fixes #437 

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
