### PR TITLE
Relay direct messages

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "November 29, 2018",
+  "date": "December 1, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [
     "Automatically remove accidental extra spaces around command arguments."
@@ -43,6 +43,7 @@
     "You can now send ROT13 encoded message using the `ROT13` command.",
     "You can now send and view spoilers, without spoiling it for everyone, using the `sendSpoiler` and `showSpoiler` commands.",
     "You can now relay a message to the announcement channel just by adding either 📢 or 📣 reaction to a message.",
+    "Bastion can now relay every direct messages, sent to it, to your inbox."
   ],
   "NEW COMMANDS!": [
     "`blacklist` - Blacklist users globally from using Bastion.",
@@ -69,7 +70,8 @@
     "`setProfilePicture` - Sets your profile picture that shows up in the Bastion user profile.",
     "`book` - Shows details about the specified book.",
     "`ignoreXP` - Set channels and/or roles to be ignored for experience.",
-    "`reactionAnnouncements` - Toggle Reaction Announcements."
+    "`reactionAnnouncements` - Toggle Reaction Announcements.",
+    "`relayDirectMessages` - Toggles relaying of direct messages, sent to Bastion, to your inbox."
   ],
   "COMMANDS WITH NEW USAGE": [
     "`addTrigger` command's usage syntax has been changed. It won't work the way it used to before, please check the help message for it, using the `help addTrigger` command, to see the new usage details.",

--- a/commands/owner/relayDirectMessages.js
+++ b/commands/owner/relayDirectMessages.js
@@ -1,0 +1,53 @@
+/**
+ * @file relayDirectMessages command
+ * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
+ * @license GPL-3.0
+ */
+
+exports.exec = async (Bastion, message) => {
+  try {
+    let settingsModel = await Bastion.database.models.settings.findOne({
+      attributes: [ 'relayDirectMessages' ],
+      where: {
+        botID: Bastion.user.id
+      }
+    });
+
+    await Bastion.database.models.settings.update({
+      relayDirectMessages: !settingsModel.dataValues.relayDirectMessages
+    },
+    {
+      where: {
+        botID: Bastion.user.id
+      },
+      fields: [ 'relayDirectMessages' ]
+    });
+
+    message.channel.send({
+      embed: {
+        color: Bastion.colors[settingsModel.dataValues.relayDirectMessages ? 'RED' : 'GREEN'],
+        description: Bastion.i18n.info(message.guild.language, settingsModel.dataValues.relayDirectMessages ? 'disableDirectMessageReyals' : 'enableDirectMessageReyals', message.author.tag)
+      }
+    }).catch(e => {
+      Bastion.log.error(e);
+    });
+  }
+  catch (e) {
+    Bastion.log.error(e);
+  }
+};
+
+exports.config = {
+  aliases: [ 'relayPrivateMessages', 'relayDMs', 'relayPMs' ],
+  enabled: true
+};
+
+exports.help = {
+  name: 'relayDirectMessages',
+  description: 'Toggles relaying of direct messages, sent to Bastion, to your inbox.',
+  botPermission: '',
+  userTextPermission: 'MANAGE_GUILD',
+  userVoicePermission: '',
+  usage: 'relayDirectMessages',
+  example: []
+};

--- a/commands/owner/relayDirectMessages.js
+++ b/commands/owner/relayDirectMessages.js
@@ -47,7 +47,7 @@ exports.help = {
   name: 'relayDirectMessages',
   description: 'Toggles relaying of direct messages, sent to Bastion, to your inbox.',
   botPermission: '',
-  userTextPermission: 'MANAGE_GUILD',
+  userTextPermission: '',
   userVoicePermission: '',
   usage: 'relayDirectMessages',
   example: []

--- a/commands/owner/relayDirectMessages.js
+++ b/commands/owner/relayDirectMessages.js
@@ -39,7 +39,8 @@ exports.exec = async (Bastion, message) => {
 
 exports.config = {
   aliases: [ 'relayPrivateMessages', 'relayDMs', 'relayPMs' ],
-  enabled: true
+  enabled: true,
+  ownerOnly: true
 };
 
 exports.help = {

--- a/data/commands.json
+++ b/data/commands.json
@@ -791,6 +791,10 @@
     "description": "Add/Update the reason for a moderation action, which is logged in the moderation log channel. Only the responsible moderator or anyone with administrator permissions can change the reason.",
     "module": "Moderation"
   },
+  "relayDirectMessages": {
+    "description": "Toggles relaying of direct messages, sent to Bastion, to your inbox.",
+    "module": "Owner"
+  },
   "reloadSettings": {
     "description": "Reloads Bastion settings, stored in the `settings` directory, from the cache. When you modify files in the `settings` directory, use this command to reload them without any need to restart.",
     "module": "Owner"

--- a/handlers/directMessageHandler.js
+++ b/handlers/directMessageHandler.js
@@ -9,35 +9,63 @@
  * @param {Message} message Discord.js message object
  * @returns {void}
  */
-module.exports = message => {
-  if (!message.content) return;
+module.exports = async message => {
+  try {
+    if (!message.content) return;
 
-  if (message.content.toLowerCase().startsWith('help')) {
-    return message.channel.send({
-      embed: {
-        color: message.client.colors.BLUE,
-        title: 'The Bastion Bot',
-        url: 'https://bastionbot.org',
-        description: 'Join [**Bastion HQ**](https://discord.gg/fzx8fkt) to test Bastion and it\'s commands, for giveaway events, for chatting and for a lot of fun!',
-        fields: [
-          {
-            name: 'Bastion HQ Invite Link',
-            value: 'https://discord.gg/fzx8fkt'
+    if (message.content.toLowerCase().startsWith('help')) {
+      return message.channel.send({
+        embed: {
+          color: message.client.colors.BLUE,
+          title: 'The Bastion Bot',
+          url: 'https://bastionbot.org',
+          description: 'Join [**Bastion HQ**](https://discord.gg/fzx8fkt) to test Bastion and it\'s commands, for giveaway events, for chatting and for a lot of fun!',
+          fields: [
+            {
+              name: 'Bastion HQ Invite Link',
+              value: 'https://discord.gg/fzx8fkt'
+            },
+            {
+              name: 'Bastion Bot Invite Link',
+              value: `https://discordapp.com/oauth2/authorize?client_id=${message.client.user.id}&scope=bot&permissions=2146958463`
+            }
+          ],
+          thumbnail: {
+            url: message.client.user.displayAvatarURL
           },
-          {
-            name: 'Bastion Bot Invite Link',
-            value: `https://discordapp.com/oauth2/authorize?client_id=${message.client.user.id}&scope=bot&permissions=2146958463`
+          footer: {
+            text: '</> with ❤ by Sankarsan Kampa (a.k.a. k3rn31p4nic)'
           }
-        ],
-        thumbnail: {
-          url: message.client.user.displayAvatarURL
-        },
-        footer: {
-          text: '</> with ❤ by Sankarsan Kampa (a.k.a. k3rn31p4nic)'
         }
+      }).catch(e => {
+        message.client.log.error(e);
+      });
+    }
+
+    let settingsModel = await message.client.database.models.settings.findOne({
+      attributes: [ 'relayDirectMessages' ],
+      where: {
+        botID: message.client.user.id
       }
-    }).catch(e => {
-      message.client.log.error(e);
     });
+
+    if (settingsModel && settingsModel.dataValues.relayDirectMessages) {
+      // Find the application owner
+      let app = await message.client.fetchApplication();
+      let owner = await message.client.fetchUser(app.owner.id);
+
+      // Relay the message
+      await owner.send({
+        embed: {
+          author: {
+            name: message.author.tag
+          },
+          description: message.content
+        }
+      });
+    }
+  }
+  catch (e) {
+    message.client.log.error(e);
   }
 };

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -593,6 +593,9 @@
   "reason": {
     "description": "Add/Update the reason for a moderation action, which is logged in the moderation log channel. Only the responsible moderator or anyone with administrator permissions can change the reason."
   },
+  "relayDirectMessages": {
+    "description": "Toggles relaying of direct messages, sent to Bastion, to your inbox."
+  },
   "reloadSettings": {
     "description": "Reloads Bastion settings, stored in the `settings` directory, from the cache. When you modify files in the `settings` directory, use this command to reload them without any need to restart."
   },

--- a/locales/en_us/info.json
+++ b/locales/en_us/info.json
@@ -102,6 +102,9 @@
   "removeMusicMasterRole": "%var% removed the **Music Master Role**.",
   "repeatSong": "%var% set the current song to repeat once.",
 
+  "disableDirectMessageReyals": "I will now stop relaying direct messages, sent to me, into your inbox.",
+  "enableDirectMessageReyals": "I will now relay every direct messages, sent to me, into your inbox.",
+
   "lastSeen": "%var% was last seen %var% ago.",
   "notSeen": "I have not seen %var% in a while.",
   "deleteReminder": "%var% your reminders have been deleted.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.76",
+  "version": "7.0.0-alpha.77",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",

--- a/utils/models.js
+++ b/utils/models.js
@@ -20,6 +20,11 @@ module.exports = (Sequelize, database) => {
       allowNull: false,
       primaryKey: true
     },
+    relayDirectMessages: {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
+    },
     blacklistedGuilds: {
       type: Sequelize.JSON
     },


### PR DESCRIPTION
#### Changes introduced by this PR
Bastion can now relay direct messages, sent to it, into the inbox of the user who created the bot application.

#### Possible drawbacks
None

#### Applicable Issues
Closes #419 

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
