### PR TITLE
Use BWAPI for movie & tvshow commands

### DIFF
--- a/commands/queries/movie.js
+++ b/commands/queries/movie.js
@@ -4,8 +4,6 @@
  * @license GPL-3.0
  */
 
-const request = xrequire('request-promise-native');
-
 exports.exec = async (Bastion, message, args) => {
   try {
     if (!args.movie) {
@@ -16,15 +14,7 @@ exports.exec = async (Bastion, message, args) => {
       return Bastion.emit('commandUsage', message, this.help);
     }
 
-    let options = {
-      method: 'GET',
-      url: `https://api.themoviedb.org/3/search/movie?api_key=&query=${encodeURIComponent(args.movie)}`,
-      qs: {
-        api_key: Bastion.credentials.theMovieDBApiKey
-      },
-      json: true
-    };
-    let movie = await request(options);
+    let movie = await Bastion.methods.makeBWAPIRequest(`/movies/search/${args.movie}`);
 
     movie = movie.results[0];
 

--- a/commands/queries/tvShow.js
+++ b/commands/queries/tvShow.js
@@ -4,8 +4,6 @@
  * @license GPL-3.0
  */
 
-const request = xrequire('request-promise-native');
-
 exports.exec = async (Bastion, message, args) => {
   try {
     if (!args.tvshow) {
@@ -16,15 +14,7 @@ exports.exec = async (Bastion, message, args) => {
       return Bastion.emit('commandUsage', message, this.help);
     }
 
-    let options = {
-      method: 'GET',
-      url: `https://api.themoviedb.org/3/search/tv?api_key=&query=${encodeURIComponent(args.tvshow)}`,
-      qs: {
-        api_key: Bastion.credentials.theMovieDBApiKey
-      },
-      json: true
-    };
-    let tvShow = await request(options);
+    let tvShow = await Bastion.methods.makeBWAPIRequest(`/tvshows/search/${args.tvshow}`);
 
     tvShow = tvShow.results[0];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.79",
+  "version": "7.0.0-alpha.80",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",

--- a/settings/credentials.example.yaml
+++ b/settings/credentials.example.yaml
@@ -22,7 +22,6 @@ fortniteAPIKey:
 HiRezDevId:
 HiRezAuthKey:
 rocketLeagueUserToken:
-theMovieDBApiKey:
 
 patreon:
   clientID:


### PR DESCRIPTION
#### Changes introduced by this PR
Use BWAPI for `movie` & `tvShow` commands. This also removes the requirement of getting a The Movie Database API key.

#### Possible drawbacks
None

#### Applicable Issues
\-

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
