### PR TITLE
Sneaky link warnings

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "December 1, 2018",
+  "date": "December 5, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [
     "Automatically remove accidental extra spaces around command arguments."
@@ -43,7 +43,8 @@
     "You can now send ROT13 encoded message using the `ROT13` command.",
     "You can now send and view spoilers, without spoiling it for everyone, using the `sendSpoiler` and `showSpoiler` commands.",
     "You can now relay a message to the announcement channel just by adding either 📢 or 📣 reaction to a message.",
-    "Bastion can now relay every direct messages, sent to it, to your inbox."
+    "Bastion can now relay every direct messages, sent to it, to your inbox.",
+    "Bastion can warn you about sneaky links in messages sent in the server."
   ],
   "NEW COMMANDS!": [
     "`blacklist` - Blacklist users globally from using Bastion.",
@@ -71,7 +72,8 @@
     "`book` - Shows details about the specified book.",
     "`ignoreXP` - Set channels and/or roles to be ignored for experience.",
     "`reactionAnnouncements` - Toggle Reaction Announcements.",
-    "`relayDirectMessages` - Toggles relaying of direct messages, sent to Bastion, to your inbox."
+    "`relayDirectMessages` - Toggles relaying of direct messages, sent to Bastion, to your inbox.",
+    "`uncoverSneakyLinks` - Toggle uncovering of sneaky links in the messages sent in the server."
   ],
   "COMMANDS WITH NEW USAGE": [
     "`addTrigger` command's usage syntax has been changed. It won't work the way it used to before, please check the help message for it, using the `help addTrigger` command, to see the new usage details.",

--- a/commands/guild_admin/uncoverSneakyLinks.js
+++ b/commands/guild_admin/uncoverSneakyLinks.js
@@ -1,0 +1,55 @@
+/**
+ * @file uncoverSneakyLinks command
+ * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
+ * @license GPL-3.0
+ */
+
+exports.exec = async (Bastion, message) => {
+  try {
+    let guildModels = await message.client.database.models.guild.findOne({
+      attributes: [ 'uncoverSneakyLinks' ],
+      where: {
+        guildID: message.guild.id
+      }
+    });
+
+    let sneakyLinkWarningsStatus = !guildModels.dataValues.uncoverSneakyLinks;
+
+    await message.client.database.models.guild.update({
+      uncoverSneakyLinks: sneakyLinkWarningsStatus
+    },
+    {
+      where: {
+        guildID: message.guild.id
+      },
+      fields: [ 'uncoverSneakyLinks' ]
+    });
+
+    message.channel.send({
+      embed: {
+        color: sneakyLinkWarningsStatus ? Bastion.colors.GREEN : Bastion.colors.RED,
+        description: Bastion.i18n.info(message.guild.language, sneakyLinkWarningsStatus ? 'enableSneakyLinkWarnings' : 'disableSneakyLinkWarnings', message.author.tag)
+      }
+    }).catch(e => {
+      Bastion.log.error(e);
+    });
+  }
+  catch (e) {
+    Bastion.log.error(e);
+  }
+};
+
+exports.config = {
+  aliases: [ 'uncoverLinks' ],
+  enabled: true
+};
+
+exports.help = {
+  name: 'uncoverSneakyLinks',
+  description: 'Toggle uncovering of sneaky links in the messages sent in the server. If enabled, Bastion will show details of all link that contains redirects to other locations, in every message sent in the server.',
+  botPermission: '',
+  userTextPermission: 'MANAGE_GUILD',
+  userVoicePermission: '',
+  usage: 'uncoverSneakyLinks',
+  example: []
+};

--- a/data/commands.json
+++ b/data/commands.json
@@ -1207,6 +1207,10 @@
     "description": "Unmutes a specified user server-wide in your Discord server.",
     "module": "Moderation"
   },
+  "uncoverSneakyLinks": {
+    "description": "Toggle uncovering of sneaky links in the messages sent in the server. If enabled, Bastion will show details of all link that contains redirects to other locations, in every message sent in the server.",
+    "module": "Guild Admin"
+  },
   "unturned": {
     "description": "Get stats of any Unturned game server.",
     "module": "Game Stats"

--- a/events/discord/message.js
+++ b/events/discord/message.js
@@ -14,11 +14,14 @@ const handleUserLevel = xrequire('./handlers/levelHandler');
 const handleCommand = xrequire('./handlers/commandHandler');
 const handleConversation = xrequire('./handlers/conversationHandler');
 const handleDirectMessage = xrequire('./handlers/directMessageHandler');
+const sneakyLinksHandler = xrequire('./handlers/sneakyLinksHandler');
 let recentLevelUps = [];
 let recentUsers = {};
 
 module.exports = async message => {
   try {
+    sneakyLinksHandler(message);
+
     /**
      * Filter Bastion's credentials from the message
      */

--- a/handlers/sneakyLinksHandler.js
+++ b/handlers/sneakyLinksHandler.js
@@ -20,7 +20,7 @@ module.exports = async message => {
     let links = [];
     for (let link in sneakyLinks) {
       if (sneakyLinks.hasOwnProperty(link)) {
-        links.push(`${link} ➡ ${sneakyLinks[link]}`);
+        links.push(`${link} > ${sneakyLinks[link]}`);
       }
     }
 
@@ -28,7 +28,10 @@ module.exports = async message => {
       embed: {
         color: message.client.colors.ORANGE,
         title: 'Sneaky Links Found!',
-        description: links.join('\n')
+        description: links.join('\n'),
+        footer: {
+          text: `ID: ${message.id}`
+        }
       }
     });
   }

--- a/handlers/sneakyLinksHandler.js
+++ b/handlers/sneakyLinksHandler.js
@@ -1,0 +1,38 @@
+/**
+ * @file sneakyLinksHandler
+ * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
+ * @license GPL-3.0
+ */
+
+/**
+ * Handles sneaky links sent in messages
+ * @param {Message} message Discord.js message object
+ * @returns {void}
+ */
+module.exports = async message => {
+  try {
+    if (!message.content.length) return;
+
+    let sneakyLinks = await message.client.methods.makeBWAPIRequest(`/text/redirects?text=${message.content}`);
+
+    if (!Object.keys(sneakyLinks).length) return;
+
+    let links = [];
+    for (let link in sneakyLinks) {
+      if (sneakyLinks.hasOwnProperty(link)) {
+        links.push(`${link} ➡ ${sneakyLinks[link]}`);
+      }
+    }
+
+    await message.channel.send({
+      embed: {
+        color: message.client.colors.ORANGE,
+        title: 'Sneaky Links Found!',
+        description: links.join('\n')
+      }
+    });
+  }
+  catch (e) {
+    message.client.log.error(e);
+  }
+};

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -905,6 +905,9 @@
   "unMute": {
     "description": "Unmutes a specified user server-wide in your Discord server."
   },
+  "uncoverSneakyLinks": {
+    "description": "Toggle uncovering of sneaky links in the messages sent in the server. If enabled, Bastion will show details of all link that contains redirects to other locations, in every message sent in the server."
+  },
   "unturned": {
     "description": "Get stats of any Unturned game server."
   },

--- a/locales/en_us/info.json
+++ b/locales/en_us/info.json
@@ -40,6 +40,8 @@
   "enablePrivateGreetingMessages": "%var% enabled private greeting messages.",
   "disableLevelUpMessages": "%var% disabled level up messages in this server. I will not send any message when someone levels up in this server.",
   "enableLevelUpMessages": "%var% enabled level up messages in this server. I will send messages, congratulating users, when they level up in this server.",
+  "disableSneakyLinkWarnings": "%var% disabled warnings of sneaky links in the messages sent in the server.",
+  "enableSneakyLinkWarnings": "%var% enabled warnings of sneaky links in the messages sent in the server. I will now show details of all link that contains redirects to other locations, in every message sent in the server.",
   "addLevelUpRole": "%var% added a level up role **%var%** to be added to users at level **%var%**.",
   "removeLevelUpRoles": "%var% removed all level up roles from level **%var%**.",
   "disableLevelUps": "%var% disabled level ups in this server. Users won't be able to gain experience points and level up while chatting.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.81",
+  "version": "7.0.0-alpha.82",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",

--- a/utils/models.js
+++ b/utils/models.js
@@ -135,6 +135,11 @@ module.exports = (Sequelize, database) => {
       type: Sequelize.STRING,
       unique: true
     },
+    redirectWarnings: {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
+    },
     filterInvites: {
       type: Sequelize.BOOLEAN,
       allowNull: false,

--- a/utils/models.js
+++ b/utils/models.js
@@ -135,7 +135,7 @@ module.exports = (Sequelize, database) => {
       type: Sequelize.STRING,
       unique: true
     },
-    redirectWarnings: {
+    uncoverSneakyLinks: {
       type: Sequelize.BOOLEAN,
       allowNull: false,
       defaultValue: false


### PR DESCRIPTION
#### Changes introduced by this PR
This PR adds a feature to Bastion that enables it to warn and send details about redirected links in all messages sent in the server.

#### Possible drawbacks
None

#### Applicable Issues
Closes #118 

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
