### PR TITLE
Auto disconnect

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "December 24, 2018",
+  "date": "December 25, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [
     "Automatically remove accidental extra spaces around command arguments."
@@ -46,7 +46,8 @@
     "You can now relay a message to the announcement channel just by adding either 📢 or 📣 reaction to a message.",
     "Bastion can now relay every direct messages, sent to it, to your inbox.",
     "Bastion can warn you about sneaky links in messages sent in the server.",
-    "Bastion can now auto play songs of it's choice when there's no song in the queue. Here's your ticket to a 24x7 music channel!"
+    "Bastion can now auto play songs of it's choice when there's no song in the queue. Here's your ticket to a 24x7 music channel!",
+    "You can now configure Bastion to prevent it from automatically disconnecting from voice channels when music is stopped or the queue is finished."
   ],
   "NEW COMMANDS!": [
     "`blacklist` - Blacklist users globally from using Bastion.",
@@ -77,7 +78,8 @@
     "`uncoverSneakyLinks` - Toggle uncovering of sneaky links in the messages sent in the server.",
     "`topGames` - Shows the top most played games in the server.",
     "`topSongs` - Shows the top most played songs, on Spotify, in the server.",
-    "`autoPlay` - Toggles auto playing of music."
+    "`autoPlay` - Toggles auto playing of music.",
+    "`autoDisconnect` - Toggles auto disconnect from voice channel."
   ],
   "COMMANDS WITH NEW USAGE": [
     "`addTrigger` command's usage syntax has been changed. It won't work the way it used to before, please check the help message for it, using the `help addTrigger` command, to see the new usage details.",

--- a/commands/music/autoDisconnect.js
+++ b/commands/music/autoDisconnect.js
@@ -1,0 +1,67 @@
+/**
+ * @file autoDisconnect command
+ * @author Sankarsan Kampa (a.k.a k3rn31p4nic)
+ * @license GPL-3.0
+ */
+
+exports.exec = async (Bastion, message) => {
+  if (!message.guild.music.enabled) {
+    if (Bastion.user.id === '267035345537728512') {
+      return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabledPublic'), message.channel);
+    }
+    return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'musicDisabled'), message.channel);
+  }
+
+  let guildModel = await Bastion.database.models.guild.findOne({
+    attributes: [ 'musicAutoDisconnect' ],
+    where: {
+      guildID: message.guild.id
+    }
+  });
+
+  let enabled, color, autoDisconnectStatus;
+  if (guildModel.dataValues.musicAutoDisconnect) {
+    enabled = false;
+    color = Bastion.colors.RED;
+    autoDisconnectStatus = Bastion.i18n.info(message.guild.language, 'disableMusicAutoDisconnect', message.author.tag);
+  }
+  else {
+    enabled = true;
+    color = Bastion.colors.GREEN;
+    autoDisconnectStatus = Bastion.i18n.info(message.guild.language, 'enableMusicAutoDisconnect', message.author.tag);
+  }
+
+  await Bastion.database.models.guild.update({
+    musicAutoDisconnect: enabled
+  },
+  {
+    where: {
+      guildID: message.guild.id
+    },
+    fields: [ 'musicAutoDisconnect' ]
+  });
+
+  await message.channel.send({
+    embed: {
+      color: color,
+      description: autoDisconnectStatus
+    }
+  }).catch(e => {
+    Bastion.log.error(e);
+  });
+};
+
+exports.config = {
+  aliases: [],
+  enabled: true
+};
+
+exports.help = {
+  name: 'autoDisconnect',
+  description: 'Toggles auto disconnect from voice channel. If enabled, Bastion will automatically leave the voice channel to save bandwidth when no one else is connected to it.',
+  botPermission: '',
+  userTextPermission: 'MANAGE_GUILD',
+  userVoicePermission: '',
+  usage: 'autoDisconnect',
+  example: []
+};

--- a/commands/music/play.js
+++ b/commands/music/play.js
@@ -250,7 +250,7 @@ exports.help = {
  * @returns {void}
  */
 async function startStreamDispatcher(guild, connection) {
-  if (!guild.music.songs[0] && guild.music.autoPlay) {
+  if (!guild.music.songs[0] && guild.music.autoPlay && connection.channel.members.size > 1) {
     let songs = await guild.client.methods.makeBWAPIRequest('/google/youtube/topsongs');
     let videoID = songs.getRandom();
 
@@ -292,7 +292,7 @@ async function startStreamDispatcher(guild, connection) {
 
     let description;
     if (!guild.music.songs[0]) {
-      description = 'Exiting voice channel.';
+      description = 'Stopping playback.';
     }
     else {
       guild.music.songs = [];
@@ -306,7 +306,7 @@ async function startStreamDispatcher(guild, connection) {
       }
     }).then(() => {
       guild.music.dispatcher.end();
-      guild.music.voiceChannel.leave();
+      if (guild.music.autoDisconnect) guild.music.voiceChannel.leave();
     }).catch(e => {
       guild.client.log.error(e);
     });

--- a/commands/music/stop.js
+++ b/commands/music/stop.js
@@ -20,19 +20,10 @@ exports.exec = async (Bastion, message) => {
     return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notPlaying'), message.channel);
   }
 
-  await message.guild.music.textChannel.send({
-    embed: {
-      color: Bastion.colors.RED,
-      description: 'Stopped Playback.'
-    }
-  }).then(() => {
-    if (message.guild.music) {
-      message.guild.music.songs = [];
-    }
-    message.guild.music.dispatcher.end();
-  }).catch(e => {
-    Bastion.log.error(e);
-  });
+  if (message.guild.music) {
+    message.guild.music.songs = [];
+    await message.guild.music.dispatcher.end();
+  }
 };
 
 exports.config = {

--- a/data/commands.json
+++ b/data/commands.json
@@ -59,6 +59,10 @@
     "description": "Get stats of any ARK: Survival Evolved game server.",
     "module": "Game Server_stats"
   },
+  "autoDisconnect": {
+    "description": "Toggles auto disconnect from voice channel. If enabled, Bastion will automatically leave the voice channel to save bandwidth when no one else is connected to it.",
+    "module": "Music"
+  },
   "autoPlay": {
     "description": "Toggles auto playing of music.",
     "module": "Music"

--- a/handlers/commandHandler.js
+++ b/handlers/commandHandler.js
@@ -17,7 +17,7 @@ const activeUsers = {};
 module.exports = async message => {
   try {
     let guildModel = await message.client.database.models.guild.findOne({
-      attributes: [ 'enabled', 'prefix', 'language', 'membersOnly', 'music', 'musicAutoPlay', 'musicTextChannel', 'musicVoiceChannel', 'musicMasterRole', 'disabledCommands' ],
+      attributes: [ 'enabled', 'prefix', 'language', 'membersOnly', 'music', 'musicAutoPlay', 'musicAutoDisconnect', 'musicTextChannel', 'musicVoiceChannel', 'musicMasterRole', 'disabledCommands' ],
       where: {
         guildID: message.guild.id
       },
@@ -56,6 +56,8 @@ module.exports = async message => {
     message.guild.music.enabled = guildModel.dataValues.music;
     // Set music auto play status
     message.guild.music.autoPlay = guildModel.dataValues.musicAutoPlay;
+    // Set music auto disconnect status
+    message.guild.music.autoDisconnect = guildModel.dataValues.musicAutoDisconnect;
     // If any of the music channels have been removed, delete them from the database.
     if (!message.guild.channels.has(guildModel.dataValues.musicTextChannel) || !message.guild.channels.has(guildModel.dataValues.musicVoiceChannel)) {
       await message.client.database.models.guild.update({

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -44,6 +44,9 @@
   "ark": {
     "description": "Get stats of any ARK: Survival Evolved game server."
   },
+  "autoDisconnect": {
+    "description": "Toggles auto disconnect from voice channel. If enabled, Bastion will automatically leave the voice channel to save bandwidth when no one else is connected to it."
+  },
   "autoPlay": {
     "description": "Toggles auto playing of music."
   },

--- a/locales/en_us/info.json
+++ b/locales/en_us/info.json
@@ -96,6 +96,8 @@
 
   "disableMusicAutoPlay": "%var% disabled auto playing of music in this server.",
   "enableMusicAutoPlay": "%var% enabled auto playing of music in this server. I will play songs of my choice when there's nothing in the queue.",
+  "disableMusicAutoDisconnect": "%var% disabled auto disconnect, from voice channel, in this server. I will stay in the voice channel even when there is no one else to listen to me.",
+  "enableMusicAutoDisconnect": "%var% enabled auto disconnect, from voice channel, in this server. I will automatically disconnect from the voice channel when there is no one else to listen to me.",
   "addMusicChannels": "%var% set the **%var%** text channel as the **Music Text Channel** for using music commands and **%var%** voice channel as the **Music Voice Channel** for listening to music.",
   "addMusicMasterRole": "%var% set the **%var%** role as the **Music Master Role**.",
   "cleanQueue": "%var% cleaned up the music queue.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.101",
+  "version": "7.0.0-alpha.102",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",

--- a/utils/models.js
+++ b/utils/models.js
@@ -116,6 +116,11 @@ module.exports = (Sequelize, database) => {
       allowNull: false,
       defaultValue: false
     },
+    musicAutoDisconnect: {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: true
+    },
     musicTextChannel: {
       type: Sequelize.STRING,
       unique: true


### PR DESCRIPTION
#### Changes introduced by this PR
This will enable guild managers to configure Bastion's default auto disconnect setting. If disabled, Bastion won't get disconnected from voice channels when music playback is stopped or ended.

#### Possible drawbacks
No

#### Applicable Issues
\-

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
