### PR TITLE
Improved Level-up roles

### DIFF
--- a/bastion.js
+++ b/bastion.js
@@ -29,6 +29,7 @@ xrequire('./prototypes/Number');
 xrequire('./prototypes/String.prototype');
 xrequire('./prototypes/Array.prototype');
 xrequire('./prototypes/Array');
+xrequire('./prototypes/Object');
 
 const WebhookHandler = xrequire('./handlers/webhookHandler.js');
 BASTION.webhook = new WebhookHandler(BASTION.credentials.webhooks);

--- a/changes.json
+++ b/changes.json
@@ -1,8 +1,9 @@
 {
-  "date": "December 25, 2018",
+  "date": "December 27, 2018",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [
-    "Automatically remove accidental extra spaces around command arguments."
+    "Automatically remove accidental extra spaces around command arguments.",
+    "Users not getting all level up roles when they already had one of those roles."
   ],
   "THESE ABILITIES HAVE ENHANCED": [
     "Logs are now much prettier, than it was already!",
@@ -22,6 +23,8 @@
     "You can now enable disabled modules using the `--module` option in the `enableCommand` command.",
     "The `lyrics` command is much much better now. Just try it out.",
     "The `acrophobia` command now uses relative frequencies of letters as the first word of English words to generate acronyms for the game.",
+    "Level up roles are now synced.",
+    "Level up roles can now be exclusive.",
     "Tons of under-the-hood improvements & changes."
   ],
   "NEW FEATURES!": [

--- a/handlers/levelHandler.js
+++ b/handlers/levelHandler.js
@@ -162,7 +162,10 @@ module.exports = async message => {
          * discord.js.
          */
         setTimeout(async () => {
-          await message.member.addRoles(levelUpRoleIDs[level], 'Level Up').catch(() => {});
+          let allLevelUpRoles = levelUpRoleIDs[level];
+          allLevelUpRoles = allLevelUpRoles.filter(role => !message.member.roles.has(role));
+
+          await message.member.addRoles(allLevelUpRoles, 'Level Up').catch(() => {});
         }, 500);
       }
       else {

--- a/handlers/levelHandler.js
+++ b/handlers/levelHandler.js
@@ -151,20 +151,27 @@ module.exports = async message => {
       if (exclusiveLevels.includes(level)) {
         let allLevelUpRoles = Object.values(levelUpRoleIDs).flatten().filter(role => !levelUpRoleIDs[level].includes(role));
         await message.member.removeRoles(allLevelUpRoles, 'Level Up').catch(() => {});
-      }
 
-      /**
-       * HACK: When adding roles instantly after removing then just above this,
-       * a race condition occurs which adds the old roles back to the member as
-       * the cache hasn't been updated with the remove roles yet.
-       * Therefore, I'm using a timeout to wait for a while before adding new
-       * roles to prevent the race condition.
-       * This hack should be removed when it's fixed in a stable version of
-       * discord.js.
-       */
-      setTimeout(async () => {
-        await message.member.addRoles(levelUpRoleIDs[level], 'Level Up').catch(() => {});
-      }, 500);
+        /**
+         * HACK: When adding roles instantly after removing then just above this,
+         * a race condition occurs which adds the old roles back to the member as
+         * the cache hasn't been updated with the remove roles yet.
+         * Therefore, I'm using a timeout to wait for a while before adding new
+         * roles to prevent the race condition.
+         * This hack should be removed when it's fixed in a stable version of
+         * discord.js.
+         */
+        setTimeout(async () => {
+          await message.member.addRoles(levelUpRoleIDs[level], 'Level Up').catch(() => {});
+        }, 500);
+      }
+      else {
+        let allLevelUpRoles = Object.filter(levelUpRoleIDs, ([ level ]) => level <= currentLevel);
+        allLevelUpRoles = Object.values(allLevelUpRoles).flatten();
+        allLevelUpRoles = allLevelUpRoles.filter(role => !message.member.roles.has(role));
+
+        await message.member.addRoles(allLevelUpRoles, 'Level Up').catch(() => {});
+      }
     }
   }
   catch (e) {

--- a/handlers/levelHandler.js
+++ b/handlers/levelHandler.js
@@ -153,13 +153,15 @@ module.exports = async message => {
         await message.member.removeRoles(allLevelUpRoles, 'Level Up').catch(() => {});
       }
 
-      // HACK: When adding roles instantly after removing then just above this,
-      // a race condition occurs which adds the old roles back to the member as
-      // the cache hasn't been updated with the remove roles yet.
-      // Therefore, I'm using a timeout to wait for a while before adding new
-      // roles to prevent the race condition.
-      // This hack should be removed when it's fixed in a stable version of
-      // discord.js.
+      /**
+       * HACK: When adding roles instantly after removing then just above this,
+       * a race condition occurs which adds the old roles back to the member as
+       * the cache hasn't been updated with the remove roles yet.
+       * Therefore, I'm using a timeout to wait for a while before adding new
+       * roles to prevent the race condition.
+       * This hack should be removed when it's fixed in a stable version of
+       * discord.js.
+       */
       setTimeout(async () => {
         await message.member.addRoles(levelUpRoleIDs[level], 'Level Up').catch(() => {});
       }, 500);

--- a/handlers/levelHandler.js
+++ b/handlers/levelHandler.js
@@ -68,7 +68,7 @@ module.exports = async message => {
     guildMemberModel.dataValues.level = parseInt(guildMemberModel.dataValues.level);
     guildMemberModel.dataValues.bastionCurrencies = parseInt(guildMemberModel.dataValues.bastionCurrencies);
 
-    let currentLevel = Math.floor(0.15 * Math.sqrt(guildMemberModel.dataValues.experiencePoints + 1));
+    let currentLevel = Math.floor(0.15 * Math.sqrt(parseInt(guildMemberModel.dataValues.experiencePoints) + 1));
 
 
     // Level Up
@@ -141,7 +141,7 @@ module.exports = async message => {
 
     let level = `${currentLevel}`;
     if (levelUpRoleIDs.hasOwnProperty(level)) {
-      await message.member.addRoles(levelUpRoleIDs[level]).catch(() => {});
+      await message.member.addRoles(levelUpRoleIDs[level], 'Level Up').catch(() => {});
     }
   }
   catch (e) {

--- a/handlers/levelHandler.js
+++ b/handlers/levelHandler.js
@@ -47,7 +47,7 @@ module.exports = async message => {
         },
         {
           model: message.client.database.models.role,
-          attributes: [ 'roleID', 'level', 'ignoreXP' ]
+          attributes: [ 'roleID', 'level', 'exclusive', 'ignoreXP' ]
         }
       ]
     });
@@ -131,17 +131,38 @@ module.exports = async message => {
     let levelUpRoles = guildModel.roles.filter(role => role.dataValues.level).map(role => role.dataValues);
 
     let levelUpRoleIDs = {};
+    let exclusiveLevels = [];
     for (let role of levelUpRoles) {
       if (!levelUpRoleIDs.hasOwnProperty(role.level)) {
         levelUpRoleIDs[role.level] = [];
       }
 
       levelUpRoleIDs[role.level].push(role.roleID);
+
+      if (role.exclusive) {
+        if (!exclusiveLevels.includes(role.level)) {
+          exclusiveLevels.push(role.level);
+        }
+      }
     }
 
     let level = `${currentLevel}`;
     if (levelUpRoleIDs.hasOwnProperty(level)) {
-      await message.member.addRoles(levelUpRoleIDs[level], 'Level Up').catch(() => {});
+      if (exclusiveLevels.includes(level)) {
+        let allLevelUpRoles = Object.values(levelUpRoleIDs).flatten().filter(role => !levelUpRoleIDs[level].includes(role));
+        await message.member.removeRoles(allLevelUpRoles, 'Level Up').catch(() => {});
+      }
+
+      // HACK: When adding roles instantly after removing then just above this,
+      // a race condition occurs which adds the old roles back to the member as
+      // the cache hasn't been updated with the remove roles yet.
+      // Therefore, I'm using a timeout to wait for a while before adding new
+      // roles to prevent the race condition.
+      // This hack should be removed when it's fixed in a stable version of
+      // discord.js.
+      setTimeout(async () => {
+        await message.member.addRoles(levelUpRoleIDs[level], 'Level Up').catch(() => {});
+      }, 500);
     }
   }
   catch (e) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.102",
+  "version": "7.0.0-alpha.103",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",

--- a/prototypes/Object.js
+++ b/prototypes/Object.js
@@ -1,0 +1,11 @@
+Object.fromPairs = (pairs) => {
+  let index = -1;
+  let length = pairs === null ? 0 : pairs.length;
+  let result = {};
+
+  while (++index < length) {
+    let pair = pairs[index];
+    result[pair[0]] = pair[1];
+  }
+  return result;
+};

--- a/prototypes/Object.js
+++ b/prototypes/Object.js
@@ -9,3 +9,7 @@ Object.fromPairs = (pairs) => {
   }
   return result;
 };
+
+Object.filter = function (object, predicate) {
+  return Object.fromPairs(Object.entries(object).filter(predicate));
+};

--- a/prototypes/Object.prototype.js
+++ b/prototypes/Object.prototype.js
@@ -1,3 +1,0 @@
-Object.prototype.filter = function (predicate) {
-  return Object.fromPairs(Object.entries(this).filter(predicate));
-};

--- a/prototypes/Object.prototype.js
+++ b/prototypes/Object.prototype.js
@@ -1,0 +1,3 @@
+Object.prototype.filter = function (predicate) {
+  return Object.fromPairs(Object.entries(this).filter(predicate));
+};

--- a/utils/models.js
+++ b/utils/models.js
@@ -511,7 +511,9 @@ module.exports = (Sequelize, database) => {
       type: Sequelize.STRING
     },
     exclusive: {
-      type: Sequelize.STRING
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
     },
     price: {
       type: Sequelize.TEXT

--- a/utils/models.js
+++ b/utils/models.js
@@ -510,6 +510,9 @@ module.exports = (Sequelize, database) => {
     level: {
       type: Sequelize.STRING
     },
+    exclusive: {
+      type: Sequelize.STRING
+    },
     price: {
       type: Sequelize.TEXT
     },


### PR DESCRIPTION
#### Changes introduced by this PR
* Level-up roles can now be exclusive (#474)
* Level-up roles are now synced (#326)

#### Possible drawbacks
Currently there's no way to set the exclusive flag of roles. But it supports it, and will be added in a future PR.

#### Applicable Issues
Closes #326 
Closes #474 

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
