### PR TITLE
Remove requirements for Battle.Net API key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.106",
+  "version": "7.0.0-alpha.107",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://bastionbot.org",
   "dependencies": {
     "@k3rn31p4nic/google-translate-api": "~1.0.5",
-    "bwapi": "github:TheBastionBot/bwapi#3.0.0",
+    "bwapi": "github:TheBastionBot/bwapi#3.0.1",
     "chalk": "~2.4.1",
     "cheerio": "~1.0.0-rc.2",
     "color-convert": "~1.9.3",

--- a/settings/credentials.example.yaml
+++ b/settings/credentials.example.yaml
@@ -29,7 +29,5 @@ patreon:
   creatorAccessToken:
   creatorRefreshToken:
 
-BattleNetApiKey:
-
 discordBotsAPIToken:
 discordBotListAPIToken:


### PR DESCRIPTION
#### Changes introduced by this PR
This PR removes the requirement to get Battle.Net API key and uses Bastion Web API instead.

#### Possible drawbacks
None

#### Applicable Issues
Closes #397 

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
