### PR TITLE
Some improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ data/backup*
 
 # Lock file
 package-lock.json
+yarn.lock
 
 ### Logs ###
 screenlog.*

--- a/commands/profile/level.js
+++ b/commands/profile/level.js
@@ -22,7 +22,7 @@ exports.exec = async (Bastion, message, args) => {
   }
 
   let description = message.author.id === args.id ? `**${args.tag}** you are currently in level **${level}**.` : `**${args.tag}** is currently in level **${level}**.`;
-  let footer = message.author.id === args.id ? `Wanna go to the next level? Just gain ${Bastion.methods.getRequiredExpForLevel(parseInt(level, 10) + 1) - xp + 1} more XP.` : null;
+  let footer = message.author.id === args.id && guildMemberModel.dataValues.experiencePoints !== '44444444444444' ? `Wanna go to the next level? Just gain ${Bastion.methods.getRequiredExpForLevel(parseInt(level, 10) + 1) - xp + 1} more XP.` : null;
 
   await message.channel.send({
     embed: {

--- a/commands/profile/level.js
+++ b/commands/profile/level.js
@@ -22,7 +22,7 @@ exports.exec = async (Bastion, message, args) => {
   }
 
   let description = message.author.id === args.id ? `**${args.tag}** you are currently in level **${level}**.` : `**${args.tag}** is currently in level **${level}**.`;
-  let footer = message.author.id === args.id ? `Wanna go to the next level? Just gain ${Bastion.methods.getRequiredExpForLevel(parseInt(level, 10) + 1) - xp} more XP.` : null;
+  let footer = message.author.id === args.id ? `Wanna go to the next level? Just gain ${Bastion.methods.getRequiredExpForLevel(parseInt(level, 10) + 1) - xp + 1} more XP.` : null;
 
   await message.channel.send({
     embed: {

--- a/commands/profile/profile.js
+++ b/commands/profile/profile.js
@@ -51,7 +51,7 @@ exports.exec = async (Bastion, message, args) => {
   }
 
   let rank = parseInt(guildMemberModel.dataValues.rank) + 1;
-  let totalExp = Bastion.methods.getRequiredExpForLevel(parseInt(guildMemberModel.dataValues.level, 10) + 1) - 1;
+  let totalExp = Bastion.methods.getRequiredExpForLevel(parseInt(guildMemberModel.dataValues.level, 10) + 1);
   let progress = guildMemberModel.dataValues.experiencePoints / totalExp * 100;
 
   let profileData = [

--- a/commands/profile/xp.js
+++ b/commands/profile/xp.js
@@ -21,7 +21,7 @@ exports.exec = async (Bastion, message, args) => {
     xp = guildMemberModel.dataValues.experiencePoints;
   }
 
-  let description = message.author.id === args.id ? `**${args.tag}** you have collected **${xp}** experience points out of ${Bastion.methods.getRequiredExpForLevel(parseInt(level, 10) + 1) - 1} that you can acquire in this level.` : `**${args.tag}** has collected **${xp}** experience points.`;
+  let description = message.author.id === args.id ? `**${args.tag}** you have collected **${xp}** experience points out of ${Bastion.methods.getRequiredExpForLevel(parseInt(level, 10) + 1)} that you can acquire in this level.` : `**${args.tag}** has collected **${xp}** experience points.`;
 
   message.channel.send({
     embed: {

--- a/commands/server_management/give.js
+++ b/commands/server_management/give.js
@@ -131,7 +131,7 @@ exports.config = {
 
 exports.help = {
   name: 'give',
-  description: 'Give the specified amount of %currency.name_plural% from your account to the specified user. If you are the bot owner, you can give any amount of %currency.name_plural%.',
+  description: 'Give the specified amount of %currency.name_plural% from your account to the specified user. If you are the server owner, you can give any amount of %currency.name_plural%.',
   botPermission: '',
   userTextPermission: '',
   userVoicePermission: '',

--- a/data/commands.json
+++ b/data/commands.json
@@ -424,7 +424,7 @@
     "module": "Searches"
   },
   "give": {
-    "description": "Give the specified amount of %currency.name_plural% from your account to the specified user. If you are the bot owner, you can give any amount of %currency.name_plural%.",
+    "description": "Give the specified amount of %currency.name_plural% from your account to the specified user. If you are the server owner, you can give any amount of %currency.name_plural%.",
     "module": "Server Management"
   },
   "giveXP": {

--- a/handlers/levelHandler.js
+++ b/handlers/levelHandler.js
@@ -68,11 +68,11 @@ module.exports = async message => {
     guildMemberModel.dataValues.level = parseInt(guildMemberModel.dataValues.level);
     guildMemberModel.dataValues.bastionCurrencies = parseInt(guildMemberModel.dataValues.bastionCurrencies);
 
-    let currentLevel = Math.floor(0.15 * Math.sqrt(parseInt(guildMemberModel.dataValues.experiencePoints) + 1));
+    let currentLevel = Math.floor(0.15 * Math.sqrt(guildMemberModel.dataValues.experiencePoints + 1));
 
 
     // Level Up
-    if (guildModel.dataValues.levelUps) {
+    if (guildModel.dataValues.levelUps && guildMemberModel.dataValues.experiencePoints < 44444444444444) {
       if (currentLevel > guildMemberModel.dataValues.level) {
         await message.client.database.models.guildMember.update({
           bastionCurrencies: guildMemberModel.dataValues.bastionCurrencies + currentLevel * 5,

--- a/locales/en_us/command.json
+++ b/locales/en_us/command.json
@@ -318,7 +318,7 @@
     "description": "Searches animated GIFs on the web and sends a random GIF based on the given query."
   },
   "give": {
-    "description": "Give the specified amount of %currency.name_plural% from your account to the specified user. If you are the bot owner, you can give any amount of %currency.name_plural%."
+    "description": "Give the specified amount of %currency.name_plural% from your account to the specified user. If you are the server owner, you can give any amount of %currency.name_plural%."
   },
   "giveXP": {
     "description": "Give the specified amount of experience points to the specified user and increase their level."

--- a/monitors/modules/sneakyLinks.js
+++ b/monitors/modules/sneakyLinks.js
@@ -12,6 +12,16 @@
 module.exports = async message => {
   if (!message.content.length) return;
 
+  let guildModel = await message.client.database.models.guild.findOne({
+    attributes: [ 'guildID' ],
+    where: {
+      guildID: message.guild.id,
+      uncoverSneakyLinks: true
+    }
+  });
+
+  if (!guildModel) return;
+
   let sneakyLinks = await message.client.methods.makeBWAPIRequest('/text/redirects', {
     qs: {
       text: message.content

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-alpha.107",
+  "version": "7.0.0-alpha.108",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",


### PR DESCRIPTION
#### Changes introduced by this PR
* Fix sneaky links always turned on despite being disabled.
* Fix XP requirement counts in `level`, `xp` & `profile` command.
* Fix `profile` command not working when you're one step closer to being leveled up.
* Max. out level at **999999**. Yup, that's the magic number!
* Add a limit of 3 transactions in 24 hours with the `give` command.
  Mostly to prevent farming from multiple accounts and giving it to their main account.

#### Possible drawbacks
None

#### Applicable Issues
\-

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
