### PR TITLE
Future support for show permission errors

### DIFF
--- a/utils/models.js
+++ b/utils/models.js
@@ -219,6 +219,11 @@ module.exports = (Sequelize, database) => {
       allowNull: false,
       defaultValue: false
     },
+    showPermsError: {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
+    },
     celebrateBirthday: {
       type: Sequelize.BOOLEAN,
       allowNull: false,


### PR DESCRIPTION
#### Changes introduced by this PR
Allow Bastion to show permission errors to a user when they don't have permission to use a command.

#### Possible drawbacks
None

#### Applicable Issues
Closes https://github.com/TheBastionBot/Bastion/issues/295

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
