### PR TITLE
Support arguments for scheduled commands

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,9 +1,10 @@
 {
-  "date": "December 31, 2018",
+  "date": "January 2, 2019",
   "image": "https://i.imgur.com/zlOMqVD.gif",
   "THESE BUGS ARE DEAD": [
     "Automatically remove accidental extra spaces around command arguments.",
-    "Users not getting all level up roles when they already had one of those roles."
+    "Users not getting all level up roles when they already had one of those roles.",
+    "Schedule command now works with any type of arguments for the scheduled command."
   ],
   "THESE ABILITIES HAVE ENHANCED": [
     "Logs are now much prettier, than it was already!",

--- a/commands/bot_owner/scheduleCommand.js
+++ b/commands/bot_owner/scheduleCommand.js
@@ -75,5 +75,5 @@ exports.help = {
   userTextPermission: '',
   userVoicePermission: '',
   usage: 'scheduleCommand <CRON PATTERN> <-c COMMAND> [-a ARGUMENTS]',
-  example: [ 'scheduleCommand 0 0 0 1 1 * -c echo -a Happy New Year!' ]
+  example: [ 'scheduleCommand 0 0 * * * * -c clear -a \\--nonpinned', 'scheduleCommand 0 0 0 1 1 * -c echo -a Happy New Year!' ]
 };

--- a/commands/bot_owner/scheduleCommand.js
+++ b/commands/bot_owner/scheduleCommand.js
@@ -31,7 +31,7 @@ exports.exec = async (Bastion, message, args) => {
   }
 
   args.cronExp = args.cronExp.join(' ');
-  args.arguments = args.arguments.join(' ');
+  args.arguments = args.arguments.join(' ').replace(/\\/g, '');
 
   let scheduledStatus = await message.channel.send({
     embed: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0-beta.3",
+  "version": "7.0.0-beta.4",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",


### PR DESCRIPTION
#### Changes introduced by this PR
Turns out, scheduled commands didn't work with command options as their argument. This adds the capability to do so.

#### Possible drawbacks
None

#### Applicable Issues
Closes #408 

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
