### PR TITLE
Fix typo in showSpoiler command

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,32 +1,7 @@
 {
-  "date": "January 2, 2019",
+  "date": "January 5, 2019",
   "image": "https://i.imgur.com/zlOMqVD.gif",
-  "Bastion. Version. Seven.": [
-    "Oh my goodness!",
-    "It's finally here!",
-    "Bastion v7!",
-    "The biggest release of Bastion, ever!"
-  ],
-  "OK. COOL. BUT WHERE IS THE FREAKING CHANGELOG?!": [
-    "I remember writing it... :thinking:",
-    "But...",
-    "forgot to post it here in the excitement of this release.",
-    "Sorry :sweat_smile:"
-  ],
-  "Are you kidding me?": [
-    "Well, yeah.",
-    "Don't worry. I didn't forgot.",
-    "And neither is the changelog empty!",
-    "On the contrary, it is very huge!",
-    "So huge that it was impossible to fit within Discord's 2000 character message limit!",
-    "Now, you must be understanding how big this release is. Did I mention this earlier, though? :thinking:"
-  ],
-  "So... Where is it then?": [
-    "I won't keep you waiting any longer.",
-    "It was so huge that I had to create [a blog for Bastion](https://medium.com/thebastionbot) and post it in a [blog post](https://medium.com/thebastionbot/bastion-v7-5cab8eb93680)!",
-    "[Here's a link to V7 release notes!](https://medium.com/thebastionbot/bastion-v7-5cab8eb93680)"
-  ],
-  "Enjoy Bastion V7": [
-    "And wish you all a new year full of crazy $#!T and sick A$$ adventures!"
+  "KILLED THOSE BUGS": [
+    "Fixed `showSpoiler` command not decoding the spoilers for you!"
   ]
 }

--- a/commands/productivity/showSpoiler.js
+++ b/commands/productivity/showSpoiler.js
@@ -5,7 +5,7 @@
  */
 
 exports.exec = async (Bastion, message, args) => {
-  if (!args.lengt) {
+  if (!args.length) {
     return Bastion.emit('commandUsage', message, this.help);
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bastion",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Give awesome perks to your Discord server!",
   "url": "https://bastionbot.org/",
   "main": "index.js",


### PR DESCRIPTION
#### Changes introduced by this PR
This PR fixes the `showSpoiler` command. A typo in the command prevented it from working.

#### Possible drawbacks
None

#### Applicable Issues
Fixes https://github.com/TheBastionBot/Bastion/issues/498

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
