### PR TITLE
Daily hits support for autoplay

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,6 +1,9 @@
 {
-  "date": "January 5, 2019",
+  "date": "January 8, 2019",
   "image": "https://i.imgur.com/zlOMqVD.gif",
+  "IMPROVEMENTS": [
+    "Bastion's autoplay will now play daily hits instead of weekly hits. Daily music listeners won't get bored of the same songs anymore."
+  ],
   "KILLED THOSE BUGS": [
     "Fixed `showSpoiler` command not decoding the spoilers for you!"
   ]

--- a/commands/music/play.js
+++ b/commands/music/play.js
@@ -251,7 +251,7 @@ exports.help = {
  */
 async function startStreamDispatcher(guild, connection) {
   if (!guild.music.songs[0] && guild.music.autoPlay && connection.channel.members.size > 1) {
-    let songs = await guild.client.methods.makeBWAPIRequest('/google/youtube/topsongs');
+    let songs = await guild.client.methods.makeBWAPIRequest('/google/youtube/topsongs/today');
     let videoID = songs.getRandom();
 
     let youtubeDLOptions = [


### PR DESCRIPTION
#### Changes introduced by this PR
Auto play will now play daily hits instead of weekly hits.

#### Possible drawbacks
None

#### Applicable Issues
Closes https://github.com/TheBastionBot/Bastion/issues/500

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
