### PR TITLE
Set giveaway upper time limit to 24

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,5 +1,5 @@
 {
-  "date": "February 1, 2019",
+  "date": "February 2, 2019",
   "image": "https://i.imgur.com/YPingwC.gif",
   "NEW STUFF": [
     "`messageChannel` can now be used by server managers to send any message to any channel in their server.",
@@ -8,6 +8,7 @@
   ],
   "OLD STUFF, BUT BUFFED!": [
     "The `lyrics` command will now automatically search the lyrics for the currently playing song if no song name is provided to it.",
+    "12 hours giveaways weren't enough for you? You can now run `giveaway` for a maximum of 24 hours!",
     "Made some under-the-hood improvements too!"
   ],
   "KILLED BUGS FROM OLD STUFF": [

--- a/commands/server_management/giveaway.js
+++ b/commands/server_management/giveaway.js
@@ -13,9 +13,9 @@ exports.exec = async (Bastion, message, args) => {
     // Giveaway item name
     args.item = args.item.join(' ');
 
-    // Verify whether timeout is within 12 hours
-    if (!args.timeout.inRange(1, 12)) {
-      return Bastion.emit('error', '', 'Giveaway can only run for at least an hour and at most 12 hours.', message.channel);
+    // Verify whether timeout is within 24 hours
+    if (!args.timeout.inRange(1, 24)) {
+      return Bastion.emit('error', '', 'Giveaway can only run for at least an hour and at most 24 hours.', message.channel);
     }
 
     // Generate a random reaction for the giveaway message
@@ -230,7 +230,7 @@ exports.config = {
 
 exports.help = {
   name: 'giveaway',
-  description: 'Starts a giveaway event, with the item of your choice, for the given amount of time, a winner is chosen at random after the event is concluded. Event can run for at least 1 hour and at most 12 hours.',
+  description: 'Starts a giveaway event, with the item of your choice, for the given amount of time, a winner is chosen at random after the event is concluded. Event can run for at least 1 hour and at most 24 hours.',
   botPermission: '',
   userTextPermission: 'MANAGE_GUILD',
   userVoicePermission: '',


### PR DESCRIPTION
#### Changes introduced by this PR
Giveaway can now run up to a maximum of 24 hours.

#### Applicable Issues
\-

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
