### PR TITLE
Patch disableCommand command

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -2,6 +2,7 @@
   "date": "February 2, 2019",
   "image": "https://i.imgur.com/YPingwC.gif",
   "KILLED THESE BUGS": [
-    "The `sendSpoiler` command had a major security issue, that came with the last release! Thanks to one of our mods who reported it as soon as the release went out and it was disabled to prevent any damage. That's been fixed now! Thank goodness!"
+    "The `sendSpoiler` command had a major security issue, that came with the last release! Thanks to one of our mods who reported it as soon as the release went out and it was disabled to prevent any damage. That's been fixed now! Thank goodness!",
+    "There was a bug that prevented you from disabling non bot owner commands. Killed that nasty bug!"
   ]
 }

--- a/commands/server_configuration/disableCommand.js
+++ b/commands/server_configuration/disableCommand.js
@@ -21,7 +21,7 @@ exports.exec = async (Bastion, message, args) => {
       return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'notFound', 'command'), message.channel);
     }
 
-    if ([ 'enablecommand', 'disablecommand' ].includes(command.help.name.toLowerCase()) || !command.config.ownerOnly) {
+    if ([ 'enablecommand', 'disablecommand' ].includes(command.help.name.toLowerCase()) || command.config.ownerOnly) {
       return Bastion.emit('error', '', Bastion.i18n.error(message.guild.language, 'commandNoDisable', command.help.name), message.channel);
     }
 


### PR DESCRIPTION
#### Changes introduced by this PR
`disableCommand` only allowed bot owner commands to be disabled. Fixed that.

#### Applicable Issues
\-

#### Checklist
- [X] Test scripts passes
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
