### PR TITLE
Role/Channel blacklists patch

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,6 +1,9 @@
 {
-  "date": "February 4, 2019",
+  "date": "February 5, 2019",
   "image": "https://i.imgur.com/aDt4u3b.gif",
+  "IMPROVEMENTS": [
+    "Users with *Manage Server* perms won't be ignored in ignored channels or even if they have roles that are being ignored by Bastion."
+  ],
   "KILLED THESE BUGS": [
     "Killed a bug that posted the announcement messages, announced through announcement reactions, in the current channel instead of the announcement channel.",
     "Killed another bug that prevented the `addWhitelistDomains` from working.",

--- a/handlers/commandHandler.js
+++ b/handlers/commandHandler.js
@@ -173,7 +173,11 @@ module.exports = async message => {
     let blacklistedChannels = guildModel.textChannels.length && guildModel.textChannels.filter(model => model.dataValues.blacklisted).map(model => model.dataValues.channelID);
     let blacklistedRoles = guildModel.roles.length && guildModel.roles.filter(model => model.dataValues.blacklisted).map(model => model.dataValues.roleID);
 
-    if ((blacklistedChannels && blacklistedChannels.includes(message.channel.id)) || (blacklistedRoles && message.member.roles.some(role => blacklistedRoles.includes(role.id)))) return message.client.log.info('The command is either used in a blacklisted channel or the user is in a blacklisted role.');
+    if (!message.member.hasPermission('MANAGE_GUILD')) {
+      if ((blacklistedChannels && blacklistedChannels.includes(message.channel.id)) || (blacklistedRoles && message.member.roles.some(role => blacklistedRoles.includes(role.id)))) {
+        return message.client.log.info('The command is either used in a blacklisted channel or the user is in a blacklisted role.');
+      }
+    }
 
     /**
      * Check if a command is disabled


### PR DESCRIPTION
<!-- A clear and concise description of the changes introduced by this pull request. -->
Channel/Role blacklists will only apply for users without `MANAGE_GUILD` perms. Users with `MANAGE_GUILD` perms won't be ignored in ignored channels or even if they have roles that are being ignored by Bastion.

#### References
<!-- Link any applicable issues/pull requests here, with a brief description explaining why. -->
\-

#### Checklist
<!-- For completed items, change [ ] to [x]. -->
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
