### PR TITLE
word filter edit

### DIFF
--- a/filters/wordFilter.js
+++ b/filters/wordFilter.js
@@ -59,7 +59,7 @@ module.exports = message => {
       let filteredWords = guildModel.dataValues.filteredWords ? guildModel.dataValues.filteredWords : [];
 
       for (let word of filteredWords) {
-        if (message.content.toLowerCase().split(' ').includes(word.toLowerCase())) {
+        if (message.content.toLowerCase().replace(/[^0-9a-z]/gi, '').includes(word.toLowerCase())) {
           // If the code reaches here, the message contains words that needs to be filtered
           resolve(true);
 

--- a/filters/wordFilter.js
+++ b/filters/wordFilter.js
@@ -59,7 +59,7 @@ module.exports = message => {
       let filteredWords = guildModel.dataValues.filteredWords ? guildModel.dataValues.filteredWords : [];
 
       for (let word of filteredWords) {
-        if (message.content.toLowerCase().replace(/[^0-9a-z]/gi, '').includes(word.toLowerCase())) {
+                if (message.content.toLowerCase().replace(/[^0-9a-z ]/gi, ' ').split(' ').includes(word.toLowerCase())) {
           // If the code reaches here, the message contains words that needs to be filtered
           resolve(true);
 
@@ -106,7 +106,55 @@ module.exports = message => {
           });
 
           return resolve(true);
-        }
+		}
+		else if (message.content.toLowerCase().replace(/[^0-9a-z ]/gi, '').split(' ').includes(word.toLowerCase())) {
+          // If the code reaches here, the message contains words that needs to be filtered
+          resolve(true);
+
+          if (message.deletable) message.delete().catch(() => {});
+
+          message.channel.send({
+            embed: {
+              color: message.client.colors.ORANGE,
+              description: `EXCUSE ME! ${message.author} you are not supposed to use that word in here!`
+            }
+          }).then(msg => {
+            msg.delete(10000).catch(() => {});
+          }).catch(() => {});
+
+
+          // Log the words that are filtered
+          if (!guildModel.dataValues.moderationLog) return;
+
+          let modLogChannel = message.guild.channels.get(guildModel.dataValues.moderationLog);
+          if (!modLogChannel) return;
+
+          await modLogChannel.send({
+            embed: {
+              color: message.client.colors.ORANGE,
+              title: 'Filtered Words',
+              fields: [
+                {
+                  name: 'User',
+                  value: message.author.tag,
+                  inline: true
+                },
+                {
+                  name: 'User ID',
+                  value: message.author.id,
+                  inline: true
+                },
+                {
+                  name: 'Blocked Word',
+                  value: word
+                }
+              ],
+              timestamp: new Date()
+            }
+          });
+
+          return resolve(true);
+      }
       }
     }
     catch (e) {

--- a/filters/wordFilter.js
+++ b/filters/wordFilter.js
@@ -59,7 +59,7 @@ module.exports = message => {
       let filteredWords = guildModel.dataValues.filteredWords ? guildModel.dataValues.filteredWords : [];
 
       for (let word of filteredWords) {
-                if (message.content.toLowerCase().replace(/[^0-9a-z ]/gi, ' ').split(' ').includes(word.toLowerCase())) {
+        if (message.content.toLowerCase().replace(/[^0-9a-z ]/gi, ' ').split(' ').includes(word.toLowerCase())) {
           // If the code reaches here, the message contains words that needs to be filtered
           resolve(true);
 


### PR DESCRIPTION
<!-- A clear and concise description of the changes introduced by this pull request. -->
edited word filter to help block words better(?) will remove spaced w o r d s as well as words inside embeds as long as letters are in the required order, they may also be on a different
l
i
n
e
and will get filtered.
filtering applied on whole sentence rather than splitting at each space, removing all non alphanumerical characters and hyphens and underscores.
#### References
<!-- Link any applicable issues/pull requests here, with a brief description explaining why. -->
epileptixdub brought this issue up
#### Checklist
<!-- For completed items, change [ ] to [x]. -->
- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
