### PR TITLE
Quick shutdown

### DIFF
--- a/changes.json
+++ b/changes.json
@@ -1,10 +1,11 @@
 {
-  "date": "September 5, 2019",
+  "date": "October 3, 2019",
   "image": "https://i.imgur.com/k6azzsE.gif",
   "IMPROVEMENTS": [
     "Some under-the-hood improvements, to make Bastion even better."
   ],
   "CHANGES": [
-    "`quake3` command has been rightly moved to the Game Server Stats category."
+    "`quake3` command has been rightly moved to the Game Server Stats category.",
+    "You can now instantly shutdown Bastion, without answering the confirmation prompt, using the `now` parameter with the `shutdown` command."
   ]
 }

--- a/commands/bot_owner/shutdown.js
+++ b/commands/bot_owner/shutdown.js
@@ -4,51 +4,74 @@
  * @license GPL-3.0
  */
 
-exports.exec = async (Bastion, message) => {
-  let confirmation = await message.channel.send({
-    embed: {
-      color: Bastion.colors.ORANGE,
-      description: 'Are you sure you want to shut me down?'
-    }
-  });
-
-  const collector = confirmation.channel.createMessageCollector(m => Bastion.credentials.ownerId.includes(m.author.id) && (m.content.toLowerCase().startsWith('yes') || m.content.toLowerCase().startsWith('no')),
-    {
-      time: 30 * 1000,
-      maxMatches: 1
-    }
-  );
-
-  collector.on('collect', async answer => {
-    if (answer.content.toLowerCase().startsWith('yes')) {
-      await message.channel.send({
-        embed: {
-          description: 'GoodBye :wave:! See you soon.'
-        }
-      });
-
-      if (Bastion.shard) {
-        await Bastion.shard.broadcastEval('this.destroy().then(() => process.exitCode = 0)');
+exports.exec = async (Bastion, message, args) => {
+  if (args && args.join(' ').toLowerCase() === 'now') {
+    await message.channel.send({
+      embed: {
+        description: 'GoodBye :wave:! See you soon.'
       }
-      else {
-        await Bastion.destroy();
-        process.exitCode = 0;
-        setTimeout(() => {
-          process.exit(0);
-        }, 5000);
-      }
+    });
 
-      Bastion.log.console('\n');
-      Bastion.log.info('GoodBye! See you next time.');
+    if (Bastion.shard) {
+      await Bastion.shard.broadcastEval('this.destroy().then(() => process.exitCode = 0)');
     }
     else {
-      await message.channel.send({
-        embed: {
-          description: 'Cool! I\'m here.'
-        }
-      });
+      await Bastion.destroy();
+      process.exitCode = 0;
+      setTimeout(() => {
+        process.exit(0);
+      }, 5000);
     }
-  });
+
+    Bastion.log.console('\n');
+    Bastion.log.info('GoodBye! See you next time.');
+  }
+  else {
+    let confirmation = await message.channel.send({
+      embed: {
+        color: Bastion.colors.ORANGE,
+        description: 'Are you sure you want to shut me down?'
+      }
+    });
+
+    const collector = confirmation.channel.createMessageCollector(m => Bastion.credentials.ownerId.includes(m.author.id) && (m.content.toLowerCase().startsWith('yes') || m.content.toLowerCase().startsWith('no')),
+      {
+        time: 30 * 1000,
+        maxMatches: 1
+      }
+    );
+
+    collector.on('collect', async answer => {
+      if (answer.content.toLowerCase().startsWith('yes')) {
+        await message.channel.send({
+          embed: {
+            description: 'GoodBye :wave:! See you soon.'
+          }
+        });
+
+        if (Bastion.shard) {
+          await Bastion.shard.broadcastEval('this.destroy().then(() => process.exitCode = 0)');
+        }
+        else {
+          await Bastion.destroy();
+          process.exitCode = 0;
+          setTimeout(() => {
+            process.exit(0);
+          }, 5000);
+        }
+
+        Bastion.log.console('\n');
+        Bastion.log.info('GoodBye! See you next time.');
+      }
+      else {
+        await message.channel.send({
+          embed: {
+            description: 'Cool! I\'m here.'
+          }
+        });
+      }
+    });
+  }
 };
 
 exports.config = {
@@ -63,6 +86,6 @@ exports.help = {
   botPermission: '',
   userTextPermission: '',
   userVoicePermission: '',
-  usage: 'shutdown',
-  example: []
+  usage: 'shutdown [now]',
+  example: [ 'shutdown', 'shutdown now' ]
 };


### PR DESCRIPTION
<!-- A clear and concise description of the changes introduced by this pull request. -->
You can now quickly shutdown Bastion, without confirmation, using the `now` parameter with the `shutdown` command.
Example: `#!shutdown now`

#### References
<!-- Link any applicable issues/pull requests here, with a brief description explaining why. -->
![Linux habits](https://media.discordapp.net/attachments/463447904749617156/622043476409843733/Screenshot_20190913-081811.png)

#### Checklist
<!-- For completed items, change [ ] to [x]. -->
- [X] Documentation is changed or added (if applicable)
- [X] Commit message follows the [commit guidelines](https://dev.bastionbot.org/contributing/pulls/#commit-message-guidelines)
