### PR TITLE
support relaying DMs via webhooks

### DIFF
--- a/settings.example.yaml
+++ b/settings.example.yaml
@@ -46,7 +46,7 @@ musicActivity: true
 # Relay Direct Messages
 # When enabled, Bastion will relay any direct messages it receives to the
 # owner of the bot application / team.
-# If a Discord Webhook URL is specified, it'll relay the direct messages
+# If a Discord webhook URL is specified, it'll relay the direct messages
 # via the webhook.
 # `BASTION_RELAY_DMS` environment variable overwrites this value.
 relayDirectMessages: false

--- a/settings.example.yaml
+++ b/settings.example.yaml
@@ -46,6 +46,8 @@ musicActivity: true
 # Relay Direct Messages
 # When enabled, Bastion will relay any direct messages it receives to the
 # owner of the bot application / team.
+# If a Discord Webhook URL is specified, it'll relay the direct messages
+# via the webhook.
 # `BASTION_RELAY_DMS` environment variable overwrites this value.
 relayDirectMessages: false
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ import { tesseract } from "@bastion/tesseract/typings/types";
 export namespace bastion {
     export interface Settings extends tesseract.Settings {
         musicActivity?: boolean;
-        relayDirectMessages?: boolean;
+        relayDirectMessages?: boolean | string;
         port?: number;
         auth?: string;
         coinMarketCapApiKey?: string;

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -4,6 +4,7 @@
  */
 export const SERVER_INVITE = /(https:\/\/)?(www\.)?(discord\.gg|discordapp\.com\/invite|discord\.com\/invite)\/([a-z0-9-.]+)?/i;
 export const URI = /((([A-Za-z]{3,9}:(?:\/\/))(?:[-;:&=+$,\w]+@)?[A-Za-z0-9.-]+|(?:www\.|[-;:&=+$,\w]+@)[A-Za-z0-9.-]+)((?:\/[+~%/.\w\-_]*)?\??(?:[-+=&;%@.\w_]*)#?(?:[.!/\\\w]*))?)/i;
+export const WEBHOOK_URL = /(?:https:\/\/)(?:www\.)?(?:discordapp|discord)\.com\/api\/webhooks\/([0-9]+)\/([a-z0-9_-]+)/i;
 
 export const REGEX_CMYK = /^(\d{1,2}|100) (\d{1,2}|100) (\d{1,2}|100) (\d{1,2}|100)$/;
 export const REGEX_RGB = /^(\d{1,2}|1\d{2}|2[0-5]{2}) (\d{1,2}|1\d{2}|2[0-5]{2}) (\d{1,2}|1\d{2}|2[0-5]{2})$/;


### PR DESCRIPTION
The `relayDirectMessages` field in the `settings.yaml` file can now accept a Discord webhook URL. And if a webhook URL is specified, Bastion will relay DMs to via the webhook instead of relaying DMs to the app owner.

#### Checklist
<!-- For completed items, change [ ] to [x]. -->
- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/contributing/pulls#commit-message-guidelines)
