### PR TITLE
Message delete / update: display original message / diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "devDependencies": {
         "@types/discord-rpc": "^4.0.3",
         "@types/express": "^4.17.14",
+        "@types/git-diff": "^2.0.3",
         "@types/http-errors": "^2.0.1",
         "@types/jsdom": "^20.0.1",
         "@types/node": "^18.11.9",
@@ -35,6 +36,7 @@
         "dotenv": "^16.0.3",
         "emoji-regex": "^10.2.1",
         "gamedig": "^4.0.5",
+        "git-diff": "^2.0.6",
         "jsdom": "^20.0.3",
         "libsodium-wrappers": "^0.7.10",
         "mathjs": "^11.4.0",

--- a/src/listeners/messageDelete.ts
+++ b/src/listeners/messageDelete.ts
@@ -44,7 +44,12 @@ class MessageDeleteListener extends Listener<"messageDelete"> {
                     value: time(message.createdAt),
                     inline: true,
                 },
-            ],
+                message.content && {
+                    name: "Content",
+                    value: message.content,
+                    inline: false,
+                }
+            ].filter(x => x),
             timestamp: new Date().toISOString(),
         });
     }

--- a/src/listeners/messageUpdate.ts
+++ b/src/listeners/messageUpdate.ts
@@ -6,6 +6,7 @@ import { Message, MessageType, PartialMessage, time } from "discord.js";
 import { Listener } from "@bastion/tesseract";
 
 import { logGuildEvent } from "../utils/guilds";
+import gitDiff from "git-diff";
 
 class MessageUpdateListener extends Listener<"messageUpdate"> {
     constructor() {
@@ -51,7 +52,17 @@ class MessageUpdateListener extends Listener<"messageUpdate"> {
                     value: time(newMessage.createdAt),
                     inline: true,
                 },
-            ],
+                oldMessage.content && newMessage.content && {
+                    name: "Diff",
+                    value: gitDiff(oldMessage.content, newMessage.content, {
+                        noHeaders: true,
+                        wordDiff: true
+                    })
+                        .split("\n")
+                        .join("\n"),
+                    inline: false,
+                },
+            ].filter(x => x),
             timestamp: new Date().toISOString(),
         });
     }


### PR DESCRIPTION
# Changes

## On message delete

- display original message (text content only)

## On message update

- display a git (word) diff between old and new message (also text content only)

# Sample

![Screenshot_20221231_180249](https://user-images.githubusercontent.com/91375035/210132678-b4b1bafe-c16c-4bc3-9480-49f6cebd3072.png)

