### PR TITLE
Revert "suggestions: set up voting"

### DIFF
--- a/src/commands/suggest.ts
+++ b/src/commands/suggest.ts
@@ -3,7 +3,7 @@
  * @copyright 2022
  */
 import { ApplicationCommandOptionType, ButtonStyle, ChatInputCommandInteraction, ComponentType, GuildTextBasedChannel } from "discord.js";
-import { Client, Command, Logger } from "@bastion/tesseract";
+import { Client, Command } from "@bastion/tesseract";
 
 import GuildModel from "../models/Guild";
 import MessageComponents from "../utils/components";
@@ -33,7 +33,7 @@ class SuggestCommand extends Command {
 
         // send the suggestion
         if (guildDocument?.suggestionsChannel && interaction.guild.channels.cache.has(guildDocument.suggestionsChannel)) {
-            const message = await (interaction.guild.channels.cache.get(guildDocument.suggestionsChannel) as GuildTextBasedChannel).send({
+            await (interaction.guild.channels.cache.get(guildDocument.suggestionsChannel) as GuildTextBasedChannel).send({
                 embeds: [
                     {
                         color: COLORS.INDIGO,
@@ -64,10 +64,6 @@ class SuggestCommand extends Command {
                     },
                 ],
             });
-
-            // set the message up for voting
-            message.react("👍").catch(Logger.ignore);
-            message.react("👎").catch(Logger.ignore);
 
             return await interaction.editReply((interaction.client as Client).locales.getText(interaction.guildLocale, "suggestionReceived"));
         }


### PR DESCRIPTION
Reverts TheBastionBot/Bastion#985

The suggestion channel can be set as a voting channel and Bastion will automatically add 👍🏻 & 👎🏻 emotes to all the suggestions and it will achieve the same thing. 
