### PR TITLE
Fix: level up removed other roles

### DIFF
--- a/src/listeners/messageCreate.ts
+++ b/src/listeners/messageCreate.ts
@@ -47,7 +47,7 @@ class MessageCreateListener extends Listener<"messageCreate"> {
         // update member roles
         if (levelRoles.length) {
             const memberRoles = message.member.roles.cache
-            .filter(r => extraRoles.some(doc => doc.id === r.id))   // remove roles from any other level
+            .filter(r => !extraRoles.some(doc => doc.id === r.id))   // remove roles from any other level
             .map(r => r.id)
             .concat(levelRoles.map(doc => doc.id)); // add roles in the current level
 


### PR DESCRIPTION
Level up has been removing other roles. With some investigation it was found out to be because of a wrongly-used filter function.

See https://github.com/sdip15fa/Bastion/commit/d76bc87134ff5168de82639687e1c40d8fdc9699.