### PR TITLE
Fix: Docker build failing on newer `node:lts-alpine3.21` version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine as build
+FROM node:lts-alpine3.20 as build
 
 WORKDIR /app
 
@@ -11,7 +11,7 @@ RUN npm install
 RUN npm run build
 
 
-FROM node:lts-alpine
+FROM node:lts-alpine3.20
 
 WORKDIR /app
 


### PR DESCRIPTION
Update the Dockerfile to specifically use the `node:lts-alpine3.20` image.

I was having issues building locally, and found that building with the most recent node image release (`lts-alpine3.21`) does not succeed: [docker-build.log](https://github.com/user-attachments/files/18375360/docker-build.log)

Building was working on one of my machines but not the other, and I realised that the successful build came from the old `3.20` image that I already had on the working machine.

I don't know whether it would be preferable to use the newer `3.21` version and fix the dependencies, but pinning to `3.20` has fixed the build on my end. It may be a good idea anyway to pin a specific version, to prevent this from happening again.

#### Checklist
- [x] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)
