### PR TITLE
commands(give): let users with `ManageGuild` permission self-run `/give`

### DIFF
--- a/src/commands/give.ts
+++ b/src/commands/give.ts
@@ -43,9 +43,9 @@ class GiveCommand extends Command {
         const xp = interaction.options.getInteger("xp");
 
         // check whether user is giving it to themselves
-        const isGuildOwner = () => interaction.user.id === interaction.guild.ownerId
-        const isGuildManager = () => interaction.memberPermissions.has(PermissionFlagsBits.ManageGuild)
-        const isGivingToSelf = () => interaction.user.id === user.id
+        const isGuildOwner = () => interaction.user.id === interaction.guild.ownerId;
+        const isGuildManager = () => interaction.memberPermissions.has(PermissionFlagsBits.ManageGuild);
+        const isGivingToSelf = () => interaction.user.id === user.id;
         if (!isGuildOwner() && !isGuildManager() && isGivingToSelf()) {
             return await interaction.reply((interaction.client as Client).locales.getText(interaction.guildLocale, "giveSelfError"));
         }

--- a/src/commands/give.ts
+++ b/src/commands/give.ts
@@ -43,7 +43,10 @@ class GiveCommand extends Command {
         const xp = interaction.options.getInteger("xp");
 
         // check whether user is giving it to themselves
-        if (interaction.user.id !== interaction.guild.ownerId && interaction.user.id === user.id) {
+        const isGuildOwner = () => interaction.user.id === interaction.guild.ownerId
+        const isGuildManager = () => interaction.memberPermissions.has(PermissionFlagsBits.ManageGuild)
+        const isGivingToSelf = () => interaction.user.id === user.id
+        if (!isGuildOwner() && !isGuildManager() && isGivingToSelf()) {
             return await interaction.reply((interaction.client as Client).locales.getText(interaction.guildLocale, "giveSelfError"));
         }
 


### PR DESCRIPTION
Allows users with the *ManageGuild* permission to run `/give` on themselves.

#### References
Fixes: https://github.com/TheBastionBot/Bastion/issues/1077
Instead of requiring the *Administrator* permission, I have made it require the *ManageGuild* permission instead, to follow the `userPermissions` setting in the `GiveCommand` constructor.
I also ignored the issue requirement of allowing **Bot Owner** to run the command, because just the *ManageGuild* permission might be more appropriate.

#### Checklist
- [x] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)
