### PR TITLE
Implement Custom Level-Up Messages for Servers With Gamification

### DIFF
--- a/src/commands/config/gamification.ts
+++ b/src/commands/config/gamification.ts
@@ -29,7 +29,7 @@ class GamificationCommand extends Command {
                 {
                     type: ApplicationCommandOptionType.String,
                     name: "message",
-                    description: "A custom message to send on level up. Supports tokens: %%level%%, %%date%%, %%time%%, %%username%%."
+                    description: "A custom message to send upon level up. Supports tokens: %level%, %date%, %time%, %username%."
                 },
                 {
                     type: ApplicationCommandOptionType.Number,

--- a/src/commands/config/gamification.ts
+++ b/src/commands/config/gamification.ts
@@ -29,7 +29,7 @@ class GamificationCommand extends Command {
                 {
                     type: ApplicationCommandOptionType.String,
                     name: "message",
-                    description: "A custom message to send on level up. Supports tokens: %%level%%, %%date%%, %%time%%."
+                    description: "A custom message to send on level up. Supports tokens: %%level%%, %%date%%, %%time%%, %%username%%."
                 },
                 {
                     type: ApplicationCommandOptionType.Number,

--- a/src/commands/config/gamification.ts
+++ b/src/commands/config/gamification.ts
@@ -27,6 +27,11 @@ class GamificationCommand extends Command {
                     channel_types: [ ChannelType.GuildText ],
                 },
                 {
+                    type: ApplicationCommandOptionType.String,
+                    name: "message",
+                    description: "A custom message to send on level up. Supports tokens: %%level%%, %%date%%, %%time%%."
+                },
+                {
                     type: ApplicationCommandOptionType.Number,
                     name: "multiplier",
                     description: "The reward multiplier.",
@@ -40,6 +45,7 @@ class GamificationCommand extends Command {
         await interaction.deferReply();
         const messages = interaction.options.getBoolean("messages");
         const channel = interaction.options.getChannel("channel");
+        const customMessage = interaction.options.getString("message");
         const multiplier = interaction.options.getNumber("multiplier");
 
         // check for premium membership
@@ -55,6 +61,7 @@ class GamificationCommand extends Command {
         guildDocument.gamification = messages || multiplier ? true : guildDocument.gamification ? undefined : true;
         guildDocument.gamificationMessages = typeof messages === "boolean" ? messages : guildDocument.gamificationMessages || undefined;
         guildDocument.gamificationChannel = channel?.id || undefined;
+        guildDocument.gamificationCustomMessage = customMessage || undefined;
         guildDocument.gamificationMultiplier = multiplier || guildDocument.gamificationMultiplier || undefined;
 
         await guildDocument.save();

--- a/src/listeners/messageCreate.ts
+++ b/src/listeners/messageCreate.ts
@@ -96,10 +96,10 @@ class MessageCreateListener extends Listener<"messageCreate"> {
                         () => now.getUTCMinutes().toString().padStart(2, "0")
                     ];
                     gamificationMessage = gamificationMessage
-                        .replaceAll(/%%level%%/g, `${computedLevel}`)
-                        .replaceAll(/%%username%%/g, `${message.author.displayName}`)
-                        .replaceAll(/%%date%%/g, `${year()}-${month()}-${day()}`)
-                        .replaceAll(/%%time%%/g, `${hour()}:${minute()}`)
+                        .replaceAll(/%level%/g, `${computedLevel}`)
+                        .replaceAll(/%username%/g, `${message.author.displayName}`)
+                        .replaceAll(/%date%/g, `${year()}-${month()}-${day()}`)
+                        .replaceAll(/%time%/g, `${hour()}:${minute()}`)
                 } else {
                     gamificationMessage = (message.client as Client).locales.getText(message.guild.preferredLocale, "leveledUp", { level: `Level ${ computedLevel }` });
                 }

--- a/src/listeners/messageCreate.ts
+++ b/src/listeners/messageCreate.ts
@@ -91,9 +91,9 @@ class MessageCreateListener extends Listener<"messageCreate"> {
                     const [year, month, day, hour, minute] = [
                         () => now.getUTCFullYear().toString(),
                         () => (now.getUTCMonth() + 1).toString().padStart(2, "0"),
-                        () => now.getUTCDate().toString(),
-                        () => now.getUTCHours().toString(),
-                        () => now.getUTCMinutes().toString()
+                        () => now.getUTCDate().toString().padStart(2, "0"),
+                        () => now.getUTCHours().toString().padStart(2, "0"),
+                        () => now.getUTCMinutes().toString().padStart(2, "0")
                     ];
                     gamificationMessage = gamificationMessage
                         .replaceAll(/%%level%%/g, `${computedLevel}`)

--- a/src/listeners/messageCreate.ts
+++ b/src/listeners/messageCreate.ts
@@ -97,6 +97,7 @@ class MessageCreateListener extends Listener<"messageCreate"> {
                     ];
                     gamificationMessage = gamificationMessage
                         .replaceAll(/%%level%%/g, `${computedLevel}`)
+                        .replaceAll(/%%username%%/g, `${message.author.displayName}`)
                         .replaceAll(/%%date%%/g, `${year()}-${month()}-${day()}`)
                         .replaceAll(/%%time%%/g, `${hour()}:${minute()}`)
                 } else {

--- a/src/listeners/messageCreate.ts
+++ b/src/listeners/messageCreate.ts
@@ -85,7 +85,23 @@ class MessageCreateListener extends Listener<"messageCreate"> {
 
             // achievement message
             if (guildDocument.gamificationMessages) {
-                const gamificationMessage = (message.client as Client).locales.getText(message.guild.preferredLocale, "leveledUp", { level: `Level ${ computedLevel }` });
+                let gamificationMessage = guildDocument.gamificationCustomMessage;
+                if (guildDocument.gamificationCustomMessage) {
+                    const now = new Date();
+                    const [year, month, day, hour, minute] = [
+                        () => now.getUTCFullYear().toString(),
+                        () => (now.getUTCMonth() + 1).toString().padStart(2, "0"),
+                        () => now.getUTCDate().toString(),
+                        () => now.getUTCHours().toString(),
+                        () => now.getUTCMinutes().toString()
+                    ];
+                    gamificationMessage = gamificationMessage
+                        .replaceAll(/%%level%%/g, `${computedLevel}`)
+                        .replaceAll(/%%date%%/g, `${year()}-${month()}-${day()}`)
+                        .replaceAll(/%%time%%/g, `${hour()}:${minute()}`)
+                } else {
+                    gamificationMessage = (message.client as Client).locales.getText(message.guild.preferredLocale, "leveledUp", { level: `Level ${ computedLevel }` });
+                }
 
                 if (guildDocument.gamificationChannel && message.guild.channels.cache.has(guildDocument.gamificationChannel)) {
                     (message.guild.channels.cache.get(guildDocument.gamificationChannel) as GuildTextBasedChannel)

--- a/src/models/Guild.ts
+++ b/src/models/Guild.ts
@@ -22,6 +22,7 @@ export interface Guild {
     musicRole?: string;
     // gamification
     gamification?: boolean;
+    gamificationCustomMessage?: string;
     gamificationMessages?: boolean;
     gamificationChannel?: string;
     gamificationMultiplier?: number;
@@ -109,6 +110,9 @@ export default mongoose.model<Guild & mongoose.Document>("Guild", new mongoose.S
     },
     gamification: {
         type: Boolean,
+    },
+    gamificationCustomMessage: {
+        type: String
     },
     gamificationMessages: {
         type: Boolean,


### PR DESCRIPTION
Adds a new argument to the `/config gamification` command: "**message**," which allows the command user to customise the message sent to users who level up.

The custom message supports emojis, markdown & variable tokens. The supported tokens are as follows:
- *%level%*
- *%username%*
- *%date% (UTC)*
- *%time% (UTC)*

I based the token format on that used by the locale system: surrounded by percent signs (%).

#### Usage
*Configuring a custom message*
![Screenshot_20250112_223602](https://github.com/user-attachments/assets/b164c67d-a535-4c6e-a447-1fc8938e4209)

*Result of leveling up*
![Screenshot_20250112_223535](https://github.com/user-attachments/assets/d2c52a56-281b-4fd2-a7b2-0e2c2ffb30cc)

#### References
Fixes: #1081 

#### Checklist
- [x] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)
