### PR TITLE
feat(music): fall back to play-dl when yt-dlp is unavailable

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@discordjs/opus": "^0.10.0",
         "@google/generative-ai": "^0.24.1",
         "@iamtraction/google-translate": "^2.0.1",
-        "@iamtraction/play-dl": "^1.9.8",
+        "@iamtraction/play-dl": "^2.0.1",
         "@snazzah/davey": "^0.1.12",
         "discord-rpc": "^4.0.1",
         "dotenv": "^17.2.3",

--- a/src/commands/music/play.ts
+++ b/src/commands/music/play.ts
@@ -174,8 +174,11 @@ class PlayCommand extends Command {
             if (code && !signal) Logger.error(new Error(`yt-dlp exited with code ${ code }: ${ stderr.trim() }`));
         });
 
-        // guard against unhandled stream errors (e.g. broken pipe) crashing the process
-        ytdlp.stdout.on("error", Logger.error);
+        // guard against unhandled stream errors crashing the process; a premature close is
+        // expected when a song is skipped/stopped, so don't log it as an error
+        ytdlp.stdout.on("error", (error: NodeJS.ErrnoException) => {
+            if (error.code !== "ERR_STREAM_PREMATURE_CLOSE") Logger.error(error);
+        });
         // kill the yt-dlp process once the stream is no longer being consumed
         ytdlp.stdout.on("close", () => ytdlp.killed || ytdlp.kill("SIGKILL"));
 

--- a/src/commands/music/play.ts
+++ b/src/commands/music/play.ts
@@ -18,6 +18,16 @@ import { isPremiumUser } from "../../utils/premium.js";
 // YouTube cookies file in Netscape format (optional)
 const YOUTUBE_COOKIES_FILE = "cookies.txt";
 
+// whether the yt-dlp binary is available on PATH; probed once and cached as a shared promise
+let ytdlpAvailable: Promise<boolean> | undefined;
+const isYtdlpAvailable = (): Promise<boolean> => {
+    return (ytdlpAvailable ??= new Promise<boolean>(resolve => {
+        const probe = spawn("yt-dlp", [ "--version" ], { stdio: "ignore" });
+        probe.on("error", () => resolve(false));
+        probe.on("close", code => resolve(code === 0));
+    }));
+};
+
 class PlayCommand extends Command {
     constructor() {
         super({
@@ -132,6 +142,12 @@ class PlayCommand extends Command {
      * Create a audio resource for the specified audio.
      */
     private createAudioResource = async (audio: music.Song): Promise<AudioResource<music.Song>> => {
+        // prefer yt-dlp for streaming; if it isn't installed, fall back to play-dl
+        if (!(await isYtdlpAvailable())) {
+            const source = await playDL.stream(audio.url, { quality: 2 });
+            return createAudioResource(source.stream, { inputType: source.type, metadata: audio });
+        }
+
         // reject anything that isn't an http(s) URL, so it can't be smuggled in as a yt-dlp flag
         const url = new URL(audio.url);
         if (url.protocol !== "https:" && url.protocol !== "http:") throw new Error(`Unsupported audio URL protocol: ${ url.protocol }`);


### PR DESCRIPTION
Follow-ups to the yt-dlp music streaming work.

- **feat**: prefer yt-dlp for streaming, and fall back to `playDL.stream()` when the `yt-dlp` binary isn't on `PATH` (probed once, cached). Public instance stays on yt-dlp (SABR-capable, Opus passthrough); self-hosters without the binary still get playback via play-dl.
- **fix**: skipping/stopping a song tears down the yt-dlp stream mid-read, surfacing as `ERR_STREAM_PREMATURE_CLOSE` — expected teardown, so it's ignored while genuine stream errors are still logged.
- **build(deps)**: bump `@iamtraction/play-dl` to `^2.0.1` — required by both `playDL.search` (search `browseId`/multi-channel guard) and the new play-dl streaming fallback (HLS support).

#### References
<!-- No linked issue. --> Requires `@iamtraction/play-dl` >= 2.0.1 (now published). Note: 2.0.0 was an empty publish (missing `dist/`); `^2.0.1` avoids resolving to it.

#### Checklist
- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)