### PR TITLE
build(deps): major dependency upgrades (tesseract 6 / mongoose 9) + supply-chain gate

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,8 @@
+min-release-age=1
+
+allow-git=none
+allow-remote=none
+
+# WARNING: this breaks packages that rely on postinstall scripts (e.g. Husky, Prisma, native addons).
+# Comment this out if a new dependency fails to install or behaves incorrectly
+ignore-scripts=true

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,2 @@
+npmMinimalAgeGate: 1440 # 1 day
+enableScripts: false

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     },
     "dependencies": {
         "@anthropic-ai/sdk": "^0.112.3",
-        "@bastion/tesseract": "^5.2.5",
+        "@bastion/tesseract": "^6.0.0",
         "@discordjs/opus": "^0.10.0",
         "@google/generative-ai": "^0.24.1",
         "@iamtraction/google-translate": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "author": "TRACTION",
     "license": "",
     "private": true,
+    "engines": {
+        "node": ">=22.19.0"
+    },
     "scripts": {
         "build": "tsc",
         "build:commands": "tesseract commands",

--- a/package.json
+++ b/package.json
@@ -18,18 +18,19 @@
         "test": "eslint ."
     },
     "devDependencies": {
-        "@types/discord-rpc": "^4.0.9",
-        "@types/express": "^5.0.5",
+        "@eslint/js": "^10.0.1",
+        "@types/discord-rpc": "^4.0.11",
+        "@types/express": "^5.0.6",
         "@types/gamedig": "^5.0.3",
         "@types/http-errors": "^2.0.5",
-        "@types/jsdom": "^27.0.0",
-        "@types/node": "^24.10.0",
-        "eslint": "^9.39.1",
-        "typescript": "^5.9.3",
-        "typescript-eslint": "^8.46.3"
+        "@types/jsdom": "^28.0.3",
+        "@types/node": "^24.13.3",
+        "eslint": "^10.7.0",
+        "typescript": "^6.0.3",
+        "typescript-eslint": "^8.65.0"
     },
     "dependencies": {
-        "@anthropic-ai/sdk": "^0.68.0",
+        "@anthropic-ai/sdk": "^0.112.3",
         "@bastion/tesseract": "^5.2.5",
         "@discordjs/opus": "^0.10.0",
         "@google/generative-ai": "^0.24.1",
@@ -37,22 +38,22 @@
         "@iamtraction/play-dl": "^2.0.1",
         "@snazzah/davey": "^0.1.12",
         "discord-rpc": "^4.0.1",
-        "dotenv": "^17.2.3",
+        "dotenv": "^17.4.2",
         "emoji-regex": "^10.6.0",
-        "gamedig": "^5.3.2",
-        "jsdom": "^27.1.0",
-        "libsodium-wrappers": "^0.7.15",
-        "mathjs": "^15.1.0",
-        "openai": "^6.8.1",
+        "gamedig": "^5.3.3",
+        "jsdom": "^29.1.1",
+        "libsodium-wrappers": "^0.8.4",
+        "mathjs": "^15.2.0",
+        "openai": "^6.48.0",
         "r6api.js": "^4.4.1",
-        "undici": "^7.16.0",
+        "undici": "^8.8.0",
         "ytdl-core": "^4.11.5",
         "ytpl": "^2.3.0"
     },
     "optionalDependencies": {
-        "bufferutil": "^4.0.9",
+        "bufferutil": "^4.1.0",
         "erlpack": "github:discord/erlpack",
-        "utf-8-validate": "^6.0.5",
+        "utf-8-validate": "^6.0.6",
         "zlib-sync": "^0.1.10"
     }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+minimumReleaseAge: 1440 # 1 day
+blockExoticSubdeps: true
+strictDepBuilds: true
+allowBuilds:
+  # Explicitly list packages allowed to run postinstall scripts.
+  # WARNING: comment out strictDepBuilds above if this becomes hard to maintain.
+  # e.g. esbuild: true

--- a/src/listeners/messageCreate.ts
+++ b/src/listeners/messageCreate.ts
@@ -301,7 +301,7 @@ class MessageCreateListener extends Listener<"messageCreate"> {
 
             // create guild document if it wasn't found
             if (!guildDocument) {
-                guildDocument = await GuildModel.findByIdAndUpdate(message.guildId, {}, { upsert: true });
+                guildDocument = await GuildModel.findByIdAndUpdate(message.guildId, {}, { new: true, upsert: true });
             }
 
             // gamification

--- a/src/models/Giveaway.ts
+++ b/src/models/Giveaway.ts
@@ -13,7 +13,7 @@ export interface Giveaway {
     ends: Date;
 }
 
-const giveawaySchema = new mongoose.Schema<Giveaway & mongoose.Document>({
+const giveawaySchema = new mongoose.Schema<Giveaway>({
     _id: {
         type: String,
         required: true,
@@ -38,4 +38,4 @@ const giveawaySchema = new mongoose.Schema<Giveaway & mongoose.Document>({
     },
 });
 
-export default mongoose.model<Giveaway & mongoose.Document>("Giveaway", giveawaySchema);
+export default mongoose.model<Giveaway>("Giveaway", giveawaySchema);

--- a/src/models/Guild.ts
+++ b/src/models/Guild.ts
@@ -62,7 +62,7 @@ export interface Guild {
     verifiedRole?: string;
 }
 
-export default mongoose.model<Guild & mongoose.Document>("Guild", new mongoose.Schema<Guild & mongoose.Document>({
+export default mongoose.model<Guild>("Guild", new mongoose.Schema<Guild>({
     _id: {
         type: String,
         required: true,

--- a/src/models/Member.ts
+++ b/src/models/Member.ts
@@ -18,7 +18,7 @@ export interface Member {
     boost?: number;
 }
 
-const memberSchema = new mongoose.Schema<Member & mongoose.Document>({
+const memberSchema = new mongoose.Schema<Member>({
     user: {
         type: String,
         required: true,
@@ -75,4 +75,4 @@ memberSchema.index({
     unique: true,
 });
 
-export default mongoose.model<Member & mongoose.Document>("Member", memberSchema);
+export default mongoose.model<Member>("Member", memberSchema);

--- a/src/models/Poll.ts
+++ b/src/models/Poll.ts
@@ -12,7 +12,7 @@ export interface Poll {
     ends: Date;
 }
 
-const pollSchema = new mongoose.Schema<Poll & mongoose.Document>({
+const pollSchema = new mongoose.Schema<Poll>({
     _id: {
         type: String,
         required: true,
@@ -34,4 +34,4 @@ const pollSchema = new mongoose.Schema<Poll & mongoose.Document>({
     },
 });
 
-export default mongoose.model<Poll & mongoose.Document>("Poll", pollSchema);
+export default mongoose.model<Poll>("Poll", pollSchema);

--- a/src/models/Role.ts
+++ b/src/models/Role.ts
@@ -19,7 +19,7 @@ export interface Role {
     bots?: boolean;
 }
 
-export default mongoose.model<Role & mongoose.Document>("Role", new mongoose.Schema<Role & mongoose.Document>({
+export default mongoose.model<Role>("Role", new mongoose.Schema<Role>({
     _id: {
         type: String,
         required: true,

--- a/src/models/SelectRoleGroup.ts
+++ b/src/models/SelectRoleGroup.ts
@@ -16,7 +16,7 @@ export interface SelectRoleGroup {
     max?: number;
 }
 
-export default mongoose.model<SelectRoleGroup & mongoose.Document>("SelectRoleGroup", new mongoose.Schema<SelectRoleGroup & mongoose.Document>({
+export default mongoose.model<SelectRoleGroup>("SelectRoleGroup", new mongoose.Schema<SelectRoleGroup>({
     _id: {
         type: String,
         required: true,

--- a/src/models/Trigger.ts
+++ b/src/models/Trigger.ts
@@ -11,7 +11,7 @@ export interface Trigger {
     reactions?: string;
 }
 
-const triggerSchema = new mongoose.Schema<Trigger & mongoose.Document>({
+const triggerSchema = new mongoose.Schema<Trigger>({
     guild: {
         type: String,
         required: true,
@@ -29,4 +29,4 @@ const triggerSchema = new mongoose.Schema<Trigger & mongoose.Document>({
     },
 });
 
-export default mongoose.model<Trigger & mongoose.Document>("Trigger", triggerSchema);
+export default mongoose.model<Trigger>("Trigger", triggerSchema);

--- a/src/utils/emojis.ts
+++ b/src/utils/emojis.ts
@@ -31,7 +31,7 @@ const isUnicodeEmoji = (text: string): boolean => {
 };
 
 
-const parseEmoji = (text: string): string | void => {
+const parseEmoji = (text: string): string | undefined => {
     if (typeof text !== "string") return;
 
     if (snowflake.isValid(text)) return text;


### PR DESCRIPTION
Upgrades all dependencies to their latest policy-compliant major versions and addresses the breaking changes they introduce, hardens the install-time supply-chain policy, declares the Node engine floor, and fixes one latent bug found during the Mongoose review.

**Dependency upgrades** (`build(deps)`)
- `typescript` 5.9 → 6.0 (latest usable — `typescript-eslint`'s `<6.1` peer blocks 7.0), `eslint` 9 → 10 (+ explicit `@eslint/js`, no longer bundled), `typescript-eslint` 8.46 → 8.65
- `undici` 7 → 8, `jsdom` 27 → 29, `@anthropic-ai/sdk` 0.68 → 0.112, `libsodium-wrappers` 0.7 → 0.8, plus in-range refreshes (`openai`, `dotenv`, `mathjs`, `gamedig`, `@types/*`, `bufferutil`, `utf-8-validate`)
- `@bastion/tesseract` 5 → 6 — brings `discord.js` 14.27, `express` 5.2, and **Mongoose 8 → 9**
- `@types/node` held at 24.x to match the runtime

**Mongoose 9 migration** (`build(deps)`)
- Models moved off the legacy `Schema<T & mongoose.Document>` generic to the Mongoose 9 `Schema<T>` / `model<T>` pattern, so string `_id` types resolve as `string` instead of `string & ObjectId`
- `parseEmoji` returns `string | undefined` instead of `string | void` (v9 rejects `void` in `create()` values)

**Supply-chain hardening** (`chore(security)`)
- 1-day `min-release-age` install gate across `.npmrc` / `.yarnrc.yml` / `pnpm-workspace.yaml` (blunts compromised-package / typosquat windows), plus `ignore-scripts` and no remote/git deps

**Engine floor** (`build`)
- Declared `engines.node >= 22.19.0` — the true floor across the dependency tree (required by `undici` 8; nothing requires Node 24)

**Fix** (`fix(gamification)`)
- `messageCreate` now passes `{ new: true }` to the guild-document upsert, so the gamification / voting-channel / karma / auto-thread handlers no longer receive `null` on the first message in an untracked guild (pre-existing bug, surfaced during the Mongoose review)

**Verification**
- `npm run build` and `npm test` (eslint) pass
- Maintainer smoke-tested runtime (voice playback + DB paths) — passing

**Deploy notes**
- `package-lock.json` is gitignored; run `npm install` on deploy. Requires **Node ≥ 22.19**.
- `@bastion/tesseract@6.0.0` and `@iamtraction/play-dl@2.0.1` were <1 day old when this work began; they've since aged past the 1-day gate, so a clean install resolves them without any bypass.

#### References
<!-- No linked issue. -->

#### Checklist
- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)