### PR TITLE
fix(starboard): bound the dedup cache with a per-message TTL

### DIFF
--- a/src/listeners/messageReactionAdd.ts
+++ b/src/listeners/messageReactionAdd.ts
@@ -2,7 +2,7 @@
  * @author TRACTION (iamtraction)
  * @copyright 2022
  */
-import { GuildTextBasedChannel, MessageReaction, PartialMessageReaction, PartialUser, Snowflake, User } from "discord.js";
+import { GuildTextBasedChannel, MessageReaction, PartialMessageReaction, PartialUser, User } from "discord.js";
 import { Listener } from "@bastion/tesseract";
 
 import GuildModel from "../models/Guild.js";
@@ -21,10 +21,8 @@ class MessageReactionAddListener extends Listener<"messageReactionAdd"> {
         // check whether the message has the minimum reaction count
         if (reaction.count < 2) return;
 
-        // check whether the message is already in starboard
-        const starboardCache = memcache.get("starboard") as Map<Snowflake, Snowflake[]> || new Map<Snowflake, Snowflake[]>();
-        const guildStarboardCache = starboardCache.get(reaction.message.guildId);
-        if (guildStarboardCache?.includes(reaction.message.id)) return;
+        // check whether the message is already in the starboard
+        if (memcache.get(`starboard:${ reaction.message.id }`)) return;
 
         const guildDocument = await GuildModel.findById(reaction.message.guildId);
 
@@ -71,13 +69,8 @@ class MessageReactionAddListener extends Listener<"messageReactionAdd"> {
             ],
         });
 
-        // update the starboard cache
-        if (guildStarboardCache instanceof Array) {
-            guildStarboardCache.push(reaction.message.id);
-        } else {
-            starboardCache.set(reaction.message.guildId, [ reaction.message.id ]);
-        }
-        memcache.set("starboard", starboardCache);
+        // remember this message for 3 days so it isn't reposted to the starboard
+        memcache.set(`starboard:${ reaction.message.id }`, true, 3 * 24 * 60);
     }
 }
 


### PR DESCRIPTION
The starboard dedup cache was a `Map<guildId, messageId[]>` stored in `memcache` with no expiry. Message IDs were only ever pushed onto the per-guild arrays and never removed, so the cache retained every starred message ID for the life of the process — an unbounded memory leak that also reset (and thus re-posted) on restart.

This replaces it with one self-expiring `memcache` key per posted message (`starboard:<messageId>`) with a 3-day TTL, exercising memcache's existing TTL path. Steady-state size is now bounded by threshold-crossings within the TTL window instead of growing forever, and dedup lookups are O(1).

Known limitations carried over (unchanged, to be addressed by a future DB-backed rewrite): dedup state is still in RAM so a restart can allow one re-post, and the check-then-post path is not atomic.

#### References
<!-- none -->

#### Checklist
- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)