### PR TITLE
fix(livestreams): drop twitch notification state for departed guilds

### DIFF
--- a/src/schedulers/liveStreams.ts
+++ b/src/schedulers/liveStreams.ts
@@ -39,6 +39,11 @@ class LiveStreamNotificationScheduler extends Scheduler {
 
             const twitchStreams = memcache.get(TWITCH_CACHE_NAMESPACE) as Map<Snowflake, string[]>;
 
+            // drop notification state for guilds bastion has left
+            for (const id of twitchStreams.keys()) {
+                if (!this.client.guilds.cache.has(id)) twitchStreams.delete(id);
+            }
+
             for (const guild of guildDocuments) {
                 // twitch streams
                 const twitchNotificationUsers = guild.twitchNotificationUsers.filter(u => TWITCH_CHANNEL.test(u));


### PR DESCRIPTION
The `twitchStreams` cache in the live-streams scheduler is a `Map<guildId, string[]>` tracking which streamers each guild has already been notified about. Entries were added per guild but never removed, so an entry lingered for the life of the process after bastion left a guild (or the guild stopped qualifying) — a slow, unbounded-by-guild-churn accumulation.

This prunes keys for guilds no longer in the cache at the start of each run. The existing empty-cache guard (`if (!this.client.guilds.cache.size) return;`) ensures the prune never runs against an unpopulated cache. Per-guild arrays were already self-bounding (pruned to currently-live streamers each run); only the stale keys needed cleanup.

#### References
<!-- none -->

#### Checklist
- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)