### PR TITLE
feat(gamification): award XP for active voice participation

### DIFF
--- a/src/commands/give.ts
+++ b/src/commands/give.ts
@@ -51,7 +51,7 @@ class GiveCommand extends Command {
         const memberDocument = await MemberModel.findOneAndUpdate({
             user: user.id,
             guild: interaction.guildId,
-        }, {}, { new: true, upsert: true });
+        }, {}, { returnDocument: "after", upsert: true });
 
         // update coins & XP
         updateBalance(memberDocument, coins);

--- a/src/listeners/messageCreate.ts
+++ b/src/listeners/messageCreate.ts
@@ -30,7 +30,11 @@ class MessageCreateListener extends Listener<"messageCreate"> {
         if (memcache.get(key)) return;
 
         // find member document or create a new one
-        const memberDocument = await MemberModel.findOneAndUpdate({ user: message.author.id, guild: message.guildId }, {}, { new: true, upsert: true });
+        const memberDocument = await MemberModel.findOneAndUpdate(
+            { user: message.author.id, guild: message.guildId },
+            {},
+            { returnDocument: "after", upsert: true },
+        );
 
         // check whether gamification is enabled
         if (!guildDocument.gamification) return;
@@ -42,7 +46,7 @@ class MessageCreateListener extends Listener<"messageCreate"> {
         const { experience, level } = await MemberModel.findOneAndUpdate(
             { user: message.author.id, guild: message.guildId },
             { $inc: { experience: message.member.premiumSinceTimestamp ? 2 : 1 } },
-            { new: true, upsert: true },
+            { returnDocument: "after", upsert: true },
         );
 
         // compute current level from new experience
@@ -245,7 +249,11 @@ class MessageCreateListener extends Listener<"messageCreate"> {
 
             // create guild document if it wasn't found
             if (!guildDocument) {
-                guildDocument = await GuildModel.findByIdAndUpdate(message.guildId, {}, { new: true, upsert: true });
+                guildDocument = await GuildModel.findByIdAndUpdate(
+                    message.guildId,
+                    {},
+                    { returnDocument: "after", upsert: true },
+                );
             }
 
             // gamification

--- a/src/listeners/messageCreate.ts
+++ b/src/listeners/messageCreate.ts
@@ -38,26 +38,27 @@ class MessageCreateListener extends Listener<"messageCreate"> {
         // check whether member has exceeded max level or experience
         if (memberDocument.level >= gamification.MAX_LEVEL || memberDocument.experience >= gamification.MAX_EXPERIENCE(guildDocument.gamificationMultiplier)) return;
 
-        // increment experience
-        members.updateExperience(memberDocument, message.member.premiumSinceTimestamp ? 2 : 1);
+        // atomically increment experience so concurrent writers aren't clobbered
+        const { experience, level } = await MemberModel.findOneAndUpdate(
+            { user: message.author.id, guild: message.guildId },
+            { $inc: { experience: message.member.premiumSinceTimestamp ? 2 : 1 } },
+            { new: true, upsert: true },
+        );
 
         // compute current level from new experience
-        const computedLevel: number = gamification.computeLevel(memberDocument.experience, guildDocument.gamificationMultiplier);
+        const computedLevel: number = gamification.computeLevel(experience, guildDocument.gamificationMultiplier);
 
         // level up
-        if (computedLevel > memberDocument.level) {
-            // credit reward amount into member's account
-            members.updateBalance(memberDocument, computedLevel * gamification.DEFAUL_CURRENCY_REWARD_MULTIPLIER);
+        if (computedLevel > level) {
+            // persist the new level and credit the reward amount
+            await MemberModel.updateOne({ user: message.author.id, guild: message.guildId }, {
+                $set: { level: computedLevel },
+                $inc: { balance: computedLevel * gamification.DEFAUL_CURRENCY_REWARD_MULTIPLIER },
+            });
 
             // reward level roles and announce the level up
             members.handleLevelUp(message.member, guildDocument, computedLevel, message);
         }
-
-        // update level
-        memberDocument.level = computedLevel;
-
-        // save document
-        await memberDocument.save();
 
         // set the XP cooldown for the member
         memcache.set(key, true, 30 / 60); // 30 seconds

--- a/src/listeners/messageCreate.ts
+++ b/src/listeners/messageCreate.ts
@@ -2,19 +2,17 @@
  * @author TRACTION (iamtraction)
  * @copyright 2022
  */
-import { ChannelType, GuildTextBasedChannel, Message, Team, ThreadAutoArchiveDuration } from "discord.js";
+import { ChannelType, Message, Team, ThreadAutoArchiveDuration } from "discord.js";
 import { Client, Listener, Logger } from "@bastion/tesseract";
 
 import GuildModel, { Guild as GuildDocument } from "../models/Guild.js";
 import MemberModel from "../models/Member.js";
-import RoleModel from "../models/Role.js";
 import TriggerModel from "../models/Trigger.js";
 import { COLORS } from "../utils/constants.js";
 import { generate as generateEmbed } from "../utils/embeds.js";
 import * as gamification from "../utils/gamification.js";
 import * as members from "../utils/members.js";
 import memcache from "../utils/memcache.js";
-import * as numbers from "../utils/numbers.js";
 import * as regex from "../utils/regex.js";
 import Settings from "../utils/settings.js";
 import * as variables from "../utils/variables.js";
@@ -24,34 +22,6 @@ class MessageCreateListener extends Listener<"messageCreate"> {
     constructor() {
         super("messageCreate");
     }
-
-    handleLevelRoles = async (message: Message, level: number): Promise<void> => {
-        const roles = await RoleModel.find({
-            guild: message.guild.id,
-            level: { $exists: true, $ne: null },
-        });
-
-        // check whether there are any level up roles
-        if (!roles?.length) return;
-
-        // get the nearest level for which roles are available
-        const nearestLevel = numbers.smallestNeighbor(level, roles.map(r => r.level));
-
-        // identify valid roles
-        const levelRoles = roles.filter(r => r.level === nearestLevel && message.guild.roles.cache.has(r._id));
-        const extraRoles = roles.filter(r => r.level !== nearestLevel && message.guild.roles.cache.has(r._id));
-
-        // update member roles
-        if (levelRoles.length) {
-            const memberRoles = message.member.roles.cache
-                .filter(r => !extraRoles.some(doc => doc.id === r.id))   // remove roles from any other level
-                .map(r => r.id)
-                .concat(levelRoles.map(doc => doc.id)); // add roles in the current level
-
-            // update member roles
-            message.member.roles.set([ ...new Set(memberRoles) ]).catch(Logger.error);
-        }
-    };
 
     handleGamification = async (message: Message<true>, guildDocument: GuildDocument): Promise<void> => {
         const key = `xp:${ message.guildId }:${ message.author.id }`;
@@ -79,23 +49,8 @@ class MessageCreateListener extends Listener<"messageCreate"> {
             // credit reward amount into member's account
             members.updateBalance(memberDocument, computedLevel * gamification.DEFAUL_CURRENCY_REWARD_MULTIPLIER);
 
-            // achievement message
-            if (guildDocument.gamificationMessages) {
-                const gamificationMessage = (message.client as Client).locales.getText(message.guild.preferredLocale, "leveledUp", { level: `Level ${ computedLevel }` });
-
-                if (guildDocument.gamificationChannel && message.guild.channels.cache.has(guildDocument.gamificationChannel)) {
-                    (message.guild.channels.cache.get(guildDocument.gamificationChannel) as GuildTextBasedChannel)
-                        .send(`${ message.author }, ${ gamificationMessage }`)
-                        .catch(Logger.ignore);
-                } else {
-                    message.reply(gamificationMessage)
-                        .catch(Logger.ignore);
-                }
-            }
-
-            // reward level roles, if available
-            this.handleLevelRoles(message, computedLevel)
-                .catch(Logger.error);
+            // reward level roles and announce the level up
+            members.handleLevelUp(message.member, guildDocument, computedLevel, message);
         }
 
         // update level

--- a/src/schedulers/voiceExperience.ts
+++ b/src/schedulers/voiceExperience.ts
@@ -1,0 +1,136 @@
+/*!
+ * @author TRACTION (iamtraction)
+ * @copyright 2026
+ */
+import mongoose from "mongoose";
+import { GuildMember } from "discord.js";
+import { Logger, Scheduler } from "@bastion/tesseract";
+
+import GuildModel, { Guild as GuildDocument } from "../models/Guild.js";
+import MemberModel, { Member } from "../models/Member.js";
+import * as gamification from "../utils/gamification.js";
+import * as members from "../utils/members.js";
+
+const VOICE_XP_PER_TICK = 5;
+
+class VoiceExperienceScheduler extends Scheduler {
+    constructor() {
+        super("voiceExperience", "0 */5 * * * *");  // every 5 minutes
+    }
+
+    public async exec(): Promise<void> {
+        try {
+            // check whether the client is ready
+            if (!this.client.isReady()) return;
+
+            // check whether the guild cache is empty
+            if (!this.client.guilds.cache.size) return;
+
+            // collect eligible members per guild from this shard's cached voice states
+            const eligibleByGuild = new Map<string, GuildMember[]>();
+            for (const guild of this.client.guilds.cache.values()) {
+                const eligible: GuildMember[] = [];
+
+                // non-bot human count per channel
+                const humansByChannel = new Map<string, number>();
+
+                for (const voiceState of guild.voiceStates.cache.values()) {
+                    const { channel, member } = voiceState;
+
+                    // must be in a voice channel with a resolved, non-bot member
+                    if (!channel || !member || member.user.bot) continue;
+
+                    // ignore the AFK channel and muted / deafened members
+                    if (channel.id === guild.afkChannelId || voiceState.mute || voiceState.deaf) continue;
+
+                    // count this channel's non-bot humans
+                    let humans = humansByChannel.get(channel.id);
+                    if (humans === undefined) {
+                        humans = 0;
+                        for (const m of channel.members.values()) {
+                            if (!m.user.bot) humans++;
+                        }
+                        humansByChannel.set(channel.id, humans);
+                    }
+
+                    // make sure user is not alone
+                    if (humans < 2) continue;
+
+                    eligible.push(member);
+                }
+
+                if (eligible.length) eligibleByGuild.set(guild.id, eligible);
+            }
+
+            // nothing to do if no eligible members anywhere on this shard
+            if (!eligibleByGuild.size) return;
+
+            // load gamification-enabled guilds that have eligible members
+            const guildDocuments = await GuildModel.find({
+                _id: { $in: [ ...eligibleByGuild.keys() ] },
+                gamification: true,
+            });
+            if (!guildDocuments.length) return;
+
+            // read current experience/level for all eligible members
+            const userIds = new Set<string>();
+            for (const guildDocument of guildDocuments) {
+                for (const member of eligibleByGuild.get(guildDocument.id)) userIds.add(member.id);
+            }
+            const memberDocuments = await MemberModel.find({
+                guild: { $in: guildDocuments.map(g => g.id) },
+                user: { $in: [ ...userIds ] },
+            });
+            const byKey = new Map(memberDocuments.map(d => [ `${ d.guild }:${ d.user }`, d ]));
+
+            const operations: mongoose.AnyBulkWriteOperation<Member>[] = [];
+            const levelUps: { member: GuildMember; guildDocument: GuildDocument; level: number }[] = [];
+
+            for (const guildDocument of guildDocuments) {
+                for (const member of eligibleByGuild.get(guildDocument.id)) {
+                    const current = byKey.get(`${ guildDocument.id }:${ member.id }`);
+                    const currentExperience = current?.experience || 0;
+                    const currentLevel = current?.level || 0;
+
+                    // respect the max level / experience caps
+                    if (currentLevel >= gamification.MAX_LEVEL || currentExperience >= gamification.MAX_EXPERIENCE(guildDocument.gamificationMultiplier)) continue;
+
+                    // compute the XP award and the resulting level
+                    const amount = VOICE_XP_PER_TICK * (member.premiumSinceTimestamp ? 2 : 1);
+                    const newLevel = gamification.computeLevel(currentExperience + amount, guildDocument.gamificationMultiplier);
+                    const leveledUp = newLevel > currentLevel;
+
+                    // compute new level and credit the currency reward
+                    const update: mongoose.mongo.UpdateFilter<Member> = { $inc: { experience: amount } };
+                    if (leveledUp) {
+                        update.$inc = { experience: amount, balance: newLevel * gamification.DEFAUL_CURRENCY_REWARD_MULTIPLIER };
+                        update.$set = { level: newLevel };
+                        levelUps.push({ member, guildDocument, level: newLevel });
+                    }
+
+                    operations.push({
+                        updateOne: {
+                            filter: { user: member.id, guild: guildDocument.id },
+                            update,
+                            upsert: true,
+                        },
+                    });
+                }
+            }
+
+            // single batched write for all guilds on this shard
+            if (operations.length) {
+                await MemberModel.bulkWrite(operations);
+            }
+
+            // level-up side effects (roles + notification) for members who crossed a level this tick
+            for (const { member, guildDocument, level } of levelUps) {
+                members.handleLevelUp(member, guildDocument, level);
+            }
+        } catch (e) {
+            Logger.error(e);
+        }
+    }
+}
+
+export { VoiceExperienceScheduler as Scheduler };

--- a/src/utils/members.ts
+++ b/src/utils/members.ts
@@ -2,11 +2,13 @@
  * @author TRACTION (iamtraction)
  * @copyright 2022
  */
-import { GuildMember, PartialGuildMember, PresenceStatus } from "discord.js";
+import { GuildMember, GuildTextBasedChannel, Message, PartialGuildMember, PresenceStatus } from "discord.js";
 import { Document } from "mongoose";
+import { Client, Logger } from "@bastion/tesseract";
 
-import GuildModel from "../models/Guild.js";
+import GuildModel, { Guild as GuildDocument } from "../models/Guild.js";
 import MemberModel, { Member as MemberDocument } from "../models/Member.js";
+import RoleModel from "../models/Role.js";
 import * as numbers from "./numbers.js";
 
 /**
@@ -129,5 +131,68 @@ export const updateExperience = (memberDocument: MemberDocument & Document, amou
     if (memberDocument) {
         memberDocument.experience = numbers.clamp(memberDocument.experience + amount, 0, Number.MAX_SAFE_INTEGER);
         return memberDocument;
+    }
+};
+
+/**
+ * Assign level-up roles to a member for the specified level.
+ * Swaps out roles configured for other levels and applies the roles
+ * configured for the nearest level at or below the member's level.
+ * @param member The guild member to update.
+ * @param level The member's current level.
+ */
+export const assignLevelRoles = async (member: GuildMember, level: number): Promise<void> => {
+    const roles = await RoleModel.find({
+        guild: member.guild.id,
+        level: { $exists: true, $ne: null },
+    });
+
+    // check whether there are any level up roles
+    if (!roles?.length) return;
+
+    // get the nearest level for which roles are available
+    const nearestLevel = numbers.smallestNeighbor(level, roles.map(r => r.level));
+
+    // identify valid roles
+    const levelRoles = roles.filter(r => r.level === nearestLevel && member.guild.roles.cache.has(r._id));
+    const extraRoles = roles.filter(r => r.level !== nearestLevel && member.guild.roles.cache.has(r._id));
+
+    // update member roles
+    if (levelRoles.length) {
+        const memberRoles = member.roles.cache
+            .filter(r => !extraRoles.some(doc => doc.id === r.id))  // remove roles from any other level
+            .map(r => r.id)
+            .concat(levelRoles.map(doc => doc.id)); // add roles in the current level
+
+        // update member roles
+        member.roles.set([ ...new Set(memberRoles) ]).catch(Logger.error);
+    }
+};
+
+/**
+ * Side effects of a member leveling up.
+ * Assign level roles and announce the level up.
+ * @param member The guild member who leveled up.
+ * @param guildDocument The guild's settings document.
+ * @param level The member's new level.
+ * @param fallback An optional message to reply to when no gamification
+ * channel is configured.
+ */
+export const handleLevelUp = (member: GuildMember, guildDocument: GuildDocument, level: number, fallback?: Message): void => {
+    // reward level roles, if available
+    assignLevelRoles(member, level).catch(Logger.error);
+
+    // check whether level up messages are enabled
+    if (!guildDocument.gamificationMessages) return;
+
+    const message = (member.client as Client).locales.getText(member.guild.preferredLocale, "leveledUp", { level: `Level ${ level }` });
+
+    // announce the achievement
+    if (guildDocument.gamificationChannel && member.guild.channels.cache.has(guildDocument.gamificationChannel)) {
+        (member.guild.channels.cache.get(guildDocument.gamificationChannel) as GuildTextBasedChannel)
+            .send(`${ member.user }, ${ message }`)
+            .catch(Logger.ignore);
+    } else if (fallback) {
+        fallback.reply(message).catch(Logger.ignore);
     }
 };


### PR DESCRIPTION
Adds active voice participation as a second source of gamification XP, alongside the existing message-based XP.

- **Voice XP scheduler** (`voiceExperience`): a per-shard cron ticking every 5 minutes grants 5 XP (×2 for boosters) to members active in voice — not a bot, not muted/deafened, not in the AFK channel, and not alone. Experience and the level-up currency reward are applied with a single batched `bulkWrite` per shard; level roles and the level-up announcement fire only for members who crossed a level.
- **Shared `handleLevelUp` helper**: level-role assignment and the level-up announcement are extracted into the members util so both the message and voice paths share them.
- **Atomic message XP writes**: the message path now increments experience via `$inc` instead of load-mutate-`save()`, so it can't clobber the voice scheduler's concurrent writes to the same member fields.
- **Chore**: replaced the deprecated Mongoose `new` option with `returnDocument: "after"` in the touched write paths.

#### References
<!-- none -->

#### Checklist
- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)