### PR TITLE
fix(economy): atomic claim writes and double-claim guard

### DIFF
--- a/src/commands/claim.ts
+++ b/src/commands/claim.ts
@@ -67,14 +67,20 @@ class ClaimCommand extends Command {
             rewardAmount *= 2;
         }
 
-        // credit the reward and update the streak atomically so a concurrent XP writer isn't clobbered
-        await MemberModel.updateOne({
+        // credit the reward and update the streak
+        const startOfToday = new Date(today).setHours(0, 0, 0, 0);
+        const { modifiedCount } = await MemberModel.updateOne({
             user: interaction.user.id,
             guild: interaction.guild.id,
+            // prevent concurrent claims from slipping through
+            lastClaimed: { $not: { $gte: startOfToday } },
         }, {
             $inc: { balance: rewardAmount },
             $set: { lastClaimed: today.getTime(), claimStreak },
         });
+
+        // a concurrent claim already collected today's reward
+        if (!modifiedCount) return interaction.editReply((interaction.client as Client).locales.getText(interaction.guildLocale, "rewardsAlreadyClaimed"));
 
         // acknowledge
         await interaction.editReply((interaction.client as Client).locales.getText(interaction.guildLocale, "rewardsClaimed", { amount: rewardAmount }));

--- a/src/commands/claim.ts
+++ b/src/commands/claim.ts
@@ -7,7 +7,6 @@ import { Client, Command } from "@bastion/tesseract";
 
 import MemberModel from "../models/Member.js";
 import * as numbers from "../utils/numbers.js";
-import * as members from "../utils/members.js";
 
 class ClaimCommand extends Command {
     constructor() {
@@ -43,8 +42,6 @@ class ClaimCommand extends Command {
 
         // check whether already claimed today
         if (today.toDateString() === lastClaimed.toDateString()) return interaction.editReply((interaction.client as Client).locales.getText(interaction.guildLocale, "rewardsAlreadyClaimed"));
-        // otherwise, update last claim date to today
-        memberDocument.lastClaimed = today.getTime();
 
         // generate the base reward
         let rewardAmount = numbers.getRandomInt(42, 128);
@@ -55,12 +52,12 @@ class ClaimCommand extends Command {
         }
 
         // increment claim streak, if they didn't miss their timeframe
-        memberDocument.claimStreak = yesterday.toDateString() === lastClaimed.toDateString() ? memberDocument.claimStreak + 1 : 1;
+        let claimStreak = yesterday.toDateString() === lastClaimed.toDateString() ? memberDocument.claimStreak + 1 : 1;
 
         // check whether member has completed the streak
-        if (memberDocument.claimStreak === 7) {
+        if (claimStreak === 7) {
             // reset claim streak
-            memberDocument.claimStreak = 0;
+            claimStreak = 0;
             // bonus reward
             rewardAmount += numbers.getRandomInt(512, 1024);
         }
@@ -70,11 +67,14 @@ class ClaimCommand extends Command {
             rewardAmount *= 2;
         }
 
-        // credit reward amount into member's account
-        members.updateBalance(memberDocument, rewardAmount);
-
-        // save document
-        await memberDocument.save();
+        // credit the reward and update the streak atomically so a concurrent XP writer isn't clobbered
+        await MemberModel.updateOne({
+            user: interaction.user.id,
+            guild: interaction.guild.id,
+        }, {
+            $inc: { balance: rewardAmount },
+            $set: { lastClaimed: today.getTime(), claimStreak },
+        });
 
         // acknowledge
         await interaction.editReply((interaction.client as Client).locales.getText(interaction.guildLocale, "rewardsClaimed", { amount: rewardAmount }));


### PR DESCRIPTION
Two fixes to the `/claim` daily-reward command.

- **Atomic reward write:** credit the reward with `$inc` and `$set` the streak fields (`lastClaimed`, `claimStreak`) directly, instead of load-mutate-`save()`. The old read-modify-write emitted `$set balance` from a stale read, so a concurrent balance increment — e.g. a level-up currency reward from the message or voice XP paths — that landed between the `findOne` and the `save` was silently dropped.
- **Double-claim guard:** make the write conditional on `lastClaimed` still being before today (`$not: { $gte: startOfToday }`, which also matches a never-claimed member whose field is unset), and reply "already claimed" when nothing matched. Two concurrent `/claim` invocations previously both passed the read-then-check date guard and each credited a reward; only the first now gets through.

Scope is limited to `claim.ts` — the analogous `give.ts` was intentionally left as-is (admin-only, and its negative "take" amounts rely on the 0-floor clamp).

#### References
<!-- none -->

#### Checklist
- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)