### PR TITLE
chore(ci): bump checkout and setup-node actions to v5

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
`actions/checkout@v3` and `actions/setup-node@v3` run on Node 20, which GitHub Actions has deprecated on its runners, printing a version warning on every job (unrelated to the workflow's own `node-version` matrix, which was already 24.x). Both v5 releases run on Node 24 directly.

#### References
<!-- No linked issues. -->

#### Checklist
- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)