### PR TITLE
perf: index the guild scoped database reads

### DIFF
--- a/src/commands/config/select-roles/update.ts
+++ b/src/commands/config/select-roles/update.ts
@@ -82,12 +82,12 @@ class SelectRolesUpdateCommand extends Command {
         if (selectRolesMessage) {
             // update roles in select roles group
             const roleDocuments = await RoleModel.find({
-                $or: selectRoleGroup.roles.map(id => ({ id })),
+                _id: { $in: selectRoleGroup.roles },
             });
 
             const selectRoles = selectRoleGroup.roles.map(id => {
                 const role = interaction.guild.roles.cache.get(id);
-                const roleDocument = roleDocuments.find(r => r.id === id);
+                const roleDocument = roleDocuments.find(r => r._id === id);
 
                 return {
                     value: id,

--- a/src/commands/leaderboard.ts
+++ b/src/commands/leaderboard.ts
@@ -31,7 +31,7 @@ class LeaderboardCommand extends Command {
                 balance: -1,
             },
             limit: 5,
-        });
+        }).lean();
 
         // check whether member documents have been created
         if (!members.length) return interaction.editReply((interaction.client as Client).locales.getText(interaction.guildLocale, "profilesNotCreated"));

--- a/src/components/SelectRolesUpdateSelect.ts
+++ b/src/components/SelectRolesUpdateSelect.ts
@@ -47,12 +47,12 @@ class SelectRolesUpdateSelectMenu extends MessageComponent {
             await selectRoleGroup.save();
 
             const roleDocuments = await RoleModel.find({
-                $or: selectRoleGroup.roles.map(id => ({ id })),
+                _id: { $in: selectRoleGroup.roles },
             });
 
             const selectRoles = selectRoleGroup.roles.map(id => {
                 const role = interaction.guild.roles.cache.get(id);
-                const roleDocument = roleDocuments.find(r => r.id === id);
+                const roleDocument = roleDocuments.find(r => r._id === id);
 
                 return {
                     value: id,

--- a/src/listeners/clientReady.ts
+++ b/src/listeners/clientReady.ts
@@ -14,13 +14,15 @@ class ClientReadyListener extends Listener<"clientReady"> {
 
     public async exec(client: Client<true>): Promise<void> {
         // get all the guild documents
-        const guildDocuments = await GuildModel.find({}, "id").catch(Logger.error);
+        const guildDocuments = await GuildModel.find({}, "_id").lean().catch(Logger.error);
 
         if (guildDocuments) {
+            const knownGuilds = new Set(guildDocuments.map(doc => doc._id));
+
             // get all the guilds that don't have a document
             const newGuilds = client.guilds.cache
-                .map(g => ({ _id: g.id }))
-                .filter(g => !guildDocuments.some(doc => doc._id === g._id));
+                .filter(g => !knownGuilds.has(g.id))
+                .map(g => ({ _id: g.id }));
 
             // create the documents for the new guilds
             if (newGuilds.length) {

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -1,11 +1,18 @@
 /*!
  * @author TRACTION (iamtraction)
- * @copyright 2022
+ * @copyright 2026
  */
+import mongoose from "mongoose";
 import { Logger } from "@bastion/tesseract";
-import { MongoClient } from "mongodb";
 import dotenv from "dotenv";
 
+import GiveawayModel from "./models/Giveaway.js";
+import GuildModel from "./models/Guild.js";
+import MemberModel from "./models/Member.js";
+import PollModel from "./models/Poll.js";
+import RoleModel from "./models/Role.js";
+import SelectRoleGroupModel from "./models/SelectRoleGroup.js";
+import TriggerModel from "./models/Trigger.js";
 import Settings from "./utils/settings.js";
 
 // configure dotenv
@@ -13,172 +20,76 @@ dotenv.config();
 
 // init
 const settings = new Settings();
-const client = new MongoClient(settings?.mongoURI);
+
+// every model whose indexes are managed by this script
+const models = [
+    GiveawayModel,
+    GuildModel,
+    MemberModel,
+    PollModel,
+    RoleModel,
+    SelectRoleGroupModel,
+    TriggerModel,
+];
 
 // commands
 const Commands = {
-    Filters: "filters",
-    v10: "v10",
+    Indexes: "indexes",
 };
 
-const v10 = async () => {
-    await client.connect();
-    const db = client.db();
+// `npm run` strips anything that looks like a flag unless it's passed after a
+// `--` separator, so the destructive mode is opted into with a plain word
+const APPLY = "apply";
 
-    // Case
-    if (await db.collection("cases").findOne()) {
-        Logger.info("Dropping Case collection...");
-        await db.collection("cases").drop();
-        Logger.info("Dropped Case collection.");
+/**
+ * Makes the indexes in MongoDB match the ones declared in the schemas.
+ *
+ * Indexes declared in a schema are built automatically when a shard boots, but
+ * indexes that were *removed* from a schema are never dropped. This reconciles
+ * both directions, so index changes don't have to be applied by hand.
+ *
+ * Anything not declared in a schema is dropped, so this only reports what it
+ * intends to do until the changes are explicitly applied.
+ * @param apply Whether to apply the changes, instead of only reporting them.
+ */
+const indexes = async (apply: boolean): Promise<void> => {
+    // `autoIndex` builds the schema indexes as soon as a model is used against a
+    // live connection, which would apply half the changes before reporting them
+    await mongoose.connect(settings.mongoURI, { autoIndex: false });
+
+    let changes = 0;
+
+    for (const model of models) {
+        const collection = model.collection.name;
+        const { toDrop, toCreate } = await model.diffIndexes({ indexOptionsToCreate: true });
+
+        if (!toDrop.length && !toCreate.length) continue;
+
+        changes += toDrop.length + toCreate.length;
+
+        for (const name of toDrop) {
+            Logger.info(`${ collection }: drop ${ name }`);
+        }
+
+        for (const [ keys, options ] of toCreate) {
+            Logger.info(`${ collection }: create ${ JSON.stringify(keys) } ${ JSON.stringify(options) }`);
+        }
+
+        if (apply) await model.syncIndexes();
     }
 
-    // Config
-    if (await db.collection("configs").findOne()) {
-        Logger.info("Dropping Config collection...");
-        await db.collection("configs").drop();
-        Logger.info("Dropped Config collection.");
-    }
+    if (!changes) return Logger.info("Every collection is already in sync.");
 
-    // Giveaway
-    if (await db.collection("giveaways").findOne()) {
-        Logger.info("Dropping Giveaway collection...");
-        await db.collection("giveaways").drop();
-        Logger.info("Dropped Giveaway collection.");
-    }
+    if (apply) return Logger.info(`Applied ${ changes } index changes.`);
 
-    // Guild
-    if (await db.collection("guilds").findOne()) {
-        Logger.info("Migrating Guild documents...");
-        const Guild = db.collection("guilds");
-        await Guild.updateMany({}, {
-            $rename: {
-                moderationLogChannelId: "moderationLogChannel",
-                serverLogChannelId: "serverLogChannel",
-                suggestionsChannelId: "suggestionsChannel",
-                starboardChannelId: "starboardChannel",
-                reportsChannelId: "reportsChannel",
-                streamerRoleId: "streamerRole",
-                verifiedRoleId: "verifiedRole",
-            },
-            $unset: {
-                announcementsChannelId: 1,
-                chat: 1,
-                disabled: 1,
-                disabledCommands: 1,
-                farewell: 1,
-                filters: 1,
-                gambling: 1,
-                gamification: 1,
-                greeting: 1,
-                infractions: 1,
-                language: 1,
-                membersOnly: 1,
-                mentionSpam: 1,
-                moderationCaseCount: 1,
-                music: 1,
-                reactionAnnouncements: 1,
-                reactionPinning: 1,
-                referralsChannel: 1,
-                streamers: 1,
-                voiceSessions: 1,
-            },
-        });
-        Logger.info("Migrated Guild documents.");
-    }
-
-    // Member
-    // if (await db.collection("members").findOne()) {}
-
-    // Playlist
-    if (await db.collection("playlists").findOne()) {
-        Logger.info("Dropping Playlist collection...");
-        await db.collection("playlists").drop();
-        Logger.info("Dropped Playlist collection.");
-    }
-
-    // Poll
-    if (await db.collection("polls").findOne()) {
-        Logger.info("Dropping Poll collection...");
-        await db.collection("polls").drop();
-        Logger.info("Dropped Poll collection.");
-    }
-
-    // ReactionRoleGroup
-    if (await db.collection("reactionrolegroups").findOne()) {
-        Logger.info("Dropping ReactionRoleGroup collection...");
-        await db.collection("reactionrolegroups").drop();
-        Logger.info("Dropped ReactionRoleGroup collection.");
-    }
-
-    // Role
-    if (await db.collection("roles").findOne()) {
-        Logger.info("Migrating Role documents...");
-        const Role = db.collection("roles");
-        await Role.updateMany({}, {
-            $unset: {
-                autoAssignable: 1,
-                blacklisted: 1,
-                disabledCommands: 1,
-                emoji: 1,
-            }
-        });
-        Logger.info("Migrated Role documents.");
-    }
-
-    // TextChannel
-    if (await db.collection("textchannels").findOne()) {
-        Logger.info("Dropping TextChannel collection...");
-        await db.collection("textchannels").drop();
-        Logger.info("Dropped TextChannel collection.");
-    }
-
-    // Trigger
-    if (await db.collection("triggers").findOne()) {
-        Logger.info("Dropping Trigger collection...");
-        await db.collection("triggers").drop();
-        Logger.info("Dropped Trigger collection.");
-    }
-
-    // User
-    if (await db.collection("users").findOne()) {
-        Logger.info("Dropping User collection...");
-        await db.collection("users").drop();
-        Logger.info("Dropped User collection.");
-    }
+    Logger.info(`${ changes } index changes are pending. Re-run with "${ APPLY }" to apply them.`);
 };
 
-const filters = async () => {
-    await client.connect();
-    const db = client.db();
+const main = async (): Promise<void> => {
+    const [ , , command, ...flags ] = process.argv;
 
-    // Message Filters
-    Logger.info("Deleting Filters...");
-    const Guild = db.collection("guilds");
-    await Guild.updateMany({}, {
-        $unset: {
-            // invite filter
-            inviteFilter: 1,
-            inviteFilterWarnings: 1,
-            inviteFilterExemptions: 1,
-            // link filter
-            linkFilter: 1,
-            linkFilterWarnings: 1,
-            linkFilterExemptions: 1,
-            // message filter
-            messageFilter: 1,
-            messageFilterWarnings: 1,
-            messageFilterPatterns: 1,
-        },
-    });
-    Logger.info("Deleted Filters.");
-};
-
-const main = () => {
-    const [ , , command ] = process.argv;
-
-    switch (command.toLowerCase()) {
-    case Commands.Filters: return filters();
-    case Commands.v10: return v10();
+    switch (command?.toLowerCase()) {
+    case Commands.Indexes: return await indexes(flags.includes(APPLY));
     default:
         throw new Error("You need to specify a migration command.", {
             cause: "None of the valid commands were used: " + Object.values(Commands).join(" / "),
@@ -191,5 +102,6 @@ main()
     .catch(e => {
         Logger.info("Error when migrating. Join Bastion HQ for support: https://discord.gg/fzx8fkt");
         Logger.error(e);
+        process.exitCode = 1;
     })
-    .finally(() => client.close());
+    .finally(() => mongoose.disconnect());

--- a/src/models/Giveaway.ts
+++ b/src/models/Giveaway.ts
@@ -38,4 +38,11 @@ const giveawaySchema = new mongoose.Schema<Giveaway>({
     },
 });
 
+// the active giveaway count is checked per guild before a new giveaway is
+// created, and the scheduler collects due giveaways for the guilds on the shard
+giveawaySchema.index({
+    guild: 1,
+    ends: 1,
+});
+
 export default mongoose.model<Giveaway>("Giveaway", giveawaySchema);

--- a/src/models/Guild.ts
+++ b/src/models/Guild.ts
@@ -72,8 +72,6 @@ export default mongoose.model<Guild>("Guild", new mongoose.Schema<Guild>({
     },
     greetingChannel: {
         type: String,
-        unique: true,
-        sparse: true,
     },
     greetingMessage: {
         type: String,
@@ -84,8 +82,6 @@ export default mongoose.model<Guild>("Guild", new mongoose.Schema<Guild>({
     },
     farewellChannel: {
         type: String,
-        unique: true,
-        sparse: true,
     },
     farewellMessage: {
         type: String,
@@ -99,13 +95,9 @@ export default mongoose.model<Guild>("Guild", new mongoose.Schema<Guild>({
     },
     musicChannel: {
         type: String,
-        unique: true,
-        sparse: true,
     },
     musicRole: {
         type: String,
-        unique: true,
-        sparse: true,
     },
     gamification: {
         type: Boolean,
@@ -115,8 +107,6 @@ export default mongoose.model<Guild>("Guild", new mongoose.Schema<Guild>({
     },
     gamificationChannel: {
         type: String,
-        unique: true,
-        sparse: true,
     },
     gamificationMultiplier: {
         type: Number,
@@ -138,54 +128,36 @@ export default mongoose.model<Guild>("Guild", new mongoose.Schema<Guild>({
     },
     emailFilterRule: {
         type: String,
-        unique: true,
-        sparse: true,
     },
     inviteFilterRule: {
         type: String,
-        unique: true,
-        sparse: true,
     },
     linkFilterRule: {
         type: String,
-        unique: true,
-        sparse: true,
     },
     starboardChannel: {
         type: String,
-        unique: true,
-        sparse: true,
     },
     starboardThreshold: {
         type: Number,
     },
     moderationLogChannel: {
         type: String,
-        unique: true,
-        sparse: true,
     },
     serverLogChannel: {
         type: String,
-        unique: true,
-        sparse: true,
     },
     serverLogContent: {
         type: Boolean,
     },
     suggestionsChannel: {
         type: String,
-        unique: true,
-        sparse: true,
     },
     reportsChannel: {
         type: String,
-        unique: true,
-        sparse: true,
     },
     streamerRole: {
         type: String,
-        unique: true,
-        sparse: true,
     },
     autoThreadChannels: {
         type: [ String ],
@@ -195,7 +167,8 @@ export default mongoose.model<Guild>("Guild", new mongoose.Schema<Guild>({
     },
     twitchNotificationChannel: {
         type: String,
-        unique: true,
+        // the live stream scheduler selects the few guilds that configured
+        // notifications, so a sparse index keeps that lookup selective
         sparse: true,
     },
     twitchNotificationMessage: {
@@ -215,7 +188,5 @@ export default mongoose.model<Guild>("Guild", new mongoose.Schema<Guild>({
     },
     verifiedRole: {
         type: String,
-        unique: true,
-        sparse: true,
     },
 }));

--- a/src/models/Member.ts
+++ b/src/models/Member.ts
@@ -75,4 +75,14 @@ memberSchema.index({
     unique: true,
 });
 
+// serves the guild leaderboard and the member rank, which filter by guild and
+// order by these fields, in this order
+memberSchema.index({
+    guild: 1,
+    level: -1,
+    experience: -1,
+    karma: -1,
+    balance: -1,
+});
+
 export default mongoose.model<Member>("Member", memberSchema);

--- a/src/models/Poll.ts
+++ b/src/models/Poll.ts
@@ -34,4 +34,11 @@ const pollSchema = new mongoose.Schema<Poll>({
     },
 });
 
+// the active poll count is checked per guild before a new poll is created, and
+// the scheduler collects due polls for the guilds on the shard
+pollSchema.index({
+    guild: 1,
+    ends: 1,
+});
+
 export default mongoose.model<Poll>("Poll", pollSchema);

--- a/src/models/Role.ts
+++ b/src/models/Role.ts
@@ -19,7 +19,7 @@ export interface Role {
     bots?: boolean;
 }
 
-export default mongoose.model<Role>("Role", new mongoose.Schema<Role>({
+const roleSchema = new mongoose.Schema<Role>({
     _id: {
         type: String,
         required: true,
@@ -57,4 +57,13 @@ export default mongoose.model<Role>("Role", new mongoose.Schema<Role>({
     bots: {
         type: Boolean,
     },
-}));
+});
+
+// every role lookup is scoped to a guild, and the level suffix additionally
+// serves the level role queries
+roleSchema.index({
+    guild: 1,
+    level: 1,
+});
+
+export default mongoose.model<Role>("Role", roleSchema);

--- a/src/models/SelectRoleGroup.ts
+++ b/src/models/SelectRoleGroup.ts
@@ -16,7 +16,7 @@ export interface SelectRoleGroup {
     max?: number;
 }
 
-export default mongoose.model<SelectRoleGroup>("SelectRoleGroup", new mongoose.Schema<SelectRoleGroup>({
+const selectRoleGroupSchema = new mongoose.Schema<SelectRoleGroup>({
     _id: {
         type: String,
         required: true,
@@ -47,4 +47,12 @@ export default mongoose.model<SelectRoleGroup>("SelectRoleGroup", new mongoose.S
     max: {
         type: Number,
     },
-}));
+});
+
+// select role groups are listed per guild, optionally narrowed to a channel
+selectRoleGroupSchema.index({
+    guild: 1,
+    channel: 1,
+});
+
+export default mongoose.model<SelectRoleGroup>("SelectRoleGroup", selectRoleGroupSchema);

--- a/src/models/Trigger.ts
+++ b/src/models/Trigger.ts
@@ -29,4 +29,11 @@ const triggerSchema = new mongoose.Schema<Trigger>({
     },
 });
 
+// every message looks up the triggers of its guild, and the pattern suffix
+// also serves trigger removal
+triggerSchema.index({
+    guild: 1,
+    pattern: 1,
+});
+
 export default mongoose.model<Trigger>("Trigger", triggerSchema);

--- a/src/schedulers/giveaways.ts
+++ b/src/schedulers/giveaways.ts
@@ -24,7 +24,7 @@ class GiveawayScheduler extends Scheduler {
 
             // identify giveaways which've reached their timeout
             const giveawayDocuments = await GiveawayModel.find({
-                $or: this.client.guilds.cache.map(g => ({ guild: g.id })),
+                guild: { $in: [ ...this.client.guilds.cache.keys() ] },
                 ends: {
                     $lte: new Date(),
                 },
@@ -106,7 +106,7 @@ class GiveawayScheduler extends Scheduler {
             // remove the completed giveaways
             if (completed.length) {
                 await GiveawayModel.deleteMany({
-                    $or: completed.map(id => ({ _id: id })),
+                    _id: { $in: completed },
                 }).catch(Logger.error);
             }
         } catch (e) {

--- a/src/schedulers/liveStreams.ts
+++ b/src/schedulers/liveStreams.ts
@@ -32,7 +32,7 @@ class LiveStreamNotificationScheduler extends Scheduler {
             if (!this.client.guilds.cache.size) return;
 
             const guildDocuments = await GuildModel.find({
-                $or: this.client.guilds.cache.map(g => ({ _id: g.id })),
+                _id: { $in: [ ...this.client.guilds.cache.keys() ] },
                 twitchNotificationChannel: { $exists: true, $ne: null },
                 twitchNotificationUsers: { $exists: true, $type: "array", $ne: [] },
             });

--- a/src/schedulers/polls.ts
+++ b/src/schedulers/polls.ts
@@ -23,7 +23,7 @@ class PollScheduler extends Scheduler {
 
             // identify polls which've reached their timeout
             const pollDocuments = await PollModel.find({
-                $or: this.client.guilds.cache.map(g => ({ guild: g.id })),
+                guild: { $in: [ ...this.client.guilds.cache.keys() ] },
                 ends: {
                     $lte: new Date(),
                 },
@@ -100,7 +100,7 @@ class PollScheduler extends Scheduler {
             // remove the completed polls
             if (completed.length) {
                 await PollModel.deleteMany({
-                    $or: completed.map(id => ({ _id: id })),
+                    _id: { $in: completed },
                 }).catch(Logger.error);
             }
         } catch (e) {

--- a/src/utils/members.ts
+++ b/src/utils/members.ts
@@ -38,58 +38,44 @@ export const manageable = (moderator: GuildMember, member: GuildMember): boolean
 export const addInfraction = async (member: PartialGuildMember | GuildMember, reason: string) => {
     const guildDocument = await GuildModel.findById(member.guild.id);
 
-    let memberDocument = await MemberModel.findOne({ user: member.id, guild: member.guild.id });
+    // record the infraction in a single atomic upsert, so concurrent warnings
+    // can't both miss an existing document and collide on the unique index
+    const memberDocument = await MemberModel.findOneAndUpdate(
+        { user: member.id, guild: member.guild.id },
+        { $push: { infractions: reason } },
+        { returnDocument: "after", upsert: true },
+    );
 
-    // check whether member document exists
-    if (memberDocument) {
-        // add infraction to member
-        memberDocument.infractions = memberDocument.infractions instanceof Array ? memberDocument.infractions.concat(reason) : [ reason ];
-    } else {
-        // create the member document
-        memberDocument = await MemberModel.create({
-            user: member.id,
-            guild: guildDocument.id,
-            infractions: [ reason ],
-        });
+    const infractionCount = memberDocument.infractions.length;
+
+    if (infractionCount === guildDocument?.infractionsTimeoutThreshold) {
+        await member.timeout(9e5, infractionCount + " infractions");
     }
 
-    if (memberDocument.infractions.length === guildDocument.infractionsTimeoutThreshold) {
-        await member.timeout(9e5, memberDocument.infractions.length + " infractions");
+    if (infractionCount === guildDocument?.infractionsKickThreshold && member.kickable) {
+        await member.kick(infractionCount + " infractions");
     }
 
-    if (memberDocument.infractions.length === guildDocument.infractionsKickThreshold && member.kickable) {
-        await member.kick(memberDocument.infractions.length + " infractions");
-    }
-
-    if (memberDocument.infractions.length === guildDocument.infractionsBanThreshold && member.bannable) {
+    if (infractionCount === guildDocument?.infractionsBanThreshold && member.bannable) {
         await member.ban({
-            reason: memberDocument.infractions.length + " infractions",
+            reason: infractionCount + " infractions",
         });
 
         // clear all infractions once member is banned
-        memberDocument.infractions = [];
+        await clearInfraction(member);
     }
-
-    // save member
-    return memberDocument.save();
 };
 
 /**
- * Clear a member's infraction.
+ * Clear all of a member's infractions.
  * @param member The member.
  */
 export const clearInfraction = async (member: PartialGuildMember | GuildMember) => {
-    const memberDocument = await MemberModel.findOne({ user: member.id, guild: member.guild.id });
-
-    // check whether infractions exist
-    if (memberDocument?.infractions?.length) {
-        // clear all infractions
-        memberDocument.infractions = undefined;
-        delete memberDocument.infractions;
-
-        // save member
-        return memberDocument.save();
-    }
+    // clear the infractions in a single write, instead of reading the document
+    // first and saving it back
+    await MemberModel.updateOne({ user: member.id, guild: member.guild.id }, {
+        $unset: { infractions: 1 },
+    });
 };
 
 /**

--- a/src/utils/members.ts
+++ b/src/utils/members.ts
@@ -152,7 +152,7 @@ export const assignLevelRoles = async (member: GuildMember, level: number): Prom
     const roles = await RoleModel.find({
         guild: member.guild.id,
         level: { $exists: true, $ne: null },
-    });
+    }).lean();
 
     // check whether there are any level up roles
     if (!roles?.length) return;
@@ -167,9 +167,9 @@ export const assignLevelRoles = async (member: GuildMember, level: number): Prom
     // update member roles
     if (levelRoles.length) {
         const memberRoles = member.roles.cache
-            .filter(r => !extraRoles.some(doc => doc.id === r.id))  // remove roles from any other level
+            .filter(r => !extraRoles.some(doc => doc._id === r.id))  // remove roles from any other level
             .map(r => r.id)
-            .concat(levelRoles.map(doc => doc.id)); // add roles in the current level
+            .concat(levelRoles.map(doc => doc._id)); // add roles in the current level
 
         // update member roles
         member.roles.set([ ...new Set(memberRoles) ]).catch(Logger.error);


### PR DESCRIPTION
Audits every Mongoose model against how it is actually queried, and indexes the reads that were being served by collection scans.

Apart from the member `user`/`guild` pair, no collection was indexed for the field nearly every read filters on — `guild`. The leaderboard, the profile rank, the per-message trigger lookup, the auto and self assignable role reads and the select role group listings were all collection scans that grow with the whole collection instead of with the guild. Meanwhile the guild config carried sixteen `unique`/`sparse` indexes that nothing ever reads, because every guild read is a lookup by `_id`.

Verified against MongoDB 8, seeded with the index state as it exists on `dev`. Every shape above now plans as an `IXSCAN`, and the leaderboard has no `SORT` stage at all, because the index supplies the ordering. The sparse index kept on `twitchNotificationChannel` examines 4 keys instead of 5001 at 5000 guilds with 3 configured, and the planner rejects the `_id` plan in its favour.

Two defects surfaced while tracing the queries:

- The select roles menus filtered roles on an `id` field, which is a virtual over `_id` and is never stored, so the filter matched nothing and a role's configured description and emoji were never applied. Confirmed against a live collection: the old filter returns 0 documents where the new one returns the role.
- Adding an infraction read the member document and then either saved it or created one, so concurrent warnings could race and one would fail on the unique member index, losing its infraction. Five concurrent warnings now produce one document with all five infractions and no rejections.

Schema indexes are built when a shard boots, but indexes removed from a schema are never dropped, so `src/migrate.ts` — whose v10 and filters migrations have had no work to do since the first v10 release — is repurposed to reconcile them. It reports by default and only changes anything when passed `apply`.

Run it before deploying this branch:

```
npm run migrate indexes         # report what it would change
npm run migrate indexes apply   # apply
```

Ordering matters only to avoid noise: if the code ships first, the boot-time index build attempts `twitchNotificationChannel_1` as sparse-only while the unique version still exists and logs an `IndexOptionsConflict`. It is not fatal, and the old index simply persists until the migration runs. The `members` index is the expensive build, so prefer a quiet window.

#### References

None.

#### Checklist
- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)
