### PR TITLE
perf(listeners): parse the instant responses once

### DIFF
--- a/src/listeners/messageCreate.ts
+++ b/src/listeners/messageCreate.ts
@@ -19,9 +19,18 @@ import Settings from "../utils/settings.js";
 import * as variables from "../utils/variables.js";
 import * as yaml from "../utils/yaml.js";
 
+interface InstantResponse {
+    messages: string[];
+    responses: (string | string[])[];
+}
+
 class MessageCreateListener extends Listener<"messageCreate"> {
+    private responses: InstantResponse[];
+
     constructor() {
         super("messageCreate");
+
+        this.responses = yaml.parse("data", "responses.yaml") as InstantResponse[];
     }
 
     handleProtection = async (message: Message<true>, guildDocument: GuildDocument): Promise<void> => {
@@ -186,9 +195,7 @@ class MessageCreateListener extends Listener<"messageCreate"> {
     handleInstantResponses = async (message: Message): Promise<void> => {
         if (!message.content) return;
 
-        const responses = yaml.parse("data", "responses.yaml");
-
-        for (const response of responses) {
+        for (const response of this.responses) {
             if (response.messages.includes(message.content.toLowerCase())) {
                 const replies: string | string[] = response.responses[Math.floor(Math.random() * response.responses.length)];
 


### PR DESCRIPTION
`handleInstantResponses` called `yaml.parse("data", "responses.yaml")` on every direct message, and `utils/yaml.ts` is a bare `fs.readFileSync` plus a YAML parse — so each DM did a synchronous disk read and a full parse on the event loop before it could be compared against the responses.

`data/responses.yaml` is static content, so it is now parsed once in the constructor and held on the listener, matching what `guildMemberAdd` and `guildMemberRemove` already do with `greetings.yaml` and `farewells.yaml`. An `InstantResponse` interface documents the shape the handler relies on, which was previously untyped.

Behaviour is unchanged. Editing `data/responses.yaml` now requires a restart to take effect, which was already true of the greetings and farewells.

#### Test Plan

`npm test` (eslint) and `npm run build` pass. Behavioural verification is manual, per `.github/TESTING.md`:

| # | Case | Expected |
|---|---|---|
| 1 | DM the bot `knock knock`, with `relayDirectMessages` unset | Replies with the two-line "Who's there?" response, joined by a newline |
| 2 | DM a message matching an entry with several response groups, repeatedly | A group is picked at random each time, same as before |
| 3 | DM text matching no entry | No reply |
| 4 | DM with no text content (attachment only) | No reply, no error |
| 5 | DM with `relayDirectMessages` set | Message is relayed and no instant response fires |
| 6 | Start the bot with a malformed `data/responses.yaml` | Fails at startup rather than on the first DM — the parse moved into the constructor |

#### References

<!-- Link any applicable issues/pull requests here, with a brief description explaining why. -->

#### Checklist

- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)
