### PR TITLE
perf(triggers): cache the compiled triggers of a server

### DIFF
--- a/src/commands/config/triggers.ts
+++ b/src/commands/config/triggers.ts
@@ -9,6 +9,7 @@ import TriggerModel from "../../models/Trigger.js";
 import { COLORS, isPublicBastion } from "../../utils/constants.js";
 import { parseEmoji } from "../../utils/emojis.js";
 import { checkFeature, Feature, getPremiumTier } from "../../utils/premium.js";
+import { invalidateTriggers } from "../../utils/triggers.js";
 
 class TriggersCommand extends Command {
     constructor() {
@@ -56,6 +57,9 @@ class TriggersCommand extends Command {
                 pattern: remove,
             });
 
+            // clear the trigger cache for the guild
+            invalidateTriggers(interaction.guildId);
+
             return interaction.editReply(`I've deleted the triggers matching **${ remove }**.`);
         }
 
@@ -81,6 +85,9 @@ class TriggersCommand extends Command {
                 message: message,
                 reactions: emoji,
             });
+
+            // clear the trigger cache for the guild
+            invalidateTriggers(interaction.guildId);
 
             return interaction.editReply(`I've add the trigger **${ add }**.`);
         }

--- a/src/listeners/messageCreate.ts
+++ b/src/listeners/messageCreate.ts
@@ -7,7 +7,6 @@ import { Client, Listener, Logger } from "@bastion/tesseract";
 
 import GuildModel, { Guild as GuildDocument } from "../models/Guild.js";
 import MemberModel from "../models/Member.js";
-import TriggerModel from "../models/Trigger.js";
 import { COLORS } from "../utils/constants.js";
 import { generate as generateEmbed } from "../utils/embeds.js";
 import * as gamification from "../utils/gamification.js";
@@ -16,6 +15,7 @@ import memcache from "../utils/memcache.js";
 import { evaluateMessage } from "../utils/protection/index.js";
 import * as regex from "../utils/regex.js";
 import Settings from "../utils/settings.js";
+import { getTriggers } from "../utils/triggers.js";
 import * as variables from "../utils/variables.js";
 import * as yaml from "../utils/yaml.js";
 
@@ -87,16 +87,15 @@ class MessageCreateListener extends Listener<"messageCreate"> {
     };
 
     handleTriggers = async (message: Message<true>): Promise<unknown> => {
-        const triggers = await TriggerModel.find({ guild: message.guild.id });
+        const triggers = await getTriggers(message.guildId);
+        if (!triggers.length) return;
 
         // responses
         const responseMessages: string[] = [];
         const responseReactions: string[] = [];
 
         for (const trigger of triggers) {
-            const patternRegExp = new RegExp(trigger.pattern.replace(/\?/g, ".").replace(/\*+/g, ".*"), "ig");
-
-            if (!patternRegExp.test(message.content)) continue;
+            if (!trigger.pattern.test(message.content)) continue;
 
             if (trigger.message) {
                 responseMessages.push(trigger.message);

--- a/src/listeners/messageCreate.ts
+++ b/src/listeners/messageCreate.ts
@@ -87,6 +87,8 @@ class MessageCreateListener extends Listener<"messageCreate"> {
     };
 
     handleTriggers = async (message: Message<true>): Promise<unknown> => {
+        if (!message.content) return;
+
         const triggers = await getTriggers(message.guildId);
         if (!triggers.length) return;
 

--- a/src/utils/triggers.ts
+++ b/src/utils/triggers.ts
@@ -1,0 +1,48 @@
+/*!
+ * @author TRACTION (iamtraction)
+ * @copyright 2026
+ */
+import { Snowflake } from "discord.js";
+
+import TriggerModel from "../models/Trigger.js";
+import memcache from "./memcache.js";
+
+// a trigger with its glob pattern already compiled
+export interface CompiledTrigger {
+    pattern: RegExp;
+    message?: string;
+    reactions?: string;
+}
+
+const CACHE_LIFETIME = 60;
+
+const cacheKey = (guild: Snowflake): string => `triggers:${ guild }`;
+
+/**
+ * Get the compiled triggers of a server, from the cache whenever possible.
+ * @param guild The identifier of the server.
+ */
+export const getTriggers = async (guild: Snowflake): Promise<CompiledTrigger[]> => {
+    const cached = memcache.get(cacheKey(guild)) as CompiledTrigger[];
+    if (cached) return cached;
+
+    const triggers = await TriggerModel.find({ guild });
+
+    const compiled = triggers.map(trigger => ({
+        pattern: new RegExp(trigger.pattern.replace(/\?/g, ".").replace(/\*+/g, ".*"), "i"),
+        message: trigger.message,
+        reactions: trigger.reactions,
+    }));
+
+    memcache.set(cacheKey(guild), compiled, CACHE_LIFETIME);
+
+    return compiled;
+};
+
+/**
+ * Discard the cached triggers of a server, once they've been edited.
+ * @param guild The identifier of the server.
+ */
+export const invalidateTriggers = (guild: Snowflake): void => {
+    memcache.delete(cacheKey(guild));
+};


### PR DESCRIPTION
`handleTriggers` ran for every message in every server, and its first act was `TriggerModel.find({ guild })` — a database round trip per message — followed by a `new RegExp(...)` compile per trigger. Most servers have no triggers configured, so the common case was paying a query to learn there was nothing to do, on the hottest path in the bot. The `{ guild: 1, pattern: 1 }` index makes that query cheap, but a round trip is still a round trip.

The triggers of a server are now read and compiled once, held in `memcache`, and discarded when a trigger is added or removed. A server lives on a single shard and its `/config triggers` interaction is handled by that same shard, so discarding the cache in process reaches the copy that went stale — no `broadcastEval` needed. The 60 minute lifetime is only a backstop, and it doubles as eviction for servers that have gone quiet, so the cache doesn't retain every server a shard has ever seen. Plain objects are cached rather than Mongoose documents, so an entry is a `RegExp` and two strings per trigger.

Per message, for a server with N triggers: a query plus N compiles becomes a map lookup plus N `test` calls. For a server with none: a query becomes a map lookup and an early return.

Two smaller changes ride along, each as its own commit:

- **The patterns are no longer compiled with the global flag.** It was harmless while a new expression was compiled per message, but a *cached* global expression resumes from its previous `lastIndex`, so it would have matched, then skipped the next message, then matched again.
- **Messages with no text content are ignored.** This is a behaviour change: a pattern which matches an empty string — `*`, most obviously — used to respond to attachment-only, sticker-only and embed-only messages, and no longer does. Any pattern containing actual characters could never have matched empty content, so nothing else is affected. The three sibling handlers already return early on a message without content.

#### Notes for review

- **A cold cache is not deduplicated.** Messages arriving while the first query is in flight each start their own, so a cold burst can cost a few queries instead of one. Not a regression — the old code queried on every message unconditionally — and it happens at most once per server per lifetime. Closing it means caching the in-flight promise and evicting it on rejection, which was judged not worth the subtlety for now.
- **`memcache.set` does not cancel a superseded timer** (`utils/memcache.ts:16-24`), so after an invalidation the original timer still fires and drops whatever is cached under that key. The effect is one extra read and never stale data. It is a pre-existing property that also affects the XP cooldown and starboard keys, and is left for a separate change to `Memcache`.
- **Unrelated, but noted while here:** trigger patterns are only glob-translated (`?` → `.`, `*` → `.*`), so every other regular expression metacharacter reaches `RegExp` unescaped. A member with Manage Server can install a catastrophically backtracking pattern that runs against every message. Caching makes it cheaper to reach, not safer.

#### Test Plan

`npm test` (eslint) and `npm run build` pass, and the branch compiles at each commit. Behavioural verification is manual, per `.github/TESTING.md`.

| # | Case | Expected |
|---|---|---|
| 1 | Server with no triggers, ordinary chatter | No response, and no query per message after the first |
| 2 | `/config triggers add:hello* message:Hi there`, then post `hello world` | Responds. The new trigger takes effect immediately, without waiting out the lifetime |
| 3 | Post `hello world` repeatedly | Responds every time — the guard against the global flag regression |
| 4 | `/config triggers remove:hello*`, then post `hello world` | No response, immediately |
| 5 | Trigger with an emoji response | Reacts, as before |
| 6 | Trigger matching with several message responses configured | One is picked at random, as before |
| 7 | `?` and `*` in a pattern, e.g. `h?llo` and `*bye*` | Match as before |
| 8 | Case-insensitive match, e.g. `HELLO WORLD` | Responds — the `i` flag is retained |
| 9 | A `*` trigger, then post an attachment with no text | **No response** — the intended behaviour change |
| 10 | A `*` trigger, then post any text | Responds |
| 11 | Two servers on one shard with different triggers | Each matches only its own — cache is keyed per server |
| 12 | Add a trigger, wait past 60 minutes, post a match | Still responds; the cache refills on the next miss |

#### References

<!-- Link any applicable issues/pull requests here, with a brief description explaining why. -->

#### Checklist

- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)
