### PR TITLE
fix(triggers): match the trigger patterns as globs

### DIFF
--- a/src/listeners/messageCreate.ts
+++ b/src/listeners/messageCreate.ts
@@ -15,7 +15,7 @@ import memcache from "../utils/memcache.js";
 import { evaluateMessage } from "../utils/protection/index.js";
 import * as regex from "../utils/regex.js";
 import Settings from "../utils/settings.js";
-import { getTriggers } from "../utils/triggers.js";
+import { getTriggers, matches } from "../utils/triggers.js";
 import * as variables from "../utils/variables.js";
 import * as yaml from "../utils/yaml.js";
 
@@ -92,12 +92,14 @@ class MessageCreateListener extends Listener<"messageCreate"> {
         const triggers = await getTriggers(message.guildId);
         if (!triggers.length) return;
 
+        const content = message.content.toUpperCase();
+
         // responses
         const responseMessages: string[] = [];
         const responseReactions: string[] = [];
 
         for (const trigger of triggers) {
-            if (!trigger.pattern.test(message.content)) continue;
+            if (!matches(trigger, content)) continue;
 
             if (trigger.message) {
                 responseMessages.push(trigger.message);

--- a/src/utils/triggers.ts
+++ b/src/utils/triggers.ts
@@ -7,9 +7,10 @@ import { Snowflake } from "discord.js";
 import TriggerModel from "../models/Trigger.js";
 import memcache from "./memcache.js";
 
-// a trigger with its glob pattern already compiled
+// a trigger whose pattern has been split into the literal segments between its
+// `*` wildcards, each of which may still contain `?` wildcards
 export interface CompiledTrigger {
-    pattern: RegExp;
+    segments: string[];
     message?: string;
     reactions?: string;
 }
@@ -17,6 +18,55 @@ export interface CompiledTrigger {
 const CACHE_LIFETIME = 60;
 
 const cacheKey = (guild: Snowflake): string => `triggers:${ guild }`;
+
+/**
+ * Whether the segment matches the text at the specified position, where a `?`
+ * in the segment matches any single character.
+ */
+const matchesAt = (segment: string, text: string, position: number): boolean => {
+    for (let i = 0; i < segment.length; i++) {
+        if (segment[i] !== "?" && segment[i] !== text[position + i]) return false;
+    }
+
+    return true;
+};
+
+/**
+ * The first position at or after the specified one where the segment matches,
+ * or `-1` if it doesn't match anywhere.
+ */
+const indexOfSegment = (segment: string, text: string, from: number): number => {
+    // a segment without a wildcard is searched natively, which is the common case
+    if (!segment.includes("?")) return text.indexOf(segment, from);
+
+    for (let position = from; position + segment.length <= text.length; position++) {
+        if (matchesAt(segment, text, position)) return position;
+    }
+
+    return -1;
+};
+
+/**
+ * Whether the pattern of the trigger matches the specified text.
+ *
+ * The segments are separated by `*`, so they only have to appear in order,
+ * anywhere in the text, and none of them is ever matched twice — which is what
+ * keeps a pattern from being able to make matching expensive.
+ * @param trigger The compiled trigger to match.
+ * @param text The text to match it against.
+ */
+export const matches = (trigger: CompiledTrigger, text: string): boolean => {
+    let cursor = 0;
+
+    for (const segment of trigger.segments) {
+        const position = indexOfSegment(segment, text, cursor);
+        if (position < 0) return false;
+
+        cursor = position + segment.length;
+    }
+
+    return true;
+};
 
 /**
  * Get the compiled triggers of a server, from the cache whenever possible.
@@ -29,7 +79,7 @@ export const getTriggers = async (guild: Snowflake): Promise<CompiledTrigger[]> 
     const triggers = await TriggerModel.find({ guild });
 
     const compiled = triggers.map(trigger => ({
-        pattern: new RegExp(trigger.pattern.replace(/\?/g, ".").replace(/\*+/g, ".*"), "i"),
+        segments: trigger.pattern.toUpperCase().split(/\*+/).filter(Boolean),
         message: trigger.message,
         reactions: trigger.reactions,
     }));


### PR DESCRIPTION
A trigger pattern had only its `?` and `*` translated before it was handed to `RegExp`, so every other metacharacter reached the expression unescaped. Nothing in the command, the locales or the command definitions ever described a pattern as a regular expression — the only syntax implied is `?` and `*` — so the pattern is now matched as the glob it claims to be.

Three problems went with the old approach:

- **A pattern didn't match what was typed.** A trigger for `1+1` matched `11`, one for `a.b` matched `axb`, and one for `c++` didn't work at all.
- **An invalid pattern silently disabled the feature.** `/config triggers add:+` stores fine, `new RegExp("+")` throws, the throw is swallowed by the handler's `catch`, and *every* trigger in that server stops responding with nothing surfaced to anyone.
- **A pattern could stall a shard.** Nested quantifiers such as `(a+)+b` were stored verbatim and matched against every message in the server. Node is single threaded, so catastrophic backtracking blocks every server on that shard, not just the one that configured it. Manage Server is not a trustworthy boundary on a public bot. Measured, matching `(a+)+b` against a message of N `a` characters:

  | N | before | after |
  |---|---|---|
  | 20 | 56 ms | 0.05 ms |
  | 24 | 138 ms | 0.006 ms |
  | 28 | 2,142 ms | 0.009 ms |
  | 32 | 34,547 ms | 0.006 ms |
  | 2000 (the message limit) | never returned, killed at 120 s | 0.012 ms |

  The cost doubles about every two characters, so a 32 character message blocks the event loop for half a minute and a full length message never finishes. The pattern is literal text now, found with a single `indexOf`.

Escaping the metacharacters would have fixed the first two, but a pattern like `*a*a*a*a*b` is ten characters and still backtracks, which would have needed an arbitrary cap on wildcards. So matching no longer uses a regular expression at all.

The pattern is split on runs of `*` into literal segments, which — because `*` matches anything and matching is unanchored — only have to appear **in order**. Each is located by a greedy leftmost search from a cursor that only moves forward, so nothing is ever matched twice and no pattern can make matching expensive. A segment with no `?` is found with native `String.indexOf`; one containing `?` uses a fixed width compare, since `?` is exactly one character. Worst case is bounded at pattern length × message length, and the common case is a single `indexOf`, which is faster than the regular expression it replaces. Cache entries are now plain strings rather than `RegExp` objects.

Case insensitivity is done by folding both sides with `toUpperCase`, which is the operation a case insensitive regular expression is defined in terms of, so everything the expression treated as equal is still equal. Lower-folding would have quietly dropped the Greek final sigma equivalence.

#### Behaviour changes

Every plain-glob pattern behaves identically — verified against the previous implementation over 400,000 randomly generated pattern/text pairs with zero divergence, plus the hand-written cases below. What changes:

| Pattern | Text | Before | After |
|---|---|---|---|
| `1+1` | `11` | matched | no match — `+` is literal now |
| `1+1` | `1+1=2` | no match | matches |
| `a.b` | `axb` | matched | no match — `.` is literal now |
| `(hi\|hey)` | `hi` | matched | no match — alternation is literal now |
| `c++` | anything | threw, disabling every trigger in the server | matches the literal text `c++` |
| `hi*there` | `hi⏎there` | no match | matches — wildcards cross line breaks |
| `σ`, `ı`, `ß` | `ς`, `I`, `SS` | sigma matched, the others didn't | all match |

Servers relying on regular expression syntax deliberately — `^hello`, `(hi|hey)`, `\d+` — will see those patterns become literal. That is the intended correction, since the feature was never documented as taking a regular expression, but it's the one thing worth mentioning in the release notes.

#### Test Plan

`npm test` (eslint) and `npm run build` pass, and the branch compiles at each commit. Matching was verified against the previous implementation with a throwaway script (not committed): 400,000 random `a b c ? *` patterns against random texts, zero differences, plus the table above. Behavioural verification is manual, per `.github/TESTING.md`.

| # | Case | Expected |
|---|---|---|
| 1 | `add:hello message:Hi`, post `well hello there` | Responds — matching is still unanchored |
| 2 | `add:hello*world`, post `hello big world` | Responds; `world hello` does not |
| 3 | `add:h?llo`, post `hallo` and `hllo` | First responds, second doesn't |
| 4 | `add:*bye*`, post `ok bye then` | Responds |
| 5 | `add:HELLO`, post `hello` | Responds — folding is case insensitive |
| 6 | `add:1+1`, post `1+1=2` and `11` | First responds, second doesn't |
| 7 | `add:c++`, post `i love c++` | Responds. Previously this pattern threw and disabled every trigger in the server |
| 8 | `add:+` on its own, then post anything | No response, no error, and the other triggers in the server keep working |
| 9 | `add:(a+)+b`, then post 2000 characters of `a` | Responds only to the literal text `(a+)+b`; the shard stays responsive |
| 10 | `add:hi*there`, post `hi` newline `there` | Responds — the wildcard crosses the line break |
| 11 | Emoji response trigger | Reacts, as before |
| 12 | Trigger with several message responses | One is picked at random, as before |
| 13 | Add and remove a trigger, posting a match after each | Takes effect immediately both ways |
| 14 | Two servers on one shard with different triggers | Each matches only its own |

#### References

Follows #1113, which moved the pattern compile behind a cache and noted this exposure for a separate change.

#### Checklist

- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)


