### PR TITLE
fix(utils): keep the cache expiries cancellable

### DIFF
--- a/src/utils/memcache.ts
+++ b/src/utils/memcache.ts
@@ -4,38 +4,50 @@
  */
 class Memcache {
     private store: Map<string, unknown>;
+    private expiries: Map<string, NodeJS.Timeout>;
 
     constructor() {
         this.store = new Map<string, unknown>();
+        this.expiries = new Map<string, NodeJS.Timeout>();
     }
+
+    private cancel = (key: string): void => {
+        clearTimeout(this.expiries.get(key));
+        this.expiries.delete(key);
+    };
 
     public get = (key: string): unknown => {
         return this.store.get(key);
     };
 
     public set = (key: string, value: unknown, minutes?: number): boolean => {
+        this.cancel(key);
         this.store.set(key, value);
 
         if (minutes) {
-            setTimeout(() => this.store.delete(key), minutes * 6e4).unref();
+            this.expiries.set(key, setTimeout(() => this.delete(key), minutes * 6e4).unref());
         }
 
         return true;
     };
 
     public delete = (key: string): unknown => {
+        if (!this.store.has(key)) return null;
+
         const item = this.store.get(key);
 
-        if (item) {
-            this.store.delete(key);
-            return item;
-        }
+        this.cancel(key);
+        this.store.delete(key);
 
-        return null;
+        return item;
     };
 
     public clear = (): boolean => {
+        for (const expiry of this.expiries.values()) clearTimeout(expiry);
+
+        this.expiries.clear();
         this.store.clear();
+
         return true;
     };
 }


### PR DESCRIPTION
`Memcache` scheduled an item's expiry with `setTimeout` and threw the handle away, so nothing could ever cancel it — and the callback closed over the *key*, not over the value it was scheduled for. Three consequences:

- **Writing to a key added a second expiry instead of replacing the first.** A value written at minute 59 of a 60 minute lifetime inherited the original entry's one minute remainder. A lifetime meant "N minutes from the *first* write", not from this one.
- **Deleting a key left its expiry armed.** The orphaned timer fired later and deleted whatever had been cached under that key since.
- **A falsy value could never be deleted.** `delete` tested `if (item)` rather than the key's presence, so a cached `false`, `0` or `""` stayed in the store and `delete` reported `null` as though it had never been there.

Nothing served stale data — items only ever expired *early* — but early expiry matters in two places. `utils/protection/index.ts:140` caches the action already taken against a member, which is what stops one spam burst producing a second incident and a second moderation log entry, and `:216` caches a moderator's pardon. Both windows could end before their time.

The expiries are now tracked per key and cancelled whenever the key is written or deleted, or the cache is cleared, so a lifetime means what every call site already assumed. `delete` gates on the key's presence instead of the item's truthiness. No consumer needed changing: the semantics only move in the direction they were already relying on.

#### Notes for review

- No consumer is affected by the reset-on-overwrite change, because every one of them reads before it writes — `ACTED_KEY` is set only past the early return at `protection/index.ts:111`, and the xp cooldown and starboard keys are guarded by a `get`. The fix removes a latent hazard rather than altering current behaviour.
- `schedulers/liveStreams.ts:23` is the only writer that passes no lifetime, and its key never gets one, so cancelling on write is a no-op there.
- `minutes = 0` still means "no expiry", unchanged. It is now marginally sharper as a footgun, since `set(key, value, 0)` after a lifetimed write makes the entry permanent rather than inheriting the old expiry. No caller passes zero; the smallest lifetime in the codebase is `30 / 60`.
- Still one timer per key, which this doesn't change. At 100,000 lifetimed keys that model costs 36.8 MB of heap and 60.1 MB of RSS, against 14.2 MB for an `expiresAt` per entry swept periodically. No current key space comes close to that — the largest are bounded by messages per 30 seconds, servers per shard, and patrons — so it's noted for later rather than fixed here.

#### Test Plan

`npm test` (eslint) and `npm run build` pass. Behaviour was checked with a throwaway script (not committed) covering each defect, run against both this implementation and the one on `dev`:

| # | Case | Before | After |
|---|---|---|---|
| 1 | `set` a key, re-`set` it near the end of its lifetime, read it past the original expiry | Gone — the first timer deleted the new value | Present |
| 2 | Re-set key still expires at its own lifetime | — | Gone, as expected |
| 3 | `set`, `delete`, `set` again with a longer lifetime, read past the original expiry | Gone — the orphaned timer deleted the new value | Present |
| 4 | `delete` a key holding `false` | Still in the store | Removed |
| 5 | Return value of that `delete` | `null` | `false` |
| 6 | `delete` a key which isn't cached | `null` | `null` |
| 7 | `set`, `clear`, `set` again, read past the first lifetime | Gone — the timer survived the clear | Present |

Cases 1, 3, 4, 5 and 7 fail on `dev` and pass here.

Manual verification against a running bot, per `.github/TESTING.md`:

| # | Case | Expected |
|---|---|---|
| 8 | Trigger a protection incident, then have the same member keep spamming | One incident and one moderation log entry, with no second report when the suppression window would previously have lapsed early |
| 9 | Pardon a member from a report, then have them post again inside the pardon window | No new action taken |
| 10 | Add a trigger, post a match, edit the triggers again, post another match | Both respond; the cache refills correctly after each invalidation |
| 11 | Gain xp, then keep talking for a minute | Xp is awarded at the same rate as before |
| 12 | Star a message past the threshold twice | Posted to the starboard once |

#### References

Noted while reviewing #1113, which relies on `delete` to invalidate its cache.

#### Checklist

- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)
