### PR TITLE
perf(gamification): check that gamification is enabled first

### DIFF
--- a/src/listeners/messageCreate.ts
+++ b/src/listeners/messageCreate.ts
@@ -38,6 +38,9 @@ class MessageCreateListener extends Listener<"messageCreate"> {
     };
 
     handleGamification = async (message: Message<true>, guildDocument: GuildDocument): Promise<void> => {
+        // check whether gamification is enabled
+        if (!guildDocument.gamification) return;
+
         const key = `xp:${ message.guildId }:${ message.author.id }`;
 
         // check whether the member had recently gained XP
@@ -49,9 +52,6 @@ class MessageCreateListener extends Listener<"messageCreate"> {
             {},
             { returnDocument: "after", upsert: true },
         );
-
-        // check whether gamification is enabled
-        if (!guildDocument.gamification) return;
 
         // check whether member has exceeded max level or experience
         if (memberDocument.level >= gamification.MAX_LEVEL || memberDocument.experience >= gamification.MAX_EXPERIENCE(guildDocument.gamificationMultiplier)) return;


### PR DESCRIPTION
`handleGamification` upserted the member's document *before* it checked whether gamification was enabled, then returned without using the result. So in every server with gamification disabled, each active member caused a database **write** per message — rate limited only by the thirty second experience cooldown, which means one wasted upsert per active member per thirty seconds, forever, on the hottest path in the bot.

The check now runs first, before the cache lookup and before anything touches the database.

#### The consequence

That upsert was the only thing which created a `Member` document from chat activity, so with gamification disabled a member who has never had one will not get one, and `/profile` and `/claim` answer "a profile for that user hasn't been created in the server yet".

That reads as a correction rather than a regression: the `profilesNotCreated` string already tells servers *"Make sure gamification is enabled and members are active in the server."* The old behaviour contradicted what the bot itself says. Servers which have already accumulated documents, balances and streaks keep every one of them — only members with no document at all in a gamification-disabled server are affected.

Every consumer of the model was checked before making the change. Eleven files import it, seventeen call sites:

| Consumer | Behaviour when the document is absent | Affected |
|---|---|---|
| `commands/claim.ts:24` | Explicit null check, replies `profileNotCreated` | Reply only, gamification disabled |
| `commands/claim.ts:72` | Unreachable, guarded by the check at `:30` | No |
| `commands/profile.ts:42` | Explicit null check, replies `profileNotCreated`. `:55` is a list query | Reply only, gamification disabled |
| `commands/leaderboard.ts:24` | `if (!members.length)`, replies `profilesNotCreated` | No |
| `commands/give.ts:51` | Upserts the recipient itself | No |
| `commands/user/infractions.ts:64` | `memberDocument?.infractions?.length` | No |
| `utils/members.ts:43` | Warnings upsert their own document. `:76` unsets, which no-ops | No |
| `utils/protection/tenure.ts:26` | Already gated on `gamification`, and optional chains the result | No |
| `schedulers/voiceExperience.ts:74` | Queries only `gamification: true` servers, treats an absent document as zero, and its writes carry `upsert: true` at `:108` | No |
| `routes/guilds.ts:70` | List query | No |
| `listeners/messageCreate.ts:153` | Karma, already gated on `gamification` | No |
| `migrate.ts` | Index management only | No |

#### Test Plan

`npm test` (eslint) and `npm run build` pass. Behavioural verification is manual, per `.github/TESTING.md`.

| # | Case | Expected |
|---|---|---|
| 1 | Server with gamification **enabled**, talk repeatedly | Experience is awarded exactly as before, once per thirty seconds, and levelling up still announces and grants level roles |
| 2 | Server with gamification enabled, a member's first ever message | Their document is created and they gain experience |
| 3 | Server with gamification **disabled**, talk repeatedly | No write to the members collection at all |
| 4 | Server with gamification disabled, `/profile` for a member who never had a document | "A profile hasn't been created yet" |
| 5 | Server with gamification disabled, `/profile` for a member who already has one | Their existing profile, balance and streak, unchanged |
| 6 | Server with gamification disabled, `/give` coins to a member with no document | Succeeds, creating the document |
| 7 | Server with gamification disabled, warn a member with no document | The infraction is recorded, and the timeout and kick thresholds still apply |
| 8 | Server with gamification disabled, `/leaderboard` with no documents | "User profiles haven't been created yet" |
| 9 | Server with gamification enabled, sit in a voice channel | Voice experience still accrues on the scheduler's tick |
| 10 | Disable gamification on a server which already has profiles, then re-enable it | Experience resumes from the stored values |

#### References

The last item of the message hot path review that produced #1112, #1113, #1114 and #1115.

#### Checklist

- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)
