### PR TITLE
refactor(utils): expire the cached items lazily

### DIFF
--- a/src/utils/memcache.ts
+++ b/src/utils/memcache.ts
@@ -2,50 +2,63 @@
  * @author TRACTION (iamtraction)
  * @copyright 2022
  */
+interface MemcacheEntry {
+    /** The cached value. */
+    v: unknown;
+    /** When the item expires, in milliseconds since the epoch. Items without one never expire. */
+    exp?: number;
+}
+
+/** How often the leftovers of expired items are reclaimed, in milliseconds. */
+const SWEEP_INTERVAL = 6e4;
+
 class Memcache {
-    private store: Map<string, unknown>;
-    private expiries: Map<string, NodeJS.Timeout>;
+    private store: Map<string, MemcacheEntry>;
 
     constructor() {
-        this.store = new Map<string, unknown>();
-        this.expiries = new Map<string, NodeJS.Timeout>();
+        this.store = new Map<string, MemcacheEntry>();
+
+        setInterval(this.sweep, SWEEP_INTERVAL).unref();
     }
 
-    private cancel = (key: string): void => {
-        clearTimeout(this.expiries.get(key));
-        this.expiries.delete(key);
+    /** Looks up an item, dropping it if it has expired since it was last touched. */
+    private resolve = (key: string): MemcacheEntry => {
+        const entry = this.store.get(key);
+        if (!entry) return null;
+
+        if (entry.exp && entry.exp <= Date.now()) {
+            this.store.delete(key);
+            return null;
+        }
+
+        return entry;
+    };
+
+    /** Reclaims the expired items which nothing has touched since. */
+    private sweep = (): void => {
+        for (const key of this.store.keys()) this.resolve(key);
     };
 
     public get = (key: string): unknown => {
-        return this.store.get(key);
+        return this.resolve(key)?.v;
     };
 
     public set = (key: string, value: unknown, minutes?: number): boolean => {
-        this.cancel(key);
-        this.store.set(key, value);
-
-        if (minutes) {
-            this.expiries.set(key, setTimeout(() => this.delete(key), minutes * 6e4).unref());
-        }
+        this.store.set(key, { v: value, exp: minutes ? Date.now() + minutes * 6e4 : undefined });
 
         return true;
     };
 
     public delete = (key: string): unknown => {
-        if (!this.store.has(key)) return null;
+        const entry = this.resolve(key);
+        if (!entry) return null;
 
-        const item = this.store.get(key);
-
-        this.cancel(key);
         this.store.delete(key);
 
-        return item;
+        return entry.v;
     };
 
     public clear = (): boolean => {
-        for (const expiry of this.expiries.values()) clearTimeout(expiry);
-
-        this.expiries.clear();
         this.store.clear();
 
         return true;


### PR DESCRIPTION
`Memcache` armed a `setTimeout` per lifetimed item and tracked the handle so that every mutation path could cancel the timer it replaced. #1115 exists because two of those three paths weren't cancelling. The model needs an invariant maintained by hand — *every* write, delete and clear must remember to cancel — and nothing enforces it.

Items now carry the time they expire, `get`/`delete` drop an item which is past due before returning it, and one shared interval reclaims whatever nothing reads again. The `expiries` map and `cancel()` are gone, and with them the class of bug #1115 fixed: overwriting a key replaces its expiry along with its value, and deleting or clearing leaves nothing armed. It can't regress, because there is no longer anything to forget to cancel.

The expiry is optional rather than a sentinel (`exp?`, named after the JWT claim), so an item written without a lifetime has none rather than a magic zero. `exp` is in milliseconds, not JWT's seconds, so it compares directly against `Date.now()` with no conversion on the read path.

#### Notes for review

- **No consumer changed.** `get` still answers `undefined` for an item which isn't cached and `delete` still answers the item or `null`. There is no public `size`/`keys`/`has`, so an expired item lingering until the next sweep is unobservable.
- **Eviction moves from exact to lazy.** An expired item can hold memory until it is next read or swept — at most a minute past its lifetime. Every one of the eight call sites reads before it acts, so none of them depends on an item vanishing at a precise instant, only on it being gone by the time it is read, which is exactly what the lookup guarantees.
- **`schedulers/liveStreams.ts:40` mutates a cached `Map` in place** and was the one call site that could have broken. `get` returns the stored reference rather than a copy, and the entry holds no lifetime so the sweep walks past it. Verified, below.
- **The sweep is O(n) in cache size, not in expired items**, because a `Map` has no ordering by expiry — it costs 191 ns per entry and blocks the loop for its duration. That is 0.2 ms at 1,000 items and ~1 ms at 5,000, which is where these key spaces sit (the largest is the xp cooldown, bounded by distinct members earning xp per 30 seconds). It would be 19 ms per minute at 100,000. If a key space ever gets near that, the answer is to sweep in slices and yield between them, not to go back to per-key timers.
- **This is a refactor, not a performance fix.** Nothing was broken after #1115. On the hot path it is marginally *slower*: reads cost ~84 ns more, of which 48 ns is the `Date.now()` call, against a handler that spends ~1 ms in Mongo. Writes are 2.6–4.6× faster and memory per lifetimed key drops 2.6×, but no key space here is big enough for that to matter — it is worth having for the invariant it removes.

<details>
<summary>Measurements — node v24.18.0, each in its own process with <code>--expose-gc</code>, medians of 5 runs</summary>

Memory, N lifetimed keys caching `true`. Varying the lifetimes so Node keeps many timer lists rather than one changed nothing measurable.

| keys | timers heap | timers RSS | expiry heap | expiry RSS | bytes/key timers | bytes/key expiry |
|---|---|---|---|---|---|---|
| 1,000 | 0.4 MB | 2.2 MB | 0.1 MB | 0.3 MB | 425 | 150 |
| 10,000 | 3.9 MB | 10.8 MB | 1.5 MB | 5.8 MB | 410 | 159 |
| 100,000 | 36.8 MB | 59.4 MB | 14.2 MB | 22.1 MB | 386 | 149 |
| 250,000 | 88.4 MB | 148.4 MB | 33.7 MB | 57.4 MB | 371 | 141 |

Throughput, ns/op over 200k ops. The xp workload is one `get` per message and one `set` per award, as `messageCreate.ts:47,86` does it.

| operation | timers | expiry | change |
|---|---|---|---|
| set (with a lifetime) | 450.6 | 174.6 | −61% |
| set (overwrite) | 586.1 | 127.2 | −78% |
| get (hit) | 36.3 | 120.5 | +232% |
| get (miss) | 4.2 | 7.6 | +82% |
| delete | 204.5 | 138.4 | −32% |
| xp cooldown workload | 50.3 | 87.8 | +75% |

Where the read cost goes — the clock read is the regression, not the wrapper: `Date.now()` alone is 48.0 ns on this box, against 41.0 ns for the bare `map.get` and 93.3 ns for the two together. `performance.now()` measures 40.7 ns and is monotonic, but it would break the "milliseconds since the epoch" contract for 13 ns, so it isn't used.

</details>

#### Test Plan

`npm test` (eslint) and `npm run build` pass. Behaviour was checked with throwaway scripts (not committed) against the compiled module, covering every defect #1115 fixed plus the cases this change introduces:

| # | Case | Result |
|---|---|---|
| 1 | Re-`set` a key near the end of its lifetime, read past the original expiry | Present |
| 2 | The re-`set` key still expires at its own lifetime | Gone, as expected |
| 3 | `set`, `delete`, `set` again with a longer lifetime, read past the original expiry | Present |
| 4 | `delete` a key holding `false` | Removed |
| 5 | Return value of that `delete` | `false` |
| 6 | `delete` a key which isn't cached | `null` |
| 7 | `set`, `clear`, `set` again, read past the first lifetime | Present |
| 8 | An item set without a lifetime, read well past when one would have lapsed | Present |
| 9 | `delete` an expired item the sweep hasn't reached | `null`, not the stale value |
| 10 | `get` an expired item twice | Dropped on the first read |

And for `liveStreams`, the consumer which mutates a cached object in place:

| # | Case | Result |
|---|---|---|
| 11 | `get` returns the stored object rather than a copy | Same reference |
| 12 | Mutations made on one tick are visible on the next | Visible |
| 13 | An in-place `delete` on the cached `Map` is visible through the cache | Visible |
| 14 | The entry survives a sweep with its contents intact | Survives |
| 15 | That same sweep evicts an expired key and leaves a live one — so 14 isn't a false pass | Evicted / kept |

Still to do — manual verification against a running bot, per `.github/TESTING.md`, since the expiry path is what the protection windows ride on:

| # | Case | Expected |
|---|---|---|
| 16 | Trigger a protection incident, then have the same member keep spamming | One incident and one moderation log entry |
| 17 | Pardon a member from a report, then have them post again inside the pardon window | No new action taken |
| 18 | Add a trigger, post a match, edit the triggers, post another match | Both respond; the cache refills after each invalidation |
| 19 | Gain xp, then keep talking for a minute | Xp awarded at the same rate as before |
| 20 | Star a message past the threshold twice | Posted to the starboard once |
| 21 | Let the live stream scheduler run twice with a notified stream | No duplicate notification |

#### References

- #1115 fixed the cancellation bugs this removes the possibility of. Its review notes measured the per-key timer cost at 36.8 MB heap for 100,000 lifetimed keys and left the model alone as premature; this is that follow-up.

#### Checklist

- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)
