### PR TITLE
feat(chat): support any OpenAI compatible API

### DIFF
--- a/settings.example.yaml
+++ b/settings.example.yaml
@@ -79,10 +79,18 @@ auth: ""
 coinMarketCapApiKey: ""
 # Required for `apod` command.
 nasaApiKey: "DEMO_KEY"
-# Required for `chat` command to use the OpenAI's ChatGPT APIs.
+# Required for `chat` command to use the OpenAI's ChatGPT APIs, or any other
+# OpenAI compatible API, including self hosted ones, such as Ollama.
 # API pricing depends on these values.
-# For more details, check https://openai.com/pricing
+# For more details, check https://openai.com/pricing and https://ollama.com
 openai:
+  # Set the `baseURL` to use any other OpenAI compatible API, including self
+  # hosted ones, such as Ollama (http://localhost:11434/v1), LM Studio, vLLM,
+  # llama.cpp, etc. Leave it empty to use the OpenAI APIs.
+  # Self hosted APIs usually don't need an `apiKey`, but if yours does, set it
+  # below. Remember to set the `model` to one that's available on your server,
+  # for example, "llama3.2" on Ollama.
+  baseURL: ""
   apiKey: ""
   # https://openai.com/api/pricing
   model: "gpt-5-nano"

--- a/src/actions/Sentiment.ts
+++ b/src/actions/Sentiment.ts
@@ -26,10 +26,11 @@ class SentimentCommand extends Command {
         const systemPrompt = "You are a helpful and informative AI assistant. You will analyze the given text and provide an assessment of its sentiment. Consider the overall tone, specific words and phrases used, and any contextual clues. Your response should be short, concise, objective, and informative.";
         const sentimentPrompt = `Please analyze the following text and provide a assessment of its sentiment: ${ interaction.targetMessage.content }`;
 
-        // use ChatGPT if OpenAI API key is present
-        if (((interaction.client as Client).settings as Settings).get("openai").apiKey) {
+        // use any OpenAI compatible API, i.e. OpenAI, Ollama, etc., if its API key or base URL is present
+        if (((interaction.client as Client).settings as Settings).get("openai").apiKey || ((interaction.client as Client).settings as Settings).get("openai").baseURL) {
             const openai = new OpenAI({
-                apiKey: ((interaction.client as Client).settings as Settings).get("openai").apiKey,
+                baseURL: ((interaction.client as Client).settings as Settings).get("openai").baseURL || undefined,
+                apiKey: ((interaction.client as Client).settings as Settings).get("openai").apiKey || "bastion",
             });
 
             const response = await openai.chat.completions.create({

--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -61,10 +61,11 @@ class ChatCommand extends Command {
         // if first message is from the bot, remove it
         if (history[0]?.role === "assistant") history.shift();
 
-        // use ChatGPT if OpenAI API key is present
-        if (((interaction.client as Client).settings as Settings).get("openai").apiKey) {
+        // use any OpenAI compatible API, i.e. OpenAI, Ollama, etc., if its API key or base URL is present
+        if (((interaction.client as Client).settings as Settings).get("openai").apiKey || ((interaction.client as Client).settings as Settings).get("openai").baseURL) {
             const openai = new OpenAI({
-                apiKey: ((interaction.client as Client).settings as Settings).get("openai").apiKey,
+                baseURL: ((interaction.client as Client).settings as Settings).get("openai").baseURL || undefined,
+                apiKey: ((interaction.client as Client).settings as Settings).get("openai").apiKey || "bastion",
             });
 
             const response = await openai.chat.completions.create({
@@ -147,7 +148,7 @@ class ChatCommand extends Command {
         }
 
         return await interaction.editReply({
-            content: "You haven't set up API keys for any gen AI APIs.",
+            content: "You haven't set up any AI provider yet. Set an API key for OpenAI, Gemini or Anthropic, or the base URL of a self hosted, OpenAI compatible API, such as Ollama.",
         });
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export namespace bastion {
         coinMarketCapApiKey?: string;
         nasaApiKey?: string;
         openai?: {
+            baseURL?: string;
             apiKey?: string;
             model?: string;
             maxTokens?: number;


### PR DESCRIPTION
`/chat` and the `Sentiment` action pick a provider by which API key is configured, so every reply had to be generated by OpenAI, Gemini or Anthropic. #1082 asks for a self hosted option, so that a hoster can keep the bot self contained and run whichever model they like.

Ollama, LM Studio, vLLM and llama.cpp all serve OpenAI's chat completions API, and the `openai` client already accepts a `baseURL`. Configuring one is therefore the whole feature: no new dependency, and it reaches any OpenAI compatible server rather than Ollama alone. Both branches now run on either `openai.apiKey` or the new `openai.baseURL`.

#### Notes for review

- **`ollama-js` isn't used, deliberately.** It would mean a fourth provider branch duplicated across `commands/chat.ts` and `actions/Sentiment.ts`, its own message shape mapping, and a dependency that can only talk to one server. The `baseURL` reaches Ollama, LM Studio, vLLM, llama.cpp and hosted gateways through the client that is already installed.
- **The key falls back to a placeholder.** Self hosted servers usually don't authenticate, but the client throws on construction without a key, so `apiKey || "bastion"` stands in. A hoster whose gateway does want a key sets it as before.
- **An empty `baseURL` is passed as `undefined`, not `""`.** The client defaults `baseURL` from `OPENAI_BASE_URL` only when the option is `undefined`, so the empty string would have silently disabled that fallback.
- **`max_tokens` is unchanged.** It is the field Ollama and llama.cpp accept, and OpenAI honours it on the models configured here. Switching to `max_completion_tokens` would break the self hosted path, so it is left for a separate change.
- **`commands/image/generate.ts` is untouched on purpose.** It hardcodes `dall-e-3`, and no local server implements `/images/generations`. Passing the base URL through would have pointed image generation at a server that answers 404, and defaulting its key would have overridden the client's `OPENAI_API_KEY` fallback for hosters who configure it that way. Local image generation is its own feature.
- **Ordering needed no change.** OpenAI is already the first branch, so a configured `baseURL` takes precedence over the Gemini and Anthropic keys without reordering. A hoster with both a key and a base URL gets the base URL, which is the explicit choice of the two.
- **No `.env` key.** `utils/settings.ts` has no environment override for the `openai` block, so `baseURL` is configured in `settings.yaml` alongside the rest of it.
- **`commands.json` is not regenerated.** No command name, description or option changed.

#### Test Plan

`npm test` (eslint) and `npm run build` pass. Behavioural verification is manual, per `.github/TESTING.md`.

| # | Case | Expected |
|---|---|---|
| 1 | `baseURL: "http://localhost:11434/v1"`, `model: "llama3.2"`, no `apiKey`, run `/chat` | Ollama answers; nothing leaves the host |
| 2 | Same, with a Gemini or Anthropic key also set | Still answered by Ollama |
| 3 | Same, on the `Sentiment` action | Ollama answers |
| 4 | `baseURL` set to a server that is down | The command fails visibly rather than falling through to another provider |
| 5 | `apiKey` set, `baseURL` empty, run `/chat` | Unchanged from before |
| 6 | Neither set, Gemini key present | Gemini answers, as before |
| 7 | Nothing configured at all | The reply names the key based providers and the self hosted option |
| 8 | `apiKey` set, `baseURL` empty, run `/image generate` | Unchanged from before |
| 9 | `apiKey` set *and* `baseURL` set to Ollama, run `/image generate` | Still generated by DALL-E |
| 10 | `model` left at an OpenAI name while `baseURL` points at Ollama | Fails with the server's own unknown model error |

#### References

- Closes #1082 — asks for offline text generation in `/chat` against a local Ollama instance, and suggests `ollama-js`. This uses Ollama's OpenAI compatible endpoint instead, for the reasons above.

#### Checklist

- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)
