### PR TITLE
feat(translate): reply to the translator only

### DIFF
--- a/src/actions/Translate.ts
+++ b/src/actions/Translate.ts
@@ -2,7 +2,7 @@
  * @author TRACTION (iamtraction)
  * @copyright 2024
  */
-import { ApplicationCommandType, MessageContextMenuCommandInteraction } from "discord.js";
+import { ApplicationCommandType, MessageContextMenuCommandInteraction, MessageFlags } from "discord.js";
 import { Command } from "@bastion/tesseract";
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import translate = require("@iamtraction/google-translate");
@@ -25,6 +25,7 @@ class TranslateCommand extends Command {
         return await interaction.reply({
             content: `${ response.text }
 -# Translated from ${ response.from.language.iso?.toUpperCase() } to English`,
+            flags: [ MessageFlags.Ephemeral ],
         });
     }
 }


### PR DESCRIPTION
The `Translate` action replied in the channel, so anyone who translated a
message published that translation to everyone else — and could run it
again on the same message as many times as they liked, which is how it
becomes a way to spam an announcement channel. #1078 asks for the
translation to be visible only to whoever asked for it.

The reply carries `MessageFlags.Ephemeral`. That is the whole change: no
setting, no permission check, no state.

#### Notes for review

- **No configuration option.** The issue floats letting the bot owner
choose, but there is no reading of "public translation" that the caller
wants and the channel does — a member who wants everyone to see it can
post it themselves, and the guild's `Guild` document would grow a field
that only ever wants one value. Ephemeral-always is the behaviour the
issue is actually asking for.
- **`actions/Sentiment.ts` is untouched.** The same issue mentions it in
passing, but sentiment analysis costs an API call per invocation, so
whether its reply is public is a question about rate limiting and cost
rather than channel noise. It belongs with the premium/limits helpers in
`utils/premium.ts`, not in this change.
- **The empty-content early return is unchanged.** `exec` still returns
without replying when the target message has no text (an
attachment-only or embed-only message), which surfaces to the caller as
Discord's own failed-interaction notice. That is pre-existing, and
fixing it means picking a user-facing string and a locale key — separate
change.
- **`commands.json` is not regenerated.** The action's name,
description and type are unchanged.

#### Test Plan

`npm test` (eslint) and `npm run build` pass. Behavioural verification
is manual, per `.github/TESTING.md`.

| # | Case | Expected |
|---|---|---|
| 1 | Right-click a non-English message → Apps → Translate | Only the caller sees the translation; nothing is posted to the channel |
| 2 | Two members translate the same message | Each sees their own reply; the channel stays clean |
| 3 | Run it repeatedly on one message | No accumulating public messages |
| 4 | Translate in a channel where the bot can't send messages | The ephemeral reply still reaches the caller |
| 5 | Translate an already-English message | Replies ephemerally, `Translated from EN to English` footer as before |
| 6 | Translate an attachment-only message | Unchanged from before — no reply |

#### References

- Addresses the second point of #1078 — translations posted publicly in
an announcement channel can be spammed by different people. The
giveaway point in that issue is untouched, so it stays open.

#### Checklist

- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)
