### PR TITLE
fix(poll): show 0% instead of NaN% for unvoted options

### DIFF
--- a/src/components/PollEndButton.ts
+++ b/src/components/PollEndButton.ts
@@ -49,7 +49,7 @@ class PollEndButton extends MessageComponent {
                     title: interaction.message.embeds[0].title,
                     fields: interaction.message.embeds[0].fields.sort((a, b) => (votes[b.name] || 0) - (votes[a.name] || 0) ).map(f => ({
                         name: f.value,
-                        value: `${ votes[f.name] || 0 } votes — ${ ((votes[f.name] || 0) / totalVotes * 100).toFixed(0) }%`,
+                        value: `${ votes[f.name] || 0 } votes — ${ totalVotes ? ((votes[f.name] || 0) / totalVotes * 100).toFixed(0) : 0 }%`,
                     })),
                     footer: {
                         text: `${ totalVotes } votes`

--- a/src/schedulers/polls.ts
+++ b/src/schedulers/polls.ts
@@ -54,7 +54,7 @@ class PollScheduler extends Scheduler {
                         const options = pollMessage.embeds[0].fields.map(f => f.value);
 
                         // identify poll votes
-                        const reactions = [ "🇦", "🇧", "🇨", "🇩", "🇪", "🇫", "🇬", "🇭", "🇮", "🇯", "🇰", "🇱", "🇲" ];
+                        const reactions = [ "🇦", "🇧", "🇨", "🇩", "🇪", "🇫", "🇬", "🇭", "🇮", "🇯" ];
                         const votes: { [key: string]: number } = {};
 
                         let totalVotes = 0;

--- a/src/schedulers/polls.ts
+++ b/src/schedulers/polls.ts
@@ -78,7 +78,7 @@ class PollScheduler extends Scheduler {
                                     title: pollMessage.embeds[0].title,
                                     fields: pollMessage.embeds[0].fields.sort((a, b) => (votes[b.name] || 0) - (votes[a.name] || 0) ).map(f => ({
                                         name: f.value,
-                                        value: `${ votes[f.name] || 0 } votes — ${ ((votes[f.name] || 0) / totalVotes * 100).toFixed(0) }%`,
+                                        value: `${ votes[f.name] || 0 } votes — ${ totalVotes ? ((votes[f.name] || 0) / totalVotes * 100).toFixed(0) : 0 }%`,
                                     })),
                                     footer: {
                                         text: `${ totalVotes } votes`


### PR DESCRIPTION
Every poll that nobody had voted on declared its results as `0 votes — NaN%` on every option.

`/poll` reacts to its own message once per option, and Discord's reaction `count` includes that reaction, so both places that declare results subtract one from every count to discount it. An unvoted poll therefore totals zero votes — which is the state every poll starts in, not an unusual one — and each option's percentage was computed by dividing into that zero. `0 / 0` is `NaN`, and `NaN.toFixed(0)` is the string `"NaN"`.

The percentage is now only computed when there is a total to divide by, so an unvoted option reads `0 votes — 0%`. The second commit aligns the scheduler's vote-reaction list with the other two copies.

#### Notes for review

- **This was introduced by #1024**, which subtracted the bot's own vote from the count. Before it, `totalVotes` summed the raw counts, so an unvoted poll totalled `N` rather than `0` and the division was safe. Fixing that bug uncovered this one, in both files it touched.
- **Both end paths were affected identically** — the `polls` scheduler ending a timed poll, and a moderator pressing *End Poll*. The two carry duplicate copies of the same tally-and-render block, so both needed the same one-line change.
- **The tally block is not extracted.** It is duplicated between `schedulers/polls.ts` and `components/PollEndButton.ts`, and a shared helper is the obvious follow-up, but hoisting it would bury a one-line correctness fix inside a refactor of two files. Left for a separate change.
- **The reaction-list commit changes no behaviour.** The scheduler listed thirteen reactions (`🇦`–`🇲`) where `commands/poll.ts` and `components/PollEndButton.ts` list ten; `/poll` only exposes `option1`–`option10`, so entries eleven to thirteen were unreachable. It is committed separately from the fix for that reason.
- **A related off-by-one is left alone, deliberately.** Both files subtract one unconditionally, assuming the bot's reaction is present. If someone removes it from an option, that option under-reports by one vote — and a poll with a single real vote then totals zero and hits the same guard. Correcting it means subtracting based on `MessageReaction#me` rather than always, which changes reported vote counts on every poll, so it wants its own change and its own verification rather than riding along here.
- **`commands.json` is not regenerated.** No command name, description or option changed.

#### Test Plan

`npm test` (eslint) and `npm run build` pass. Behavioural verification is manual, per `.github/TESTING.md`.

| # | Case | Expected |
|---|---|---|
| 1 | `/poll` with a `timer`, let it expire with no votes | Every option reads `0 votes — 0%`; footer reads `0 votes` |
| 2 | `/poll` with no votes, press *End Poll* | Same, immediately |
| 3 | `/poll`, one member votes on one option, then end it | That option `1 votes — 100%`, the rest `0 votes — 0%` |
| 4 | `/poll`, votes spread across three options, then end it | Percentages unchanged from before, fields ordered most-voted first |
| 5 | `/poll` with all ten options, votes on the 10th | The 10th option is counted, as before |
| 6 | End a poll in a channel where the bot cannot add reactions | Reads `0 votes — 0%` rather than `NaN%` |
| 7 | Re-run the scheduler over an already-ended poll | Skipped via the `ENDED` author check, as before |

#### References

- No open issue — found by audit. `0 votes — NaN%` is visible on any unvoted poll.
- Fixes a regression from #1024, which removed Bastion's own vote from the count.

#### Checklist

- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)
