### PR TITLE
fix(poll): don't discount a vote Bastion didn't cast

### DIFF
--- a/src/components/PollEndButton.ts
+++ b/src/components/PollEndButton.ts
@@ -32,9 +32,9 @@ class PollEndButton extends MessageComponent {
         let totalVotes = 0;
         for (const key in reactions.slice(0, options.length)) {
             if (interaction.message.reactions.cache.has(reactions[key])) {
-                // calculate votes
-                const votesCount = interaction.message.reactions.cache.get(reactions[key]).count;
-                votes[reactions[key]] = votesCount - 1;
+                // calculate votes, discounting Bastion's own reaction only when it's there
+                const reaction = interaction.message.reactions.cache.get(reactions[key]);
+                votes[reactions[key]] = reaction.count - (reaction.me ? 1 : 0);
                 totalVotes += votes[reactions[key]];
             }
         }

--- a/src/schedulers/polls.ts
+++ b/src/schedulers/polls.ts
@@ -60,9 +60,9 @@ class PollScheduler extends Scheduler {
                         let totalVotes = 0;
                         for (const key in reactions.slice(0, options.length)) {
                             if (pollMessage.reactions.cache.has(reactions[key])) {
-                                // calculate votes
-                                const votesCount = pollMessage.reactions.cache.get(reactions[key]).count;
-                                votes[reactions[key]] = votesCount - 1;
+                                // calculate votes, discounting Bastion's own reaction only when it's there
+                                const reaction = pollMessage.reactions.cache.get(reactions[key]);
+                                votes[reactions[key]] = reaction.count - (reaction.me ? 1 : 0);
                                 totalVotes += votes[reactions[key]];
                             }
                         }


### PR DESCRIPTION
Poll results under-reported by one vote on any option Bastion's own reaction was no longer on.

`/poll` seeds each option with a reaction, and Discord's `count` includes it, so both places that declare results subtract one before reporting. The subtraction was unconditional — it assumed the seeded reaction is still there. Anyone can remove a reaction, and on an option where that happened the subtraction ate a real member's vote instead. A poll whose only vote sat on such an option reported no votes at all, and after #1121 it renders as `0 votes — 0%` rather than the `NaN%` that used to make it obvious something was wrong.

The count is now reduced only when Discord says Bastion is among the reactors, via `MessageReaction#me`.

#### Notes for review

- **`me` is the flag Discord sends for exactly this.** It is assigned from the payload in the `MessageReaction` constructor (`MessageReaction.js:33`), and both paths fetch the message before counting — `schedulers/polls.ts:43` and `components/PollEndButton.ts:23` — where `Message._patch` rebuilds the whole `ReactionManager` from `data.reactions` (`Message.js:253-261`). So the flag describes who is on each option now, not who was expected to be, and it isn't read off a stale cache.
- **This changes reported vote counts, which is the point.** On a poll where every seeded reaction is intact — the normal case — every number is identical to before. The numbers only move where the old arithmetic was wrong.
- **Counts can no longer go negative.** `me` is true only when Bastion is among the counted users, so the subtraction is only applied to a count that includes it.
- **`meBurst` is not consulted.** `count` covers normal and burst reactions together, with `me` and `meBurst` tracked apart (`MessageReaction.js:33-39`), but bots cannot send super reactions, so Bastion's own is always the normal kind and `me` alone identifies it. A member super-reacting is a real vote and still counts as one.
- **The zero-vote guard from #1121 is still required.** It is not made redundant by this: a poll nobody voted on still totals zero. This stops real votes being erased *into* that state; that commit handles the case where the state is genuine.
- **The duplicated tally block is still duplicated.** This is the second fix applied to both copies in a row, which is the argument for extracting it — but hoisting it here would bury a vote-counting correction inside a refactor of two files. Still worth doing separately.
- **The wider point:** counting reactions as ballots is what produces this class of bug. Discord's native polls (a `poll` field on the message, with real per-answer tallies and an expiry) would remove the seeded reaction, the subtraction, the ten-option ceiling and the duplicated emoji lists together. That is a feature rather than a fix, and out of scope here.
- **`commands.json` is not regenerated.** No command name, description or option changed.

#### Test Plan

`npm test` (eslint) and `npm run build` pass. Behavioural verification is manual, per `.github/TESTING.md`.

| # | Case | Expected |
|---|---|---|
| 1 | One member votes on an option, remove Bastion's reaction from it, end the poll | `1 votes — 100%` (was `0 votes — 0%`) |
| 2 | Votes on three options, Bastion's reaction intact throughout, end the poll | Every count and percentage identical to before this change |
| 3 | Remove Bastion's reaction from an option nobody voted on, end the poll | `0 votes — 0%`, no negative count |
| 4 | Poll with no votes at all, Bastion's reactions intact | `0 votes — 0%`, footer `0 votes` — unchanged from #1121 |
| 5 | Member reacts, then removes their own vote, end the poll | `0 votes — 0%` |
| 6 | Member super-reacts an option, end the poll | Counted as one vote |
| 7 | Both end paths — expire a timed poll via the scheduler, and press *End Poll* | Identical totals from each |
| 8 | Bastion never managed to seed reactions (no Add Reactions permission), members react anyway | Their votes are counted, not decremented |

#### References

- Follows #1121, which fixed the `NaN%` rendering on the same two files and documented this off-by-one as out of its scope.
- Both are consequences of #1024, which introduced the unconditional subtraction.

#### Checklist

- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)
