### PR TITLE
chore(deps): remove the unused ytdl-core dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
                 "openai": "^6.48.0",
                 "r6api.js": "^4.4.1",
                 "undici": "^8.8.0",
-                "ytdl-core": "^4.11.5",
                 "ytpl": "^2.3.0"
             },
             "devDependencies": {
@@ -3836,19 +3835,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/m3u8stream": {
-            "version": "0.8.6",
-            "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.8.6.tgz",
-            "integrity": "sha512-LZj8kIVf9KCphiHmH7sbFQTVe4tOemb202fWwvJwR9W5ENW/1hxJN6ksAWGhQgSBSa3jyWhnjKU1Fw1GaOdbyA==",
-            "license": "MIT",
-            "dependencies": {
-                "miniget": "^4.2.2",
-                "sax": "^1.2.4"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/magic-bytes.js": {
             "version": "1.13.0",
             "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
@@ -5723,20 +5709,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/ytdl-core": {
-            "version": "4.11.5",
-            "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.11.5.tgz",
-            "integrity": "sha512-27LwsW4n4nyNviRCO1hmr8Wr5J1wLLMawHCQvH8Fk0hiRqrxuIu028WzbJetiYH28K8XDbeinYW4/wcHQD1EXA==",
-            "license": "MIT",
-            "dependencies": {
-                "m3u8stream": "^0.8.6",
-                "miniget": "^4.2.2",
-                "sax": "^1.1.3"
-            },
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/ytpl": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
         "openai": "^6.48.0",
         "r6api.js": "^4.4.1",
         "undici": "^8.8.0",
-        "ytdl-core": "^4.11.5",
         "ytpl": "^2.3.0"
     },
     "optionalDependencies": {


### PR DESCRIPTION
Removes `ytdl-core` from the manifest. It has been declared since the v10 manifest sweep (`5e59b8db`) but was never imported anywhere — the only `ytdl`-shaped references in `src/` are the `yt-dlp` binary probe and spawn in `src/commands/music/play.ts`, which is a separate thing. Audio streams through `yt-dlp`, falling back to `@iamtraction/play-dl` when the binary isn't on `PATH`, so nothing in the codebase needs the package.

Upstream is also unmaintained: `4.11.5` is its final release and the repository is archived, so it was only contributing a dead transitive dependency (`m3u8stream`) and a stale advisory surface. `miniget` and `sax` stay in the lockfile because `ytpl` still requires them.

#### References
<!-- Link any applicable issues/pull requests here, with a brief description explaining why. -->
None.

#### Checklist
- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
