### PR TITLE
fix(logs): guard nullable joinedAt in the join log listeners

### DIFF
--- a/src/listeners/guildCreate.ts
+++ b/src/listeners/guildCreate.ts
@@ -41,7 +41,7 @@ class GuildCreateListener extends Listener<"guildCreate"> {
             footer: {
                 text: `Shard ${ guild.shardId }`,
             },
-            timestamp: guild.members.me.joinedAt.toISOString(),
+            timestamp: (guild.members.me?.joinedAt ?? new Date()).toISOString(),
         }).catch(Logger.error);
     }
 }

--- a/src/listeners/guildMemberAdd.ts
+++ b/src/listeners/guildMemberAdd.ts
@@ -119,7 +119,7 @@ class GuildMemberAddListener extends Listener<"guildMemberAdd"> {
             thumbnail: {
                 url: member.displayAvatarURL(),
             },
-            timestamp: member.joinedAt.toISOString(),
+            timestamp: (member.joinedAt ?? new Date()).toISOString(),
         });
     }
 }


### PR DESCRIPTION
Two server-log listeners dereferenced a nullable `joinedAt` when building their embed `timestamp`, so a member object without `joined_at` — or an uncached client member — threw a `TypeError` and cost the log entry.

- `guildMemberAdd` used `member.joinedAt.toISOString()`. `joinedAt` is `Date | null`; discord.js only parses it when the gateway payload carries `joined_at`. Because the deref happened while building the argument to `logGuildEvent` (which is also what checks whether a log channel is configured), the throw aborted `exec()` for every guild, not just those with server logging enabled. `guildMemberRemove` already guarded the same property for its `Joined Server` field.
- `guildCreate` used `guild.members.me.joinedAt.toISOString()`, which dereferences twice: `members.me` resolves from the member cache and need not be populated when the event fires.

Both now fall back to the current time rather than `?.`, so the entry keeps a usable timestamp instead of silently dropping the field. Falling back to now matches how `guildMemberRemove` timestamps its leave log, and is accurate for `guildCreate` since the client has just joined.

`strict: false` in `tsconfig.json` is why the compiler never flagged either one.

#### References
None.

#### Checklist
- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)