### PR TITLE
perf(live-streams): look up each Twitch channel once per sweep

### DIFF
--- a/src/commands/search/game.ts
+++ b/src/commands/search/game.ts
@@ -8,6 +8,7 @@ import { Client, Command } from "@bastion/tesseract";
 import * as requests from "../../utils/requests.js";
 import { COLORS } from "../../utils/constants.js";
 import Settings from "../../utils/settings.js";
+import { twitchHeaders } from "../../utils/twitch.js";
 
 interface Game {
     alternative_names?: string[];
@@ -55,10 +56,7 @@ class GameCommand extends Command {
             fields: "*, alternative_names.*, artworks.*, cover.*, genres.*, platforms.*, screenshots.*, videos.*, websites.*",
             limit: "10",
             search: name,
-        }), {
-            "authorization": "Bearer " + ((interaction.client as Client).settings as Settings)?.get("twitch")?.accessToken,
-            "client-id": ((interaction.client as Client).settings as Settings)?.get("twitch")?.clientId,
-        });
+        }), twitchHeaders((interaction.client as Client).settings as Settings));
         const games: Game[] = await body.json() as unknown[];
 
         if (games?.length) {

--- a/src/schedulers/liveStreams.ts
+++ b/src/schedulers/liveStreams.ts
@@ -41,6 +41,7 @@ const buildEmbed = (stream: TwitchStream): APIEmbed => ({
         name: stream.user_name,
         url: "https://twitch.tv/" + stream.user_login,
     },
+    title: stream.game_name || undefined,
     description: stream.title,
     fields: [
         {

--- a/src/schedulers/liveStreams.ts
+++ b/src/schedulers/liveStreams.ts
@@ -76,7 +76,7 @@ class LiveStreamNotificationScheduler extends Scheduler {
                                     color: COLORS.TWITCH,
                                     author: {
                                         name: stream.user_name,
-                                        url: "https://twitch.tv/" + stream.user_name,
+                                        url: "https://twitch.tv/" + stream.user_login,
                                     },
                                     description: stream.title,
                                     fields: [

--- a/src/schedulers/liveStreams.ts
+++ b/src/schedulers/liveStreams.ts
@@ -2,28 +2,167 @@
  * @author TRACTION (iamtraction)
  * @copyright 2022
  */
-import { GuildTextBasedChannel, Snowflake } from "discord.js";
+import { APIEmbed, GuildTextBasedChannel, Snowflake } from "discord.js";
 import { Logger, Scheduler } from "@bastion/tesseract";
 
-import GuildModel from "../models/Guild.js";
-import memcache from "../utils/memcache.js";
+import GuildModel, { Guild } from "../models/Guild.js";
+import * as arrays from "../utils/arrays.js";
 import * as requests from "../utils/requests.js";
 import { COLORS } from "../utils/constants.js";
 import { TWITCH_CHANNEL } from "../utils/regex.js";
+import { twitchHeaders } from "../utils/twitch.js";
 import Settings from "../utils/settings.js";
 import { TwitchStream } from "../types.js";
 
-const TWITCH_CACHE_NAMESPACE = "twitchStreams";
+/** The most channels Twitch's streams endpoint accepts, and reports on, in one request. */
+const TWITCH_BATCH_SIZE = 100;
+/** How many guilds are announced to at a time. */
+const NOTIFICATION_CONCURRENCY = 8;
+/** How long before this shard started watching a stream can have begun and still be announced, in milliseconds. */
+const NOTIFICATION_GRACE = 6e5;
+
+/** A channel waiting to hear when a Twitch channel goes live. */
+interface StreamSubscriber {
+    channel: GuildTextBasedChannel;
+    message?: string;
+}
+
+/** A live stream, and one of the channels waiting to hear about it. */
+interface StreamNotification {
+    stream: TwitchStream;
+    login: string;
+    embeds: APIEmbed[];
+    subscriber: StreamSubscriber;
+}
+
+const buildEmbed = (stream: TwitchStream): APIEmbed => ({
+    color: COLORS.TWITCH,
+    author: {
+        name: stream.user_name,
+        url: "https://twitch.tv/" + stream.user_login,
+    },
+    description: stream.title,
+    fields: [
+        {
+            name: "Viewers",
+            value: stream.viewer_count.toLocaleString(),
+            inline: true,
+        },
+        {
+            name: "Language",
+            value: stream.language.toUpperCase(),
+            inline: true,
+        },
+    ],
+    image: {
+        url: stream.thumbnail_url.replace("{width}", "1280").replace("{height}", "720"),
+    },
+    footer: {
+        text: "🔴 LIVE",
+    },
+    timestamp: stream.started_at,
+});
 
 class LiveStreamNotificationScheduler extends Scheduler {
+    /** The stream each guild was last told about, per Twitch channel it follows. Rebuilt every sweep. */
+    private notified = new Map<Snowflake, Map<string, string>>();
+
+    /** Whether a sweep is still running, since cron starts the next one regardless. */
+    private sweeping = false;
+
+    /** When this shard started watching. */
+    private readonly bootedAt = Date.now();
+
     constructor() {
         super("liveStreams", "0 */5 * * * *");  // every 5 minutes
+    }
 
-        // twitch streams for which the guilds have received notifications
-        memcache.set(TWITCH_CACHE_NAMESPACE, new Map<Snowflake, string[]>());
+    /** Collects the guilds following each Twitch channel. */
+    private resolveSubscribers(guildDocuments: Guild[]): Map<string, StreamSubscriber[]> {
+        const subscribers = new Map<string, StreamSubscriber[]>();
+
+        for (const guild of guildDocuments) {
+            const channel = this.client.guilds.cache.get(guild.id)?.channels.cache.get(guild.twitchNotificationChannel) as GuildTextBasedChannel;
+            if (!channel) continue;
+
+            const subscriber: StreamSubscriber = { channel, message: guild.twitchNotificationMessage };
+
+            for (const user of guild.twitchNotificationUsers) {
+                if (!TWITCH_CHANNEL.test(user)) continue;
+
+                const login = user.toLowerCase();
+                if (!subscribers.has(login)) subscribers.set(login, []);
+                subscribers.get(login).push(subscriber);
+            }
+        }
+
+        return subscribers;
+    }
+
+    /**
+     * Looks up which of the specified channels are currently live, a batch of channels at a time.
+     * Reports the channels it got an answer for alongside them. a batch Twitch refused says nothing
+     * about whether its channels are live, which isn't the same as them having gone offline.
+     */
+    private async fetchLiveStreams(logins: string[]): Promise<{ streams: TwitchStream[]; answered: Set<string>; }> {
+        const streams: TwitchStream[] = [];
+        const answered = new Set<string>();
+        const headers = twitchHeaders(this.client.settings as Settings);
+
+        for (const batch of arrays.chunks(logins, TWITCH_BATCH_SIZE)) {
+            const query = new URLSearchParams([
+                [ "first", `${ TWITCH_BATCH_SIZE }` ],
+                ...batch.map(login => [ "user_login", login ]),
+            ]);
+
+            try {
+                const { body, statusCode } = await requests.get("https://api.twitch.tv/helix/streams?" + query.toString(), headers);
+
+                if (statusCode >= 400) {
+                    Logger.error(`Twitch responded with ${ statusCode } for ${ batch.length } channels: ${ await body.text() }`);
+
+                    // a rejected token or an exhausted rate limit applies to every remaining batch too
+                    if (statusCode === 401 || statusCode === 429) break;
+
+                    continue;
+                }
+
+                const data = (await body.json())?.["data"] as TwitchStream[];
+                streams.push(...(data || []).filter(stream => stream.type === "live"));
+
+                for (const login of batch) answered.add(login);
+            } catch (e) {
+                Logger.error(e);
+            }
+        }
+
+        return { streams, answered };
+    }
+
+    /** Announces the streams a single guild hasn't been told about yet, in the order they were found. */
+    private async notifyGuild(notifications: StreamNotification[], notified: Map<string, string>): Promise<void> {
+        for (const { stream, login, embeds, subscriber } of notifications) {
+            // check whether this stream has already been notified
+            if (notified.get(login) === stream.id) continue;
+
+            // adopt whatever was already live before this shard started watching, instead of announcing it again
+            if (Date.parse(stream.started_at) < this.bootedAt - NOTIFICATION_GRACE) {
+                notified.set(login, stream.id);
+                continue;
+            }
+
+            await subscriber.channel.send({ content: subscriber.message, embeds })
+                .then(() => notified.set(login, stream.id))
+                .catch(Logger.ignore);
+        }
     }
 
     public async exec(): Promise<void> {
+        // a sweep can outlast the five minutes it has before the next one starts. cron doesn't wait for
+        // it, and two of them running at once would announce over each other and lose what was announced
+        if (this.sweeping) return;
+        this.sweeping = true;
+
         try {
             // check whether the client is ready
             if (!this.client.isReady()) return;
@@ -37,78 +176,56 @@ class LiveStreamNotificationScheduler extends Scheduler {
                 twitchNotificationUsers: { $exists: true, $type: "array", $ne: [] },
             });
 
-            const twitchStreams = memcache.get(TWITCH_CACHE_NAMESPACE) as Map<Snowflake, string[]>;
+            const subscribers = this.resolveSubscribers(guildDocuments);
+            const { streams, answered } = await this.fetchLiveStreams([ ...subscribers.keys() ]);
 
-            // drop notification state for guilds bastion has left
-            for (const id of twitchStreams.keys()) {
-                if (!this.client.guilds.cache.has(id)) twitchStreams.delete(id);
+            // group the live streams by the guilds waiting to hear about them, rendering each stream only once
+            // however many guilds it's going out to
+            const live = new Set<string>();
+            const notifications = new Map<Snowflake, StreamNotification[]>();
+            for (const stream of streams) {
+                const login = stream.user_login?.toLowerCase();
+                live.add(login);
+
+                const embeds = [ buildEmbed(stream) ];
+                for (const subscriber of subscribers.get(login) || []) {
+                    const { guildId } = subscriber.channel;
+
+                    if (!notifications.has(guildId)) notifications.set(guildId, []);
+                    notifications.get(guildId).push({ stream, login, embeds, subscriber });
+                }
             }
 
-            for (const guild of guildDocuments) {
-                // twitch streams
-                const twitchNotificationUsers = guild.twitchNotificationUsers.filter(u => TWITCH_CHANNEL.test(u));
-                if (guild.twitchNotificationChannel && this.client.guilds.cache.get(guild.id).channels.cache.has(guild.twitchNotificationChannel) && twitchNotificationUsers?.length) {
-                    // get current live streams
-                    const { body, statusCode } = await requests.get("https://api.twitch.tv/helix/streams/?user_login=" + twitchNotificationUsers.join("&user_login="), {
-                        "authorization": "Bearer " + (this.client.settings as Settings).get("twitch").accessToken,
-                        "client-id": (this.client.settings as Settings).get("twitch").clientId,
-                    });
+            // rebuild the state around what's still being followed, so that channels a guild has since
+            // dropped, and guilds bastion has since left, don't linger for the life of the process
+            const previous = this.notified;
+            this.notified = new Map<Snowflake, Map<string, string>>();
+            for (const [ login, guildSubscribers ] of subscribers) {
+                // a channel twitch answered for and didn't report as live has gone offline, and is
+                // forgotten so that it's announced again next time; one it stayed quiet about is kept
+                if (answered.has(login) && !live.has(login)) continue;
 
-                    if (statusCode >= 400) {
-                        return Logger.error(await body.json());
-                    }
+                for (const { channel } of guildSubscribers) {
+                    const stream = previous.get(channel.guildId)?.get(login);
+                    if (!stream) continue;
 
-                    const streams: TwitchStream[] = (await body.json())?.["data"] || [];
-
-                    // streams that were already notified
-                    if (!twitchStreams.has(guild.id)) twitchStreams.set(guild.id, []);
-                    const notifiedStreams = twitchStreams.get(guild.id).filter(user => streams.some(s => s.user_name === user));
-
-                    for (const stream of streams) {
-                        // check whether this stream has already been notified
-                        if (notifiedStreams.includes(stream.user_name)) continue;
-
-                        // notify
-                        await (this.client.guilds.cache.get(guild.id).channels.cache.get(guild.twitchNotificationChannel) as GuildTextBasedChannel).send({
-                            content: guild.twitchNotificationMessage,
-                            embeds: [
-                                {
-                                    color: COLORS.TWITCH,
-                                    author: {
-                                        name: stream.user_name,
-                                        url: "https://twitch.tv/" + stream.user_login,
-                                    },
-                                    description: stream.title,
-                                    fields: [
-                                        {
-                                            name: "Viewers",
-                                            value: stream.viewer_count.toLocaleString(),
-                                            inline: true,
-                                        },
-                                        {
-                                            name: "Language",
-                                            value: stream.language.toUpperCase(),
-                                            inline: true,
-                                        },
-                                    ],
-                                    image: {
-                                        url: stream.thumbnail_url.replace("{width}", "1280").replace("{height}", "720"),
-                                    },
-                                    footer: {
-                                        text: "🔴 LIVE",
-                                    },
-                                    timestamp: stream.started_at,
-                                },
-                            ],
-                        }).then(() => notifiedStreams.push(stream.user_name)).catch(Logger.ignore);
-                    }
-
-                    // save notified streams
-                    twitchStreams.set(guild.id, notifiedStreams);
+                    if (!this.notified.has(channel.guildId)) this.notified.set(channel.guildId, new Map<string, string>());
+                    this.notified.get(channel.guildId).set(login, stream);
                 }
+            }
+
+            // announce to several guilds at once
+            for (const batch of arrays.chunks([ ...notifications ], NOTIFICATION_CONCURRENCY)) {
+                await Promise.all(batch.map(([ guildId, guildNotifications ]) => {
+                    if (!this.notified.has(guildId)) this.notified.set(guildId, new Map<string, string>());
+
+                    return this.notifyGuild(guildNotifications, this.notified.get(guildId));
+                }));
             }
         } catch (e) {
             Logger.error(e);
+        } finally {
+            this.sweeping = false;
         }
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,15 +118,17 @@ export namespace patreon {
 
 export interface TwitchStream {
     readonly game_id: string;
+    readonly game_name: string;
     readonly id: string;
+    readonly is_mature: boolean;
     readonly language: string;
-    readonly pagination: string;
     readonly started_at: string;
-    readonly tag_ids: string;
+    readonly tags: string[];
     readonly thumbnail_url: string;
     readonly title: string;
     readonly type: "live" | "";
     readonly user_id: string;
+    readonly user_login: string;
     readonly user_name: string;
     readonly viewer_count: number;
 }

--- a/src/utils/twitch.ts
+++ b/src/utils/twitch.ts
@@ -2,6 +2,7 @@
  * @author TRACTION (iamtraction)
  * @copyright 2025
  */
+import { IncomingHttpHeaders } from "node:http";
 import { Dispatcher } from "undici";
 
 import { refreshToken } from "./tokenRefresh.js";
@@ -9,6 +10,12 @@ import { refreshToken } from "./tokenRefresh.js";
 import type Settings from "./settings.js";
 
 const TWITCH_TOKEN_URL = "https://id.twitch.tv/oauth2/token";
+
+/** The credentials Twitch expects on every request. */
+export const twitchHeaders = (settings: Settings): IncomingHttpHeaders => ({
+    "client-id": settings?.get("twitch")?.clientId,
+    "authorization": "Bearer " + settings?.get("twitch")?.accessToken,
+});
 
 interface TwitchConfig {
     clientId: string;


### PR DESCRIPTION
Live stream notifications asked Twitch about one guild at a time, so a channel
followed by four hundred guilds was looked up four hundred times every five
minutes. The request never set a page size, and the endpoint defaults to twenty,
so a guild watching more channels than that was quietly told about only the
first twenty — and past a hundred followed channels Twitch rejects the request
outright, which the premium limits make reachable.

A rejected request returned out of the entire sweep rather than the guild that
caused it. The guilds come back in a stable order, so that starved the same tail
of guilds every five minutes, indefinitely, and a single transient 5xx was
enough to trigger it. What had already been announced lived in memory, keyed on
the streamer's display name, so every restart re-announced every stream that was
live at the time, to every server following it.

- **The lookup is inverted.** The guilds following each channel are collected
first, so every channel is asked about exactly once however many guilds want to
hear about it, a hundred at a time with the page size stated. A batch that fails
is logged and skipped; only a rejected token or an exhausted rate limit stops
the sweep, because those apply to every remaining batch anyway.
- **A failed lookup is no longer read as a channel going offline.** Which
channels Twitch answered for is tracked alongside which are live, so absence
from a response means "off the air" only for the ones it answered about. For the
rest nothing was learnt and their state is left alone — otherwise one failed
batch reads as everyone going offline and re-announces all of them on recovery.
- **What has been announced is keyed on the id of the broadcast**, not the
streamer's display name, and rebuilt each sweep from what is still followed —
which drops guilds Bastion has left and channels a guild has dropped, both of
which used to linger for the life of the process. None of it survives a restart,
so anything already live when a shard starts watching is adopted silently
instead of announced again.
- **Announcements go out to several guilds at once.** They're separate channels
on separate rate limit routes, so waiting for one before starting the next only
delayed the last guild in the list. Discord's request budget belongs to the whole
bot and every shard spends from it blind to the others, so the number in flight
stays well under what one shard could manage alone. A sweep that outlasts the
five minutes before the next one now holds that one off, since two overlapping
sweeps would swap the state out from under each other.

The embed's author link pointed at the streamer's display name. For most English
channels that's the login with different capitalisation and Twitch URLs are
case-insensitive, so it worked by coincidence — but of a hundred live channels
sampled, twelve had a display name that differed, every one of them Japanese or
Chinese. `akamikarubi` displaying as `赤見かるび` linked to `twitch.tv/赤見かるび`,
which goes nowhere. The link is built from the login now.

The category also now heads the embed, above the stream's own title, since what
someone is playing is most of why the notification is worth opening. A channel
can be live with no category set, and those keep the title off rather than
render an empty line.

`TwitchStream` described fields the API doesn't send — `pagination` is a
top-level key of the response and never appears on a stream object — and omitted
ones it does. `/game` searches IGDB, which authenticates with the same Twitch
application, so the credentials it assembled by hand now come from
`utils/twitch.ts`, the module that already owns that config and its refresh.

#### References
<!-- Link any applicable issues/pull requests here, with a brief description explaining why. -->

#### Checklist
<!-- For completed items, change [ ] to [x]. -->
- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)
