### PR TITLE
fix(premium): survive a Patreon answer bastion can't read

### DIFF
--- a/src/utils/patreon.ts
+++ b/src/utils/patreon.ts
@@ -18,6 +18,7 @@ const qs = querystring.stringify({
     "fields[member]": "patron_status,is_follower,full_name,pledge_relationship_start,lifetime_support_cents,currently_entitled_amount_cents,last_charge_date,last_charge_status,will_pay_amount_cents",
     "fields[user]": "image_url,social_connections",
     "include": "user",
+    "page[count]": 1000,
 });
 const PATRONS_URL = "https://www.patreon.com/api/oauth2/v2/campaigns/754397/members?" + qs;
 

--- a/src/utils/patreon.ts
+++ b/src/utils/patreon.ts
@@ -3,86 +3,90 @@
  * @copyright 2022
  */
 import * as querystring from "node:querystring";
+import { Logger } from "@bastion/tesseract";
 
-import memcache from "./memcache.js";
 import * as requests from "./requests.js";
 import Settings from "./settings.js";
 import { patreon } from "../types.js";
 
-export const CACHE_NAMESPACE = "patreon";
+/** How long a fetched list is served before Patreon is asked again, in milliseconds. */
+const REFRESH_TTL = 36e5;
+/** How long before Patreon is asked again after it couldn't be reached, in milliseconds. */
+const RETRY_DELAY = 3e5;
 
-/**
- * Returns the list of all currently active patrons.
- * @returns {Patron[]} List of all active patrons.
- */
-export const fetchPatrons = async (): Promise<patreon.Patron[]> => {
+const qs = querystring.stringify({
+    "fields[member]": "patron_status,is_follower,full_name,pledge_relationship_start,lifetime_support_cents,currently_entitled_amount_cents,last_charge_date,last_charge_status,will_pay_amount_cents",
+    "fields[user]": "image_url,social_connections",
+    "include": "user",
+});
+const PATRONS_URL = "https://www.patreon.com/api/oauth2/v2/campaigns/754397/members?" + qs;
+
+/** The patrons Patreon last answered with, held past their lifetime to serve while it can't be reached. */
+let patrons: patreon.Patron[] = [];
+/** When Patreon is asked again, whether the last answer was a list or a failure. */
+let askAt = 0;
+/** A list already being asked for, so everything asking at once waits for one instead of several. */
+let fetching: Promise<patreon.Patron[]> = null;
+
+/** Walks the campaign's members, a page at a time. */
+const fetchFromPatreon = async (): Promise<patreon.Patron[]> => {
     const settings = new Settings();
+    const collected: patreon.Patron[] = [];
 
-    // get patrons from cache
-    const patronsCache = memcache.get(CACHE_NAMESPACE + ":patrons") as patreon.Patron[];
-
-    // return the cached patrons, if available
-    if (patronsCache) {
-        return patronsCache;
-    }
-
-    const patrons: patreon.Patron[] = [];
-
-    const qs = querystring.stringify({
-        "fields[member]": "patron_status,is_follower,full_name,pledge_relationship_start,lifetime_support_cents,currently_entitled_amount_cents,last_charge_date,last_charge_status,will_pay_amount_cents",
-        "fields[user]": "image_url,social_connections",
-        "include": "user",
-    });
-
-    let url = "https://www.patreon.com/api/oauth2/v2/campaigns/754397/members?" + qs;
+    let url = PATRONS_URL;
 
     while (url) {
-        // fetch patrons
         const response = await requests.get(url, {
             Authorization: `Bearer ${ settings.get("patreon")?.accessToken }`,
         });
 
-        const patreonResponse: patreon.PatreonResponse = await response.body.json();
-
-        // consolidate member & user into one data structure
-        const members: patreon.Patron[] = patreonResponse.data
-            .filter(entity => entity.type === "member" && entity.attributes.lifetime_support_cents)
-            .map(member => {
-                const user = patreonResponse.included.find(entity => entity.id === member.relationships.user.data.id);
-
-                return Object.assign({}, member.attributes, { ...user.attributes });
-            });
-
-        // store each patrons in cache
-        for (const member of members.filter(m => m.social_connections && m.social_connections.discord && m.social_connections.discord.user_id)) {
-            memcache.set(CACHE_NAMESPACE + ":patrons:" + member.social_connections.discord.user_id, member, 60);
+        if (response.statusCode >= 400) {
+            throw new Error(`Patreon responded with ${ response.statusCode }: ${ await response.body.text().catch(() => "") }`);
         }
 
-        // store the patrons
-        patrons.push(...members);
+        const page = await response.body.json() as patreon.PatreonResponse;
 
-        // update the next page's url
-        url = patreonResponse.links && patreonResponse.links.next || null;
+        // throw error instead of returning a partial list
+        if (!page?.data) throw new Error("Patreon answered without any members.");
+
+        for (const member of page.data) {
+            if (member.type !== "member" || !member.attributes?.lifetime_support_cents) continue;
+
+            const user = page.included?.find(entity => entity.id === member.relationships?.user?.data?.id);
+            collected.push({ ...member.attributes, ...user?.attributes });
+        }
+
+        url = page.links?.next || null;
     }
 
-    // store the patrons in cache
-    if (patrons.length) {
-        memcache.set(CACHE_NAMESPACE + ":patrons", patrons, 60);
+    return collected;
+};
+
+/** Asks Patreon for a fresher list, keeping the one it already has if it can't be reached. */
+const refresh = async (): Promise<patreon.Patron[]> => {
+    try {
+        patrons = await fetchFromPatreon();
+        askAt = Date.now() + REFRESH_TTL;
+    } catch (e) {
+        Logger.error(e);
+
+        // prevent flooding the Patreon API when there's an outage
+        askAt = Date.now() + RETRY_DELAY;
+    } finally {
+        fetching = null;
     }
 
     return patrons;
 };
 
-export const fetchPatronByDiscordId = async (userId: string): Promise<patreon.Patron> => {
-    // get patron from cache
-    const patronCache = memcache.get(CACHE_NAMESPACE + ":patrons:" + userId) as patreon.Patron;
+/**
+ * Return last known patrons if Patreon can't be reached.
+ */
+export const fetchPatrons = async (): Promise<patreon.Patron[]> => {
+    if (askAt > Date.now()) return patrons;
 
-    // return the cached patrons, if available
-    if (patronCache) {
-        return patronCache;
-    }
-
-    // fetch the patron
-    const patrons = await fetchPatrons();
-    return patrons.find(patron => patron.social_connections && patron.social_connections.discord && patron.social_connections.discord.user_id === userId);
+    return fetching ??= refresh();
 };
+
+export const fetchPatronByDiscordId = async (userId: string): Promise<patreon.Patron> =>
+    (await fetchPatrons()).find(patron => patron.social_connections?.discord?.user_id === userId);

--- a/src/utils/patreon.ts
+++ b/src/utils/patreon.ts
@@ -32,10 +32,15 @@ let fetching: Promise<patreon.Patron[]> = null;
 const fetchFromPatreon = async (): Promise<patreon.Patron[]> => {
     const settings = new Settings();
     const collected: patreon.Patron[] = [];
+    const walked = new Set<string>();
 
     let url = PATRONS_URL;
 
     while (url) {
+        // prevent infinite loop if a page points back at an already walked page
+        if (walked.has(url)) throw new Error("Patreon paged back to somewhere it had already sent us.");
+        walked.add(url);
+
         const response = await requests.get(url, {
             Authorization: `Bearer ${ settings.get("patreon")?.accessToken }`,
         });


### PR DESCRIPTION
A premium check could take a command down with it.

`fetchPatrons` parsed Patreon's answer without looking at the status first, so an expired token or an outage — anything returning `errors` where `data` was expected — threw `TypeError: Cannot read properties of undefined (reading 'filter')`. That travelled out of `getPremiumTier` into every place that gates on a tier, and the ones that defer their reply before checking (`4db8d5d5` moved `/poll` there deliberately) left whoever ran the command on "Bastion is thinking…" for good. Free users hit it too, since the tier lookup runs before anyone knows whether they're a patron.

`fetchPatrons` is now total — it cannot throw, so nothing downstream needs a guard.

Three further problems surfaced while fixing that one:

- **A partial crawl was cached as complete.** The campaign paginates. A failure partway through kept the pages already collected and cached them for an hour as the whole campaign, so every patron on a page that was never reached silently dropped to Free. Any page failing now abandons the refresh.
- **No single flight.** A cache expiry across thousands of guilds meant every concurrent gated command started its own paginated crawl.
- **`included` is page-scoped and optional.** A member with no matching user threw; it now just lacks `social_connections`, which the lookup already tolerates.

Premium is held rather than dropped when Patreon can't be reached. Failing to `Free` would have been simpler and wrong — an outage on Patreon's side would strip premium from people currently paying for it. The last list is served until Patreon answers again, with a five-minute backoff instead of a retry per command.

The memcache entries are gone. An entry disappears the moment it expires, which is the one thing this needed it not to do, so the state moved into the module alongside the two deadlines and the in-flight crawl — the same shape as the Twitch token cache in #1128.

#### Verification

Against the live Patreon API: the crawl returns the same 147 paying members and 3 active patrons as before, each resolving to the tier they resolved to previously (Diamond, Gold, Gold), and a non-patron still comes back `Free`.

Failure paths exercised against a mocked Patreon: 401, 500, a 502 HTML error page, a 200 with no `data`, a 200 with a null body, a member with no matching user, and a member with no relationships — none throw. Twelve concurrent callers produce one request. A failure is not re-asked per call.

Paging went from nine requests (~4s, nine chances to lose the list) to one, using the documented `page[count]` maximum.

#### References

Same class of failure as #1128, which fixed the Twitch token — a stored credential nothing renewed and no caller checked the status of. Patreon still has no refresh path; its authorization-code grant needs the refresh token persisted somewhere, which is a separate design question. The token dies quietly now, with patrons keeping their tier, instead of hanging every gated command.

#### Checklist
- [ ] Documentation is changed or added (not applicable — no user-facing or documented behaviour changed)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)

