### PR TITLE
fix: delete the documents left behind by deleted roles, messages and guilds

### DIFF
--- a/src/listeners/guildDelete.ts
+++ b/src/listeners/guildDelete.ts
@@ -5,7 +5,12 @@
 import { Guild } from "discord.js";
 import { Client, Listener, Logger } from "@bastion/tesseract";
 
+import GiveawayModel from "../models/Giveaway.js";
 import GuildModel from "../models/Guild.js";
+import PollModel from "../models/Poll.js";
+import RoleModel from "../models/Role.js";
+import SelectRoleGroupModel from "../models/SelectRoleGroup.js";
+import TriggerModel from "../models/Trigger.js";
 import { COLORS } from "../utils/constants.js";
 import { log as bastionLog } from "../utils/webhooks.js";
 
@@ -15,8 +20,15 @@ class GuildDeleteListener extends Listener<"guildDelete"> {
     }
 
     public async exec(guild: Guild): Promise<void> {
-        // delete the guild document
-        await GuildModel.findByIdAndDelete(guild.id);
+        // delete all the guild related data
+        await Promise.all([
+            GuildModel.findByIdAndDelete(guild.id),
+            RoleModel.deleteMany({ guild: guild.id }),
+            TriggerModel.deleteMany({ guild: guild.id }),
+            SelectRoleGroupModel.deleteMany({ guild: guild.id }),
+            PollModel.deleteMany({ guild: guild.id }),
+            GiveawayModel.deleteMany({ guild: guild.id }),
+        ]);
 
         // bastion log
         bastionLog(guild.client as Client, {

--- a/src/listeners/guildDelete.ts
+++ b/src/listeners/guildDelete.ts
@@ -28,7 +28,7 @@ class GuildDeleteListener extends Listener<"guildDelete"> {
             SelectRoleGroupModel.deleteMany({ guild: guild.id }),
             PollModel.deleteMany({ guild: guild.id }),
             GiveawayModel.deleteMany({ guild: guild.id }),
-        ]);
+        ]).catch(Logger.error);
 
         // bastion log
         bastionLog(guild.client as Client, {

--- a/src/listeners/messageDelete.ts
+++ b/src/listeners/messageDelete.ts
@@ -18,24 +18,26 @@ class MessageDeleteListener extends Listener<"messageDelete"> {
         if (!message.inGuild()) return;
 
         // cleanup Select Role Groups associated with the deleted message
-        if (message.partial || message.author?.id === message.client.user.id) {
+        if (!message.author || message.author.id === message.client.user.id) {
             await SelectRoleGroupModel.deleteOne({ _id: message.id }).catch(Logger.error);
         }
 
-        if (message.author.bot) return;
-        if (![ MessageType.Default, MessageType.Reply ].includes(message.type)) return;
+        if (!message.partial) {
+            if (message.author.bot) return;
+            if (![ MessageType.Default, MessageType.Reply ].includes(message.type)) return;
+        }
 
         const guildDocument = await GuildModel.findById(message.guild.id);
 
         await logGuildEvent(message.guild, {
             title: "Message Deleted",
             fields: [
-                {
+                message.author && {
                     name: "Author",
                     value: message.author.tag,
                     inline: true,
                 },
-                {
+                message.author && {
                     name: "Author ID",
                     value: message.author.id,
                     inline: true,

--- a/src/listeners/messageDelete.ts
+++ b/src/listeners/messageDelete.ts
@@ -6,6 +6,7 @@ import { Message, MessageType, PartialMessage, time } from "discord.js";
 import { Listener } from "@bastion/tesseract";
 
 import GuildModel from "../models/Guild.js";
+import SelectRoleGroupModel from "../models/SelectRoleGroup.js";
 import { logGuildEvent } from "../utils/guilds.js";
 
 class MessageDeleteListener extends Listener<"messageDelete"> {
@@ -14,8 +15,14 @@ class MessageDeleteListener extends Listener<"messageDelete"> {
     }
 
     public async exec(message: Message<boolean> | PartialMessage): Promise<void> {
-        if (message.author.bot) return;
         if (!message.inGuild()) return;
+
+        // cleanup Select Role Groups associated with the deleted message
+        if (message.partial || message.author?.id === message.client.user.id) {
+            await SelectRoleGroupModel.deleteOne({ _id: message.id });
+        }
+
+        if (message.author.bot) return;
         if (![ MessageType.Default, MessageType.Reply ].includes(message.type)) return;
 
         const guildDocument = await GuildModel.findById(message.guild.id);

--- a/src/listeners/messageDelete.ts
+++ b/src/listeners/messageDelete.ts
@@ -3,7 +3,7 @@
  * @copyright 2022
  */
 import { Message, MessageType, PartialMessage, time } from "discord.js";
-import { Listener } from "@bastion/tesseract";
+import { Listener, Logger } from "@bastion/tesseract";
 
 import GuildModel from "../models/Guild.js";
 import SelectRoleGroupModel from "../models/SelectRoleGroup.js";
@@ -19,7 +19,7 @@ class MessageDeleteListener extends Listener<"messageDelete"> {
 
         // cleanup Select Role Groups associated with the deleted message
         if (message.partial || message.author?.id === message.client.user.id) {
-            await SelectRoleGroupModel.deleteOne({ _id: message.id });
+            await SelectRoleGroupModel.deleteOne({ _id: message.id }).catch(Logger.error);
         }
 
         if (message.author.bot) return;

--- a/src/listeners/messageDeleteBulk.ts
+++ b/src/listeners/messageDeleteBulk.ts
@@ -3,7 +3,7 @@
  * @copyright 2022
  */
 import { GuildTextBasedChannel, Message, OmitPartialGroupDMChannel, PartialMessage, ReadonlyCollection } from "discord.js";
-import { Listener } from "@bastion/tesseract";
+import { Listener, Logger } from "@bastion/tesseract";
 
 import SelectRoleGroupModel from "../models/SelectRoleGroup.js";
 import { logGuildEvent } from "../utils/guilds.js";
@@ -15,7 +15,7 @@ class MessageDeleteBulkListener extends Listener<"messageDeleteBulk"> {
 
     public async exec(messages: ReadonlyCollection<string, OmitPartialGroupDMChannel<Message<boolean> | PartialMessage>>, channel: GuildTextBasedChannel): Promise<void> {
         // cleanup Select Role Groups associated with the deleted messages
-        await SelectRoleGroupModel.deleteMany({ _id: { $in: [ ...messages.keys() ] } });
+        await SelectRoleGroupModel.deleteMany({ _id: { $in: [ ...messages.keys() ] } }).catch(Logger.error);
 
         await logGuildEvent(channel.guild, {
             title: "Messages Cleared",

--- a/src/listeners/messageDeleteBulk.ts
+++ b/src/listeners/messageDeleteBulk.ts
@@ -5,6 +5,7 @@
 import { GuildTextBasedChannel, Message, OmitPartialGroupDMChannel, PartialMessage, ReadonlyCollection } from "discord.js";
 import { Listener } from "@bastion/tesseract";
 
+import SelectRoleGroupModel from "../models/SelectRoleGroup.js";
 import { logGuildEvent } from "../utils/guilds.js";
 
 class MessageDeleteBulkListener extends Listener<"messageDeleteBulk"> {
@@ -13,6 +14,9 @@ class MessageDeleteBulkListener extends Listener<"messageDeleteBulk"> {
     }
 
     public async exec(messages: ReadonlyCollection<string, OmitPartialGroupDMChannel<Message<boolean> | PartialMessage>>, channel: GuildTextBasedChannel): Promise<void> {
+        // cleanup Select Role Groups associated with the deleted messages
+        await SelectRoleGroupModel.deleteMany({ _id: { $in: [ ...messages.keys() ] } });
+
         await logGuildEvent(channel.guild, {
             title: "Messages Cleared",
             fields: [

--- a/src/listeners/roleDelete.ts
+++ b/src/listeners/roleDelete.ts
@@ -5,6 +5,7 @@
 import { Role, time } from "discord.js";
 import { Listener } from "@bastion/tesseract";
 
+import RoleModel from "../models/Role.js";
 import { logGuildEvent } from "../utils/guilds.js";
 
 class RoleDeleteListener extends Listener<"roleDelete"> {
@@ -13,6 +14,8 @@ class RoleDeleteListener extends Listener<"roleDelete"> {
     }
 
     public async exec(role: Role): Promise<void> {
+        await RoleModel.deleteOne({ _id: role.id });
+
         await logGuildEvent(role.guild, {
             color: role.color,
             title: "Role Deleted",

--- a/src/listeners/roleDelete.ts
+++ b/src/listeners/roleDelete.ts
@@ -3,7 +3,7 @@
  * @copyright 2022
  */
 import { Role, time } from "discord.js";
-import { Listener } from "@bastion/tesseract";
+import { Listener, Logger } from "@bastion/tesseract";
 
 import RoleModel from "../models/Role.js";
 import { logGuildEvent } from "../utils/guilds.js";
@@ -14,7 +14,7 @@ class RoleDeleteListener extends Listener<"roleDelete"> {
     }
 
     public async exec(role: Role): Promise<void> {
-        await RoleModel.deleteOne({ _id: role.id });
+        await RoleModel.deleteOne({ _id: role.id }).catch(Logger.error);
 
         await logGuildEvent(role.guild, {
             color: role.color,

--- a/src/schedulers/giveaways.ts
+++ b/src/schedulers/giveaways.ts
@@ -2,7 +2,7 @@
  * @author TRACTION (iamtraction)
  * @copyright 2022
  */
-import { ButtonStyle, ComponentType, DiscordAPIError, GuildTextBasedChannel, RESTJSONErrorCodes, Snowflake, User } from "discord.js";
+import { ButtonStyle, ComponentType, DiscordAPIError, RESTJSONErrorCodes, Snowflake, User } from "discord.js";
 import { Client, Logger, Scheduler } from "@bastion/tesseract";
 
 import GiveawayModel from "../models/Giveaway.js";
@@ -36,72 +36,80 @@ class GiveawayScheduler extends Scheduler {
                 // identify the guild for the giveaway
                 const guild = this.client.guilds.cache.get(giveawayDocument.guild);
 
-                if (guild?.channels?.cache.has(giveawayDocument.channel)) {
-                    // identify the channel for the giveaway
-                    const channel = guild.channels.cache.get(giveawayDocument.channel) as GuildTextBasedChannel;
+                if (!guild) continue;
 
-                    // identify the giveaway message
-                    const giveawayMessage = await channel.messages.fetch(giveawayDocument._id).catch((e: DiscordAPIError) => e);
+                // identify the channel for the giveaway
+                const channel = await guild.channels.fetch(giveawayDocument.channel).catch((e: DiscordAPIError) => e);
 
-                    // check whether the giveaway message is actually gone
-                    if (giveawayMessage instanceof Error) {
-                        if (giveawayMessage.code === RESTJSONErrorCodes.UnknownMessage) completed.push(giveawayDocument._id);
-                        continue;
-                    }
-
-                    // find giveaway winners
-                    const winnerDetails = giveawayMessage.embeds[0].footer.text.match(/^(\d+) .+/i);
-                    const winnerCount = parseInt(winnerDetails?.[1]) || 1;
-                    let winners: User[] = [];
-
-                    if (giveawayMessage.reactions.cache.has("🎉")) {
-                        // identify giveaway participants
-                        await giveawayMessage.reactions.cache.get("🎉").users.fetch().catch(Logger.ignore);
-
-                        // get random participants
-                        winners = giveawayMessage.reactions.cache.get("🎉").users.cache.filter(u => !u.bot).random(winnerCount);
-                    }
-
-                    // announce the result
-                    await giveawayMessage.edit({
-                        embeds: [
-                            {
-                                color: winners.length ? COLORS.SECONDARY : COLORS.RED,
-                                author: {
-                                    name: "GIVEAWAY ENDED",
-                                },
-                                title: giveawayMessage.embeds[0].title,
-                                description: (this.client as Client).locales.getText(guild.preferredLocale, winners.length ? "giveawayWinners" : "giveawayNoWinners"),
-                                fields: winners.length ? [
-                                    {
-                                        name: "Congratulations",
-                                        value: winners.join(" "),
-                                    },
-                                ] : [],
-                                footer: {
-                                    text: winners.length ? `${ winnerCount } Winners` : "",
-                                },
-                                timestamp: new Date().toISOString(),
-                            },
-                        ],
-                        components: winners.length ? [
-                            {
-                                type: ComponentType.ActionRow,
-                                components: [
-                                    {
-                                        type: ComponentType.Button,
-                                        label: "Reroll Giveaway",
-                                        style: ButtonStyle.Secondary,
-                                        customId: MessageComponents.GiveawayEndButton,
-                                    },
-                                ],
-                            },
-                        ] : [],
-                    }).then(() => {
-                        // mark this giveaway as complete
-                        completed.push(giveawayMessage.id);
-                    }).catch(Logger.error);
+                // check whether the giveaway's channel is actually gone
+                if (channel instanceof Error) {
+                    if (channel.code === RESTJSONErrorCodes.UnknownChannel) completed.push(giveawayDocument._id);
+                    continue;
                 }
+
+                if (!channel?.isTextBased()) continue;
+
+                // identify the giveaway message
+                const giveawayMessage = await channel.messages.fetch(giveawayDocument._id).catch((e: DiscordAPIError) => e);
+
+                // check whether the giveaway message is actually gone
+                if (giveawayMessage instanceof Error) {
+                    if (giveawayMessage.code === RESTJSONErrorCodes.UnknownMessage) completed.push(giveawayDocument._id);
+                    continue;
+                }
+
+                // find giveaway winners
+                const winnerDetails = giveawayMessage.embeds[0].footer.text.match(/^(\d+) .+/i);
+                const winnerCount = parseInt(winnerDetails?.[1]) || 1;
+                let winners: User[] = [];
+
+                if (giveawayMessage.reactions.cache.has("🎉")) {
+                    // identify giveaway participants
+                    await giveawayMessage.reactions.cache.get("🎉").users.fetch().catch(Logger.ignore);
+
+                    // get random participants
+                    winners = giveawayMessage.reactions.cache.get("🎉").users.cache.filter(u => !u.bot).random(winnerCount);
+                }
+
+                // announce the result
+                await giveawayMessage.edit({
+                    embeds: [
+                        {
+                            color: winners.length ? COLORS.SECONDARY : COLORS.RED,
+                            author: {
+                                name: "GIVEAWAY ENDED",
+                            },
+                            title: giveawayMessage.embeds[0].title,
+                            description: (this.client as Client).locales.getText(guild.preferredLocale, winners.length ? "giveawayWinners" : "giveawayNoWinners"),
+                            fields: winners.length ? [
+                                {
+                                    name: "Congratulations",
+                                    value: winners.join(" "),
+                                },
+                            ] : [],
+                            footer: {
+                                text: winners.length ? `${ winnerCount } Winners` : "",
+                            },
+                            timestamp: new Date().toISOString(),
+                        },
+                    ],
+                    components: winners.length ? [
+                        {
+                            type: ComponentType.ActionRow,
+                            components: [
+                                {
+                                    type: ComponentType.Button,
+                                    label: "Reroll Giveaway",
+                                    style: ButtonStyle.Secondary,
+                                    customId: MessageComponents.GiveawayEndButton,
+                                },
+                            ],
+                        },
+                    ] : [],
+                }).then(() => {
+                    // mark this giveaway as complete
+                    completed.push(giveawayMessage.id);
+                }).catch(Logger.error);
             }
 
             // remove the completed giveaways

--- a/src/schedulers/giveaways.ts
+++ b/src/schedulers/giveaways.ts
@@ -2,7 +2,7 @@
  * @author TRACTION (iamtraction)
  * @copyright 2022
  */
-import { ButtonStyle, ComponentType, GuildTextBasedChannel, Snowflake, User } from "discord.js";
+import { ButtonStyle, ComponentType, DiscordAPIError, GuildTextBasedChannel, RESTJSONErrorCodes, Snowflake, User } from "discord.js";
 import { Client, Logger, Scheduler } from "@bastion/tesseract";
 
 import GiveawayModel from "../models/Giveaway.js";
@@ -41,65 +41,66 @@ class GiveawayScheduler extends Scheduler {
                     const channel = guild.channels.cache.get(giveawayDocument.channel) as GuildTextBasedChannel;
 
                     // identify the giveaway message
-                    const giveawayMessage = await channel.messages.fetch(giveawayDocument._id).catch(Logger.ignore);
+                    const giveawayMessage = await channel.messages.fetch(giveawayDocument._id).catch((e: DiscordAPIError) => e);
 
-                    if (giveawayMessage) {
-                        // find giveaway winners
-                        const winnerDetails = giveawayMessage.embeds[0].footer.text.match(/^(\d+) .+/i);
-                        const winnerCount = parseInt(winnerDetails?.[1]) || 1;
-                        let winners: User[] = [];
-
-                        if (giveawayMessage.reactions.cache.has("🎉")) {
-                            // identify giveaway participants
-                            await giveawayMessage.reactions.cache.get("🎉").users.fetch().catch(Logger.ignore);
-
-                            // get random participants
-                            winners = giveawayMessage.reactions.cache.get("🎉").users.cache.filter(u => !u.bot).random(winnerCount);
-                        }
-
-                        // announce the result
-                        await giveawayMessage.edit({
-                            embeds: [
-                                {
-                                    color: winners.length ? COLORS.SECONDARY : COLORS.RED,
-                                    author: {
-                                        name: "GIVEAWAY ENDED",
-                                    },
-                                    title: giveawayMessage.embeds[0].title,
-                                    description: (this.client as Client).locales.getText(guild.preferredLocale, winners.length ? "giveawayWinners" : "giveawayNoWinners"),
-                                    fields: winners.length ? [
-                                        {
-                                            name: "Congratulations",
-                                            value: winners.join(" "),
-                                        },
-                                    ] : [],
-                                    footer: {
-                                        text: winners.length ? `${ winnerCount } Winners` : "",
-                                    },
-                                    timestamp: new Date().toISOString(),
-                                },
-                            ],
-                            components: winners.length ? [
-                                {
-                                    type: ComponentType.ActionRow,
-                                    components: [
-                                        {
-                                            type: ComponentType.Button,
-                                            label: "Reroll Giveaway",
-                                            style: ButtonStyle.Secondary,
-                                            customId: MessageComponents.GiveawayEndButton,
-                                        },
-                                    ],
-                                },
-                            ] : [],
-                        }).then(() => {
-                            // mark this giveaway as complete
-                            completed.push(giveawayMessage.id);
-                        }).catch(Logger.error);
-                    } else {
-                        // mark this giveaway as complete
-                        completed.push(giveawayDocument.id);
+                    // check whether the giveaway message is actually gone
+                    if (giveawayMessage instanceof Error) {
+                        if (giveawayMessage.code === RESTJSONErrorCodes.UnknownMessage) completed.push(giveawayDocument._id);
+                        continue;
                     }
+
+                    // find giveaway winners
+                    const winnerDetails = giveawayMessage.embeds[0].footer.text.match(/^(\d+) .+/i);
+                    const winnerCount = parseInt(winnerDetails?.[1]) || 1;
+                    let winners: User[] = [];
+
+                    if (giveawayMessage.reactions.cache.has("🎉")) {
+                        // identify giveaway participants
+                        await giveawayMessage.reactions.cache.get("🎉").users.fetch().catch(Logger.ignore);
+
+                        // get random participants
+                        winners = giveawayMessage.reactions.cache.get("🎉").users.cache.filter(u => !u.bot).random(winnerCount);
+                    }
+
+                    // announce the result
+                    await giveawayMessage.edit({
+                        embeds: [
+                            {
+                                color: winners.length ? COLORS.SECONDARY : COLORS.RED,
+                                author: {
+                                    name: "GIVEAWAY ENDED",
+                                },
+                                title: giveawayMessage.embeds[0].title,
+                                description: (this.client as Client).locales.getText(guild.preferredLocale, winners.length ? "giveawayWinners" : "giveawayNoWinners"),
+                                fields: winners.length ? [
+                                    {
+                                        name: "Congratulations",
+                                        value: winners.join(" "),
+                                    },
+                                ] : [],
+                                footer: {
+                                    text: winners.length ? `${ winnerCount } Winners` : "",
+                                },
+                                timestamp: new Date().toISOString(),
+                            },
+                        ],
+                        components: winners.length ? [
+                            {
+                                type: ComponentType.ActionRow,
+                                components: [
+                                    {
+                                        type: ComponentType.Button,
+                                        label: "Reroll Giveaway",
+                                        style: ButtonStyle.Secondary,
+                                        customId: MessageComponents.GiveawayEndButton,
+                                    },
+                                ],
+                            },
+                        ] : [],
+                    }).then(() => {
+                        // mark this giveaway as complete
+                        completed.push(giveawayMessage.id);
+                    }).catch(Logger.error);
                 }
             }
 

--- a/src/schedulers/giveaways.ts
+++ b/src/schedulers/giveaways.ts
@@ -39,22 +39,22 @@ class GiveawayScheduler extends Scheduler {
                 if (!guild) continue;
 
                 // identify the channel for the giveaway
-                const channel = await guild.channels.fetch(giveawayDocument.channel).catch((e: DiscordAPIError) => e);
+                const channel = await guild.channels.fetch(giveawayDocument.channel).catch((e: Error) => e);
 
                 // check whether the giveaway's channel is actually gone
                 if (channel instanceof Error) {
-                    if (channel.code === RESTJSONErrorCodes.UnknownChannel) completed.push(giveawayDocument._id);
+                    if (channel instanceof DiscordAPIError && channel.code === RESTJSONErrorCodes.UnknownChannel) completed.push(giveawayDocument._id);
                     continue;
                 }
 
                 if (!channel?.isTextBased()) continue;
 
                 // identify the giveaway message
-                const giveawayMessage = await channel.messages.fetch(giveawayDocument._id).catch((e: DiscordAPIError) => e);
+                const giveawayMessage = await channel.messages.fetch(giveawayDocument._id).catch((e: Error) => e);
 
                 // check whether the giveaway message is actually gone
                 if (giveawayMessage instanceof Error) {
-                    if (giveawayMessage.code === RESTJSONErrorCodes.UnknownMessage) completed.push(giveawayDocument._id);
+                    if (giveawayMessage instanceof DiscordAPIError && giveawayMessage.code === RESTJSONErrorCodes.UnknownMessage) completed.push(giveawayDocument._id);
                     continue;
                 }
 

--- a/src/schedulers/giveaways.ts
+++ b/src/schedulers/giveaways.ts
@@ -11,7 +11,7 @@ import { COLORS } from "../utils/constants.js";
 
 class GiveawayScheduler extends Scheduler {
     constructor() {
-        super("polls", "0 */15 * * * *");   // every 15th minute
+        super("giveaways", "0 */15 * * * *");   // every 15th minute
     }
 
     public async exec(): Promise<void> {

--- a/src/schedulers/polls.ts
+++ b/src/schedulers/polls.ts
@@ -2,7 +2,7 @@
  * @author TRACTION (iamtraction)
  * @copyright 2022
  */
-import { GuildTextBasedChannel, Snowflake } from "discord.js";
+import { DiscordAPIError, GuildTextBasedChannel, RESTJSONErrorCodes, Snowflake } from "discord.js";
 import { Logger, Scheduler } from "@bastion/tesseract";
 
 import PollModel from "../models/Poll.js";
@@ -40,60 +40,61 @@ class PollScheduler extends Scheduler {
                     const channel = guild.channels.cache.get(pollDocument.channel) as GuildTextBasedChannel;
 
                     // identify the poll message
-                    const pollMessage = await channel.messages.fetch(pollDocument.id).catch(Logger.ignore);
+                    const pollMessage = await channel.messages.fetch(pollDocument.id).catch((e: DiscordAPIError) => e);
 
-                    if (pollMessage) {
-                        // check if poll has ended
-                        if (pollMessage.embeds[0].author.name?.includes("ENDED")) {
-                            // mark this poll as complete
-                            completed.push(pollMessage.id);
-                            continue;
-                        }
-
-                        // identify poll options
-                        const options = pollMessage.embeds[0].fields.map(f => f.value);
-
-                        // identify poll votes
-                        const reactions = [ "🇦", "🇧", "🇨", "🇩", "🇪", "🇫", "🇬", "🇭", "🇮", "🇯" ];
-                        const votes: { [key: string]: number } = {};
-
-                        let totalVotes = 0;
-                        for (const key in reactions.slice(0, options.length)) {
-                            if (pollMessage.reactions.cache.has(reactions[key])) {
-                                // calculate votes, discounting Bastion's own reaction only when it's there
-                                const reaction = pollMessage.reactions.cache.get(reactions[key]);
-                                votes[reactions[key]] = reaction.count - (reaction.me ? 1 : 0);
-                                totalVotes += votes[reactions[key]];
-                            }
-                        }
-
-                        // declare poll results
-                        await pollMessage.edit({
-                            embeds: [
-                                {
-                                    color: COLORS.SOMEWHAT_DARK,
-                                    author: {
-                                        name: "POLL ENDED",
-                                    },
-                                    title: pollMessage.embeds[0].title,
-                                    fields: pollMessage.embeds[0].fields.sort((a, b) => (votes[b.name] || 0) - (votes[a.name] || 0) ).map(f => ({
-                                        name: f.value,
-                                        value: `${ votes[f.name] || 0 } votes — ${ totalVotes ? ((votes[f.name] || 0) / totalVotes * 100).toFixed(0) : 0 }%`,
-                                    })),
-                                    footer: {
-                                        text: `${ totalVotes } votes`
-                                    },
-                                    timestamp: new Date().toISOString(),
-                                },
-                            ],
-                        }).then(() => {
-                            // mark this poll as complete
-                            completed.push(pollMessage.id);
-                        }).catch(Logger.ignore);
-                    } else {
-                        // mark this poll as complete
-                        completed.push(pollDocument.id);
+                    // check whether the poll message is actually gone
+                    if (pollMessage instanceof Error) {
+                        if (pollMessage.code === RESTJSONErrorCodes.UnknownMessage) completed.push(pollDocument.id);
+                        continue;
                     }
+
+                    // check if poll has ended
+                    if (pollMessage.embeds[0].author.name?.includes("ENDED")) {
+                        // mark this poll as complete
+                        completed.push(pollMessage.id);
+                        continue;
+                    }
+
+                    // identify poll options
+                    const options = pollMessage.embeds[0].fields.map(f => f.value);
+
+                    // identify poll votes
+                    const reactions = [ "🇦", "🇧", "🇨", "🇩", "🇪", "🇫", "🇬", "🇭", "🇮", "🇯" ];
+                    const votes: { [key: string]: number } = {};
+
+                    let totalVotes = 0;
+                    for (const key in reactions.slice(0, options.length)) {
+                        if (pollMessage.reactions.cache.has(reactions[key])) {
+                            // calculate votes, discounting Bastion's own reaction only when it's there
+                            const reaction = pollMessage.reactions.cache.get(reactions[key]);
+                            votes[reactions[key]] = reaction.count - (reaction.me ? 1 : 0);
+                            totalVotes += votes[reactions[key]];
+                        }
+                    }
+
+                    // declare poll results
+                    await pollMessage.edit({
+                        embeds: [
+                            {
+                                color: COLORS.SOMEWHAT_DARK,
+                                author: {
+                                    name: "POLL ENDED",
+                                },
+                                title: pollMessage.embeds[0].title,
+                                fields: pollMessage.embeds[0].fields.sort((a, b) => (votes[b.name] || 0) - (votes[a.name] || 0) ).map(f => ({
+                                    name: f.value,
+                                    value: `${ votes[f.name] || 0 } votes — ${ totalVotes ? ((votes[f.name] || 0) / totalVotes * 100).toFixed(0) : 0 }%`,
+                                })),
+                                footer: {
+                                    text: `${ totalVotes } votes`
+                                },
+                                timestamp: new Date().toISOString(),
+                            },
+                        ],
+                    }).then(() => {
+                        // mark this poll as complete
+                        completed.push(pollMessage.id);
+                    }).catch(Logger.ignore);
                 }
             }
 

--- a/src/schedulers/polls.ts
+++ b/src/schedulers/polls.ts
@@ -38,22 +38,22 @@ class PollScheduler extends Scheduler {
                 if (!guild) continue;
 
                 // identify the channel for the poll
-                const channel = await guild.channels.fetch(pollDocument.channel).catch((e: DiscordAPIError) => e);
+                const channel = await guild.channels.fetch(pollDocument.channel).catch((e: Error) => e);
 
                 // check whether the poll's channel is actually gone
                 if (channel instanceof Error) {
-                    if (channel.code === RESTJSONErrorCodes.UnknownChannel) completed.push(pollDocument.id);
+                    if (channel instanceof DiscordAPIError && channel.code === RESTJSONErrorCodes.UnknownChannel) completed.push(pollDocument._id);
                     continue;
                 }
 
                 if (!channel?.isTextBased()) continue;
 
                 // identify the poll message
-                const pollMessage = await channel.messages.fetch(pollDocument.id).catch((e: DiscordAPIError) => e);
+                const pollMessage = await channel.messages.fetch(pollDocument._id).catch((e: Error) => e);
 
                 // check whether the poll message is actually gone
                 if (pollMessage instanceof Error) {
-                    if (pollMessage.code === RESTJSONErrorCodes.UnknownMessage) completed.push(pollDocument.id);
+                    if (pollMessage instanceof DiscordAPIError && pollMessage.code === RESTJSONErrorCodes.UnknownMessage) completed.push(pollDocument._id);
                     continue;
                 }
 

--- a/src/schedulers/polls.ts
+++ b/src/schedulers/polls.ts
@@ -2,7 +2,7 @@
  * @author TRACTION (iamtraction)
  * @copyright 2022
  */
-import { DiscordAPIError, GuildTextBasedChannel, RESTJSONErrorCodes, Snowflake } from "discord.js";
+import { DiscordAPIError, RESTJSONErrorCodes, Snowflake } from "discord.js";
 import { Logger, Scheduler } from "@bastion/tesseract";
 
 import PollModel from "../models/Poll.js";
@@ -35,67 +35,75 @@ class PollScheduler extends Scheduler {
                 // identify the guild for the poll
                 const guild = this.client.guilds.cache.get(pollDocument.guild);
 
-                if (guild?.channels?.cache.has(pollDocument.channel)) {
-                    // identify the channel for the poll
-                    const channel = guild.channels.cache.get(pollDocument.channel) as GuildTextBasedChannel;
+                if (!guild) continue;
 
-                    // identify the poll message
-                    const pollMessage = await channel.messages.fetch(pollDocument.id).catch((e: DiscordAPIError) => e);
+                // identify the channel for the poll
+                const channel = await guild.channels.fetch(pollDocument.channel).catch((e: DiscordAPIError) => e);
 
-                    // check whether the poll message is actually gone
-                    if (pollMessage instanceof Error) {
-                        if (pollMessage.code === RESTJSONErrorCodes.UnknownMessage) completed.push(pollDocument.id);
-                        continue;
-                    }
-
-                    // check if poll has ended
-                    if (pollMessage.embeds[0].author.name?.includes("ENDED")) {
-                        // mark this poll as complete
-                        completed.push(pollMessage.id);
-                        continue;
-                    }
-
-                    // identify poll options
-                    const options = pollMessage.embeds[0].fields.map(f => f.value);
-
-                    // identify poll votes
-                    const reactions = [ "🇦", "🇧", "🇨", "🇩", "🇪", "🇫", "🇬", "🇭", "🇮", "🇯" ];
-                    const votes: { [key: string]: number } = {};
-
-                    let totalVotes = 0;
-                    for (const key in reactions.slice(0, options.length)) {
-                        if (pollMessage.reactions.cache.has(reactions[key])) {
-                            // calculate votes, discounting Bastion's own reaction only when it's there
-                            const reaction = pollMessage.reactions.cache.get(reactions[key]);
-                            votes[reactions[key]] = reaction.count - (reaction.me ? 1 : 0);
-                            totalVotes += votes[reactions[key]];
-                        }
-                    }
-
-                    // declare poll results
-                    await pollMessage.edit({
-                        embeds: [
-                            {
-                                color: COLORS.SOMEWHAT_DARK,
-                                author: {
-                                    name: "POLL ENDED",
-                                },
-                                title: pollMessage.embeds[0].title,
-                                fields: pollMessage.embeds[0].fields.sort((a, b) => (votes[b.name] || 0) - (votes[a.name] || 0) ).map(f => ({
-                                    name: f.value,
-                                    value: `${ votes[f.name] || 0 } votes — ${ totalVotes ? ((votes[f.name] || 0) / totalVotes * 100).toFixed(0) : 0 }%`,
-                                })),
-                                footer: {
-                                    text: `${ totalVotes } votes`
-                                },
-                                timestamp: new Date().toISOString(),
-                            },
-                        ],
-                    }).then(() => {
-                        // mark this poll as complete
-                        completed.push(pollMessage.id);
-                    }).catch(Logger.ignore);
+                // check whether the poll's channel is actually gone
+                if (channel instanceof Error) {
+                    if (channel.code === RESTJSONErrorCodes.UnknownChannel) completed.push(pollDocument.id);
+                    continue;
                 }
+
+                if (!channel?.isTextBased()) continue;
+
+                // identify the poll message
+                const pollMessage = await channel.messages.fetch(pollDocument.id).catch((e: DiscordAPIError) => e);
+
+                // check whether the poll message is actually gone
+                if (pollMessage instanceof Error) {
+                    if (pollMessage.code === RESTJSONErrorCodes.UnknownMessage) completed.push(pollDocument.id);
+                    continue;
+                }
+
+                // check if poll has ended
+                if (pollMessage.embeds[0].author.name?.includes("ENDED")) {
+                    // mark this poll as complete
+                    completed.push(pollMessage.id);
+                    continue;
+                }
+
+                // identify poll options
+                const options = pollMessage.embeds[0].fields.map(f => f.value);
+
+                // identify poll votes
+                const reactions = [ "🇦", "🇧", "🇨", "🇩", "🇪", "🇫", "🇬", "🇭", "🇮", "🇯" ];
+                const votes: { [key: string]: number } = {};
+
+                let totalVotes = 0;
+                for (const key in reactions.slice(0, options.length)) {
+                    if (pollMessage.reactions.cache.has(reactions[key])) {
+                        // calculate votes, discounting Bastion's own reaction only when it's there
+                        const reaction = pollMessage.reactions.cache.get(reactions[key]);
+                        votes[reactions[key]] = reaction.count - (reaction.me ? 1 : 0);
+                        totalVotes += votes[reactions[key]];
+                    }
+                }
+
+                // declare poll results
+                await pollMessage.edit({
+                    embeds: [
+                        {
+                            color: COLORS.SOMEWHAT_DARK,
+                            author: {
+                                name: "POLL ENDED",
+                            },
+                            title: pollMessage.embeds[0].title,
+                            fields: pollMessage.embeds[0].fields.sort((a, b) => (votes[b.name] || 0) - (votes[a.name] || 0) ).map(f => ({
+                                name: f.value,
+                                value: `${ votes[f.name] || 0 } votes — ${ totalVotes ? ((votes[f.name] || 0) / totalVotes * 100).toFixed(0) : 0 }%`,
+                            })),
+                            footer: {
+                                text: `${ totalVotes } votes`
+                            },
+                            timestamp: new Date().toISOString(),
+                        },
+                    ],
+                }).then(() => {
+                    // mark this poll as complete
+                    completed.push(pollMessage.id);
+                }).catch(Logger.ignore);
             }
 
             // remove the completed polls


### PR DESCRIPTION
A role's configuration is keyed by the role's ID and a select role group by its message's ID, and neither was deleted when the role or the message was. Discord never reuses an ID, so those documents were unreachable for good while still counting against the shop role and select role limits. They're deleted with the role and the message now, and leaving a guild takes its `Role`, `Trigger`, `SelectRoleGroup`, `Poll` and `Giveaway` documents with it rather than only the guild's own.

`Member` documents outlive the departure. They carry balances, experience, karma and claim streaks that nothing can recreate, and a removal is often temporary, so a re-invite finds the progress intact.

A poll or giveaway whose channel was deleted was skipped rather than concluded, so its document sat past its end date and came back in the scheduler's query every fifteen minutes for good. Those are dropped now. Both schedulers also read any failed message fetch as proof the message was gone, so a rate limit or an outage deleted a poll that still existed — only a 404 does that. A channel Bastion can no longer see answers with a 403 instead, so a permission change leaves the poll alone to be retried on the next run.

A failed cleanup query can no longer take the logging down with it. And a message that was never cached carries no author and no type, so its deletion fell through both filters and never reached the server log at all; it's logged now, without the author and content fields it doesn't have.

#### References

#### Checklist
- [ ] Documentation is changed or added (if applicable)
- [x] Commit message follows the [commit guidelines](https://bastion.gitbook.io/docs/developers/contributing-guidelines/pulls#commit)
